### PR TITLE
Add langchain-databricks into databricks-langchain

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.8'
+          python-version: '3.9'
       - name: Install dependencies
         run: |
           pip install -r requirements/lint-requirements.txt
@@ -33,7 +33,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.8', '3.9', '3.10']
+        python-version: [3.9', '3.10']
     timeout-minutes: 20
     steps:
       - name: Checkout code
@@ -53,7 +53,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.8', '3.9', '3.10']
+        python-version: ['3.9', '3.10']
     timeout-minutes: 20
     steps:
       - name: Checkout code

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,7 +33,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.9', '3.10']
+        python-version: ['3.9', '3.10']
     timeout-minutes: 20
     steps:
       - name: Checkout code

--- a/integrations/langchain/pyproject.toml
+++ b/integrations/langchain/pyproject.toml
@@ -7,7 +7,7 @@ authors = [
 ]
 readme = "README.md"
 license = { text="Apache-2.0" }
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 dependencies = [
     "langchain>=0.2.0",
     "langchain-community>=0.2.0",

--- a/integrations/langchain/pyproject.toml
+++ b/integrations/langchain/pyproject.toml
@@ -11,6 +11,7 @@ requires-python = ">=3.8"
 dependencies = [
     "langchain>=0.2.0",
     "langchain-community>=0.2.0",
+    "langchain-databricks>=0.1.1",
     "databricks-ai-bridge",
 ]
 

--- a/integrations/langchain/src/databricks_langchain/__init__.py
+++ b/integrations/langchain/src/databricks_langchain/__init__.py
@@ -5,8 +5,7 @@ from langchain_databricks import (
     DatabricksVectorSearch,
 )
 
-# Import any additional modules specific to databricks-langchain
-from .genie import GenieAgent  # Example for GenieAgent functionality
+from .genie import GenieAgent
 
 # Expose all integrations to users under databricks-langchain
 __all__ = [

--- a/integrations/langchain/src/databricks_langchain/__init__.py
+++ b/integrations/langchain/src/databricks_langchain/__init__.py
@@ -1,0 +1,17 @@
+# Import modules from langchain-databricks
+from langchain_databricks import (
+    ChatDatabricks,
+    DatabricksEmbeddings,
+    DatabricksVectorSearch,
+)
+
+# Import any additional modules specific to databricks-langchain
+from .genie import GenieAgent  # Example for GenieAgent functionality
+
+# Expose all integrations to users under databricks-langchain
+__all__ = [
+    "ChatDatabricks",
+    "DatabricksEmbeddings",
+    "DatabricksVectorSearch",
+    "GenieAgent",
+]


### PR DESCRIPTION
Import `langchain-databricks` into `databricks-langchain`

`langchain-databricks>=0.1.1` requires python >= 3.9, so adjust min requirements accordingly. 

We don't add any extra tests at this time since we are just including the package.