### PR TITLE
Client Arguments for DatabricksVectorSearch

### DIFF
--- a/integrations/langchain/src/databricks_langchain/vectorstores.py
+++ b/integrations/langchain/src/databricks_langchain/vectorstores.py
@@ -86,6 +86,10 @@ class DatabricksVectorSearch(VectorStore):
                     Make sure the text column specified is in the index.
         columns: The list of column names to get when doing the search.
                 Defaults to ``[primary_key, text_column]``.
+        client_args: Additional arguments to pass to the VectorSearchClient.
+                    Allows you to pass in values like `service_principal_client_id`
+                    and `service_principal_client_secret` for to allow for
+                    service principal authentication instead of personal access token authentication.
 
     Instantiate:
 
@@ -212,6 +216,7 @@ class DatabricksVectorSearch(VectorStore):
         embedding: Optional[Embeddings] = None,
         text_column: Optional[str] = None,
         columns: Optional[List[str]] = None,
+        client_args: Optional[Dict[str, Any]] = None,
     ):
         if not (isinstance(index_name, str) and _INDEX_NAME_PATTERN.match(index_name)):
             raise ValueError(
@@ -230,7 +235,7 @@ class DatabricksVectorSearch(VectorStore):
             ) from e
 
         try:
-            self.index = VectorSearchClient().get_index(
+            self.index = VectorSearchClient(**client_args).get_index(
                 endpoint_name=endpoint, index_name=index_name
             )
         except Exception as e:

--- a/integrations/langchain/src/databricks_langchain/vectorstores.py
+++ b/integrations/langchain/src/databricks_langchain/vectorstores.py
@@ -238,8 +238,6 @@ class DatabricksVectorSearch(VectorStore):
             self.index = VectorSearchClient(**(client_args or {})).get_index(
                 endpoint_name=endpoint, index_name=index_name
             )
-                endpoint_name=endpoint, index_name=index_name
-            )
         except Exception as e:
             if endpoint is None and "Wrong vector search endpoint" in str(e):
                 raise ValueError(

--- a/integrations/langchain/src/databricks_langchain/vectorstores.py
+++ b/integrations/langchain/src/databricks_langchain/vectorstores.py
@@ -235,7 +235,9 @@ class DatabricksVectorSearch(VectorStore):
             ) from e
 
         try:
-            self.index = VectorSearchClient(**client_args).get_index(
+            self.index = VectorSearchClient(**(client_args or {})).get_index(
+                endpoint_name=endpoint, index_name=index_name
+            )
                 endpoint_name=endpoint, index_name=index_name
             )
         except Exception as e:


### PR DESCRIPTION
This PR allows new instances of `DatabricksVectorSearch` to pass custom arguments to the underlying `VectorSearchClient` (imported from `databricks.vector_search.client`).

This allows users to be able to use Service Principal based authentication by passing in `service_principal_client_id` or `service_principal_client_secret` within the new `client_args` parameter.