### PR TITLE
WIP: Add genie tool support and add the trace details in databricks mlflow tracing

### DIFF
--- a/integrations/langchain/README.md
+++ b/integrations/langchain/README.md
@@ -13,6 +13,15 @@ pip install databricks-langchain
 
 ### Install from source
 
+
+With https:
+
+```sh
+pip install git+https://github.com/databricks/databricks-ai-bridge.git#subdirectory=integrations/langchain
+```
+
+With SSH:
+
 ```sh
 pip install git+ssh://git@github.com/databricks/databricks-ai-bridge.git#subdirectory=integrations/langchain
 ```

--- a/integrations/langchain/src/databricks_langchain/genie.py
+++ b/integrations/langchain/src/databricks_langchain/genie.py
@@ -53,7 +53,7 @@ def GenieTool(genie_space_id: str, genie_agent_name: str, genie_space_descriptio
         name: str = f"{genie_agent_name}_details"
         description: str = genie_space_description
         args_schema: Type[BaseModel] = GenieToolInput
-        response_format: str  = "content_and_artifact"
+        response_format: str = "content_and_artifact"
 
         def _run(
                 self,

--- a/integrations/langchain/src/databricks_langchain/genie.py
+++ b/integrations/langchain/src/databricks_langchain/genie.py
@@ -1,4 +1,9 @@
-from databricks_ai_bridge.genie import Genie
+import uuid
+from typing import Tuple, Type
+
+from pydantic import BaseModel, Field, Optional
+
+from databricks_ai_bridge.genie import Genie, GenieResult
 
 
 def _concat_messages_array(messages):
@@ -30,6 +35,60 @@ def _query_genie_as_agent(input, genie_space_id, genie_agent_name):
         return {"messages": [AIMessage(content=genie_response)]}
     else:
         return {"messages": [AIMessage(content="")]}
+
+
+def GenieTool(genie_space_id: str, genie_agent_name: str, description):
+    from langchain_core.tools import BaseTool
+    from langchain_core.callbacks.manager import CallbackManagerForToolRun
+
+    genie = Genie(genie_space_id)
+
+    class GenieToolInput(BaseModel):
+        question: str = Field(description="question to ask the agent")
+        summarized_chat_history: str = Field(
+            description="summarized chat history to provide the agent context of what may have been talked about. "
+                        "Say 'No history' if there is no history to provide.")
+
+    class GenieQuestionToolWithTrace(BaseTool):
+        name: str = genie_agent_name
+        description: str = description
+        args_schema: Type[BaseModel] = GenieToolInput
+        response_format: str  = "content_and_artifact"
+
+        def _run(
+                self,
+                question: str,
+                summarized_chat_history: str,
+                run_manager: Optional[CallbackManagerForToolRun] = None
+        ) -> Tuple[str, GenieResult]:
+            message = (f"I will provide you a chat history, where your name is {genie_agent_name}. "
+                       f"Please answer the following question: {question} with the following chat history "
+                       f"for context: {summarized_chat_history}.\n")
+            response = genie.ask_question(message, with_details=True)
+            return response.response, response
+
+    tool_with_details = GenieQuestionToolWithTrace()
+
+    class GenieQuestionToolCall(BaseTool):
+        name: str = genie_agent_name
+        description: str = description
+        args_schema: Type[BaseModel] = GenieToolInput
+
+        def _run(
+                self,
+                question: str,
+                summarized_chat_history: str,
+                run_manager: Optional[CallbackManagerForToolRun] = None
+        ) -> Tuple[str, GenieResult]:
+            tool_result = tool_with_details.invoke({
+                "name": "GenieQuestionToolWithDetails",
+                "args": {"question": question, "summarized_chat_history": summarized_chat_history},
+                "id": str(uuid.uuid4()),
+                "type": "tool_call"
+            })
+            return tool_result.content
+
+    return GenieQuestionToolCall()
 
 
 def GenieAgent(genie_space_id, genie_agent_name="Genie", description=""):

--- a/integrations/langchain/src/databricks_langchain/genie.py
+++ b/integrations/langchain/src/databricks_langchain/genie.py
@@ -37,7 +37,7 @@ def _query_genie_as_agent(input, genie_space_id, genie_agent_name):
         return {"messages": [AIMessage(content="")]}
 
 
-def GenieTool(genie_space_id: str, genie_agent_name: str, description):
+def GenieTool(genie_space_id: str, genie_agent_name: str, genie_space_description: str):
     from langchain_core.tools import BaseTool
     from langchain_core.callbacks.manager import CallbackManagerForToolRun
 
@@ -51,7 +51,7 @@ def GenieTool(genie_space_id: str, genie_agent_name: str, description):
 
     class GenieQuestionToolWithTrace(BaseTool):
         name: str = genie_agent_name
-        description: str = description
+        description: str = genie_space_description
         args_schema: Type[BaseModel] = GenieToolInput
         response_format: str  = "content_and_artifact"
 
@@ -71,7 +71,7 @@ def GenieTool(genie_space_id: str, genie_agent_name: str, description):
 
     class GenieQuestionToolCall(BaseTool):
         name: str = genie_agent_name
-        description: str = description
+        description: str = genie_space_description
         args_schema: Type[BaseModel] = GenieToolInput
 
         def _run(

--- a/integrations/langchain/src/databricks_langchain/genie.py
+++ b/integrations/langchain/src/databricks_langchain/genie.py
@@ -1,7 +1,7 @@
 import uuid
-from typing import Tuple, Type
+from typing import Tuple, Type, Optional
 
-from pydantic import BaseModel, Field, Optional
+from pydantic import BaseModel, Field
 
 from databricks_ai_bridge.genie import Genie, GenieResult
 

--- a/integrations/langchain/src/databricks_langchain/genie.py
+++ b/integrations/langchain/src/databricks_langchain/genie.py
@@ -60,12 +60,14 @@ def GenieTool(genie_space_id: str, genie_agent_name: str, genie_space_descriptio
                 question: str,
                 summarized_chat_history: str,
                 run_manager: Optional[CallbackManagerForToolRun] = None
-        ) -> Tuple[str, GenieResult]:
+        ) -> Tuple[str, Optional[GenieResult]]:
             message = (f"I will provide you a chat history, where your name is {genie_agent_name}. "
                        f"Please answer the following question: {question} with the following chat history "
                        f"for context: {summarized_chat_history}.\n")
             response = genie.ask_question(message, with_details=True)
-            return response.response, response
+            if response:
+                return response.response, response
+            return "no results from room", None
 
     tool_with_details = GenieQuestionToolWithTrace()
 

--- a/integrations/langchain/src/databricks_langchain/genie.py
+++ b/integrations/langchain/src/databricks_langchain/genie.py
@@ -50,7 +50,7 @@ def GenieTool(genie_space_id: str, genie_agent_name: str, genie_space_descriptio
                         "Say 'No history' if there is no history to provide.")
 
     class GenieQuestionToolWithTrace(BaseTool):
-        name: str = genie_agent_name
+        name: str = f"{genie_agent_name}_details"
         description: str = genie_space_description
         args_schema: Type[BaseModel] = GenieToolInput
         response_format: str  = "content_and_artifact"
@@ -83,7 +83,6 @@ def GenieTool(genie_space_id: str, genie_agent_name: str, genie_space_descriptio
                 run_manager: Optional[CallbackManagerForToolRun] = None
         ) -> Tuple[str, GenieResult]:
             tool_result = tool_with_details.invoke({
-                "name": "GenieQuestionToolWithDetails",
                 "args": {"question": question, "summarized_chat_history": summarized_chat_history},
                 "id": str(uuid.uuid4()),
                 "type": "tool_call"

--- a/tests/databricks_ai_bridge/test_genie.py
+++ b/tests/databricks_ai_bridge/test_genie.py
@@ -4,7 +4,7 @@ from unittest.mock import patch
 import pandas as pd
 import pytest
 
-from databricks_ai_bridge.genie import Genie, _count_tokens, _parse_query_result
+from databricks_ai_bridge.genie import Genie, _count_tokens, _parse_query_result, GenieResult
 
 
 @pytest.fixture
@@ -48,7 +48,7 @@ def test_poll_for_result_completed_with_text(genie, mock_workspace_client):
         {"status": "COMPLETED", "attachments": [{"text": {"content": "Result"}}]},
     ]
     result = genie.poll_for_result("123", "456")
-    assert result == "Result"
+    assert result.response == "Result"
 
 
 def test_poll_for_result_completed_with_query(genie, mock_workspace_client):
@@ -65,7 +65,7 @@ def test_poll_for_result_completed_with_query(genie, mock_workspace_client):
         },
     ]
     result = genie.poll_for_result("123", "456")
-    assert result == pd.DataFrame().to_markdown()
+    assert result.response == pd.DataFrame().to_markdown()
 
 
 def test_poll_for_result_executing_query(genie, mock_workspace_client):
@@ -82,7 +82,7 @@ def test_poll_for_result_executing_query(genie, mock_workspace_client):
         },
     ]
     result = genie.poll_for_result("123", "456")
