### PR TITLE
Prepare repo for next release

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ __pycache__
 
 # Editor files
 *.vscode
+.idea
 
 # Mac
 .DS_Store

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,11 @@
+# CHANGELOG
+
+## 0.0.2 (2024-11-01)
+Initial version of databricks-ai-bridge and databricks-langchain packages
+
+Features:
+
+- Support for Databricks AI/BI Genie via the `databricks_langchain.GenieAgent` API in `databricks-langchain`
+- Support for most functionality in the existing `langchain-databricks` under `databricks-langchain`. Specifically, this 
+  release introduces `databricks_langchain.ChatDatabricks`, `databricks_langchain.DatabricksEmbeddings`, and
+  `databricks_langchain.DatabricksVectorSearch` APIs. 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 ## Setting up dev environment
 
-Create a conda environement and install dev requirements
+Create a conda environment and install dev requirements
 
 ```sh
 conda create --name databricks-ai-dev-env python=3.10
@@ -15,27 +15,4 @@ If you are working with integration packages install them as well
 
 ```sh
 pip install -e "integrations/langchain[dev]"
-```
-
-## Publishing to PyPI
-
-Note: this section is for maitainers only.
-
-We recommend first uploading to test-PyPI
-
-### Publishing core package
-
-
-```sh
-pip install build
-python3 -m build --wheel
-twine upload dist/*
-```
-
-### Publishing integration packages
-
-```sh
-cd integrations/langchain
-python3 -m build --wheel
-twine upload dist/*
 ```

--- a/integrations/langchain/pyproject.toml
+++ b/integrations/langchain/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "databricks-langchain"
 version = "0.0.2"
-description = "Support for Datarbricks AI support in LangChain"
+description = "Support for Databricks AI support in LangChain"
 authors = [
     { name="Prithvi Kannan", email="prithvi.kannan@databricks.com" },
 ]


### PR DESCRIPTION
Prepares databricks-ai-bridge for the next release by:
* Adding an initial CHANGELOG.md and backfilling it for the 0.0.2 release. A followup PR will update it for the upcoming 0.0.3 release
* Updating .gitignore to ignore .idea files
* Removing the WIP contributor guide around release SOP, we'll move this elsewhere
* Fixing a small typo in the package description