### PR TITLE
Update Genie polling logic

### DIFF
--- a/src/databricks_ai_bridge/genie.py
+++ b/src/databricks_ai_bridge/genie.py
@@ -109,7 +109,20 @@ class Genie:
                     logging.debug(f"SQL: {sql}")
                     return poll_query_results()
                 elif resp["status"] == "COMPLETED":
-                    return next(r for r in resp["attachments"] if "text" in r)["text"]["content"]
+                    # Check if there is a query object in the attachments for the COMPLETED status
+                    query_attachment = next((r for r in resp["attachments"] if "query" in r), None)
+                    if query_attachment:
+                        query = query_attachment["query"]
+                        description = query.get("description", "")
+                        sql = query.get("query", "")
+                        logging.debug(f"Description: {description}")
+                        logging.debug(f"SQL: {sql}")
+                        return poll_query_results()
+                    else:
+                        # Handle the text object in the COMPLETED status
+                        return next(r for r in resp["attachments"] if "text" in r)["text"][
+                            "content"
+                        ]
                 elif resp["status"] == "FAILED":
                     logging.debug("Genie failed to execute the query")
                     return None

--- a/tests/databricks_ai_bridge/test_genie.py
+++ b/tests/databricks_ai_bridge/test_genie.py
@@ -43,12 +43,29 @@ def test_create_message(genie, mock_workspace_client):
     )
 
 
-def test_poll_for_result_completed(genie, mock_workspace_client):
+def test_poll_for_result_completed_with_text(genie, mock_workspace_client):
     mock_workspace_client.genie._api.do.side_effect = [
         {"status": "COMPLETED", "attachments": [{"text": {"content": "Result"}}]},
     ]
     result = genie.poll_for_result("123", "456")
     assert result == "Result"
+
+
+def test_poll_for_result_completed_with_query(genie, mock_workspace_client):
+    mock_workspace_client.genie._api.do.side_effect = [
+        {"status": "COMPLETED", "attachments": [{"query": {"query": "SELECT *"}}]},
+        {
+            "statement_response": {
+                "status": {"state": "SUCCEEDED"},
+                "manifest": {"schema": {"columns": []}},
+                "result": {
+                    "data_typed_array": [],
+                },
+            }
+        },
+    ]
+    result = genie.poll_for_result("123", "456")
+    assert result == pd.DataFrame().to_markdown()
 
 
 def test_poll_for_result_executing_query(genie, mock_workspace_client):


### PR DESCRIPTION
Per genie docs, the COMPLETED state can also represent a completed SQL statement, that we should poll similar to EXECUTING_QUERY. 

> Executing SQL query
EXECUTING_QUERY: Genie will respond with a generated SQL statement, but the query is still executing. The SQL statement and its description will be available in the attachments field.
IMPORTANT: You must call the [“Fetch query results”](https://docs.google.com/document/d/1yOIkzw8sKn6Qspz885Wfcimw7yCl00ZC3-FnnNV_GOw/edit#bookmark=id.iy3afulbj70z) endpoint to fetch query results in order to advance the Message status to “COMPLETED”.
Conclusive status 
COMPLETED: The entire messaging process has completed:
Genie can respond with a follow-up question rather than an answer. In these cases, the attachments array field will contain a text object with the follow-up question in the content field.
Genie can respond with a generated SQL statement. In these cases, the attachments array field will have a query object that contains…
[title](https://openapi.dev.databricks.com/api/workspace/genie/getmessage#attachments-query-title) string: Name of the query
[query](https://openapi.dev.databricks.com/api/workspace/genie/getmessage#attachments-query-query) string: AI generated SQL query
[description](https://openapi.dev.databricks.com/api/workspace/genie/getmessage#attachments-query-description) string:  Description of the response
[last_updated_timestamp](https://openapi.dev.databricks.com/api/workspace/genie/getmessage#attachments-query-last_updated_timestamp) int64: Time when the user updated the query last