-    assert result == pd.DataFrame().to_markdown()
+    assert result.response == pd.DataFrame().to_markdown()
 
 
 def test_poll_for_result_failed(genie, mock_workspace_client):
@@ -134,7 +134,7 @@ def test_poll_for_result_max_iterations(genie, mock_workspace_client):
             },
         ]
         result = genie.poll_for_result("123", "456")
-        assert result is None
+        assert result.response is None
 
 
 def test_ask_question(genie, mock_workspace_client):
@@ -144,6 +144,16 @@ def test_ask_question(genie, mock_workspace_client):
     ]
     result = genie.ask_question("What is the meaning of life?")
     assert result == "Answer"
+
+
+def test_ask_question_with_details(genie, mock_workspace_client):
+    mock_workspace_client.genie._api.do.side_effect = [
+        {"conversation_id": "123", "message_id": "456"},
+        {"status": "COMPLETED", "attachments": [{"text": {"content": "Answer"}}]},
+    ]
+    result = genie.ask_question("What is the meaning of life?", with_details=True)
+    assert isinstance(result, GenieResult)
+    assert result.response == "Answer"
 
 
 def test_parse_query_result_empty():
@@ -240,17 +250,17 @@ def test_parse_query_result_trims_large_data():
         }
         result = _parse_query_result(resp)
         assert (
-            result
-            == pd.DataFrame(
-                {
-                    "id": [1, 2, 3],
-                    "name": ["Alice", "Bob", "Charlie"],
-                    "created_at": [
-                        datetime(2023, 10, 1).date(),
-                        datetime(2023, 10, 2).date(),
-                        datetime(2023, 10, 3).date(),
-                    ],
-                }
-            ).to_markdown()
+                result
+                == pd.DataFrame(
+            {
+                "id": [1, 2, 3],
+                "name": ["Alice", "Bob", "Charlie"],
+                "created_at": [
+                    datetime(2023, 10, 1).date(),
+                    datetime(2023, 10, 2).date(),
+                    datetime(2023, 10, 3).date(),
+                ],
+            }
+        ).to_markdown()
         )
         assert _count_tokens(result) <= 100


### PR DESCRIPTION
- [x] tested with agent executor tools
- [ ] tested with langgraph tools

- [x] tests for bridge library
- [ ] tests for the langchain integration

- [ ] docs upgrade

It is implemented by creating two nested tool calls to simulate invoking a tool to be picked up by databricks tracing. This lets you only expose query results to the llm but provide a trace for the query description, query and results in the tracing UI. Look at the usage and screenshots below. It uses tool with `response_format: str = "content_and_artifact"` which when invoked will include a trace with the genie tool call and a detailed nested trace right underneath it. 

Usage:

```python

import mlflow
from mlflow.models import ModelConfig

mlflow.langchain.autolog()
config = ModelConfig(development_config="config.yml")

from langchain_databricks import ChatDatabricks

# Create the llm
llm = ChatDatabricks(endpoint=config.get("llm_endpoint"))

from databricks_langchain.genie import GenieTool

tools = [
  GenieTool(
    genie_space_id=genie_space_id, 
    genie_agent_name=genie_agent_name, 
    genie_space_description=genie_space_description
  )
]

from langchain import hub

# Get the prompt to use - can be replaced with any prompt that includes variables "agent_scratchpad" and "input"!
prompt = hub.pull("hwchase17/openai-tools-agent")

from langchain.agents import AgentExecutor, create_tool_calling_agent
agent = create_tool_calling_agent(llm, tools, prompt)
agent_executor = AgentExecutor(agent=agent, tools=tools, verbose=True)

from mlflow.langchain.output_parsers import ChatCompletionsOutputParser
output_parser = ChatCompletionsOutputParser()


from langchain_core.runnables import RunnableLambda

# needed because agent executor returns {"input": "...", "output": "..."}
def agent_executor_to_just_response(inp):
    return inp["output"]
  
def pre_process_input(inp):
    # this is needed to conform to agent executor input which requires input and agent_scratchpad
    return {
        "input": inp
    }

chain = RunnableLambda(pre_process_input) | agent_executor | RunnableLambda(agent_executor_to_just_response) | output_parser

chain.invoke("what are the top 10 locations that show the most co2 emissions?")
```

![image](https://github.com/user-attachments/assets/e0150b3a-3224-4e9b-bc0a-aeeaf8727c13)
![image](https://github.com/user-attachments/assets/cbda848b-5ae5-4130-b810-2bc179ca9a69)
![image](https://github.com/user-attachments/assets/4558c83f-098a-42fe-b9a0-afa8ced0acb6)
