### PR TITLE
Add support for OpenAI structured outputs with json_schema

### DIFF
--- a/integrations/langchain/src/databricks_langchain/chat_models.py
+++ b/integrations/langchain/src/databricks_langchain/chat_models.py
@@ -437,7 +437,9 @@ class ChatDatabricks(BaseChatModel):
         self,
         schema: Optional[Union[Dict, Type]] = None,
         *,
-        method: Literal["function_calling", "json_mode"] = "function_calling",
+        method: Literal[
+            "function_calling", "json_mode", "json_schema"
+        ] = "function_calling",
         include_raw: bool = False,
         **kwargs: Any,
     ) -> Runnable[LanguageModelInput, Union[Dict, BaseModel]]:
@@ -625,10 +627,32 @@ class ChatDatabricks(BaseChatModel):
                 if is_pydantic_schema
                 else JsonOutputParser()
             )
+        elif method == "json_schema":
+            if schema is None:
+                raise ValueError(
+                    "schema must be specified when method is 'json_schema'. "
+                    "Received None."
+                )
+            response_format = {
+                "type": "json_schema",
+                "json_schema": {
+                    "strict": True,
+                    "schema": (
+                        schema.model_json_schema() if is_pydantic_schema else schema  # type: ignore[union-attr]
+                    ),
+                },
+            }
+            llm = self.bind(response_format=response_format)
+            output_parser = (
+                PydanticOutputParser(pydantic_object=schema)  # type: ignore[arg-type]
+                if is_pydantic_schema
+                else JsonOutputParser()
+            )
+
         else:
             raise ValueError(
-                f"Unrecognized method argument. Expected one of 'function_calling' or "
-                f"'json_mode'. Received: '{method}'"
+                f"Unrecognized method argument. Expected one of 'function_calling', "
+                f"'json_mode' or 'json_schema'. Received: '{method}'"
             )
 
         if include_raw:

--- a/integrations/langchain/tests/unit_tests/test_chat_models.py
+++ b/integrations/langchain/tests/unit_tests/test_chat_models.py
@@ -38,7 +38,7 @@ from tests.utils.chat_models import (  # noqa: F401
 def test_dict(llm: ChatDatabricks) -> None:
     d = llm.dict()
     assert d["_type"] == "chat-databricks"
-    assert d["endpoint"] == "databricks-meta-llama-3-70b-instruct"
+    assert d["endpoint"] == "databricks-meta-llama-3-3-70b-instruct"
     assert d["target_uri"] == "databricks"
 
 
@@ -85,7 +85,7 @@ def test_chat_model_stream_with_usage(llm: ChatDatabricks) -> None:
 
     # Method 2: Pass stream_usage=True to the constructor
     llm_with_usage = ChatDatabricks(
-        endpoint="databricks-meta-llama-3-70b-instruct",
+        endpoint="databricks-meta-llama-3-3-70b-instruct",
         target_uri="databricks",
         stream_usage=True,
     )
@@ -163,15 +163,17 @@ class AnswerWithJustification(BaseModel):
 # Raw JSON schema
 JSON_SCHEMA = {
     "title": "AnswerWithJustification",
-    "description": "An answer to the user question along with justification.",
+    "description": "An answer to the user question along with justification for the answer.",
     "type": "object",
     "properties": {
         "answer": {
             "type": "string",
+            "title": "Answer",
             "description": "The answer to the user question.",
         },
         "justification": {
             "type": "string",
+            "title": "Justification",
             "description": "The justification for the answer.",
         },
     },
@@ -180,9 +182,9 @@ JSON_SCHEMA = {
 
 
 @pytest.mark.parametrize("schema", [AnswerWithJustification, JSON_SCHEMA, None])
-@pytest.mark.parametrize("method", ["function_calling", "json_mode"])
+@pytest.mark.parametrize("method", ["function_calling", "json_mode", "json_schema"])
 def test_chat_model_with_structured_output(llm, schema, method: str):
-    if schema is None and method == "function_calling":
+    if schema is None and method in ["function_calling", "json_schema"]:
         pytest.skip("Cannot use function_calling without schema")
 
     structured_llm = llm.with_structured_output(schema, method=method)
@@ -190,6 +192,8 @@ def test_chat_model_with_structured_output(llm, schema, method: str):
     bind = structured_llm.first.kwargs
     if method == "function_calling":
         assert bind["tool_choice"]["function"]["name"] == "AnswerWithJustification"
+    elif method == "json_schema":
+        assert bind["response_format"]["json_schema"]["schema"] == JSON_SCHEMA
     else:
         assert bind["response_format"] == {"type": "json_object"}
 

--- a/integrations/langchain/tests/utils/chat_models.py
+++ b/integrations/langchain/tests/utils/chat_models.py
@@ -130,4 +130,6 @@ def mock_client() -> Generator:
 
 @pytest.fixture
 def llm() -> ChatDatabricks:
-    return ChatDatabricks(endpoint="databricks-meta-llama-3-70b-instruct", target_uri="databricks")
+    return ChatDatabricks(
+        endpoint="databricks-meta-llama-3-3-70b-instruct", target_uri="databricks"
+    )


### PR DESCRIPTION
Implements a "json_schema" mode in ChatDatabricks to allow passing a JSON schema to models. Enhances existing options (function calling, JSON mode). Includes updates to test cases to reflect currently-available models and to test the new functionality. (And passes all unit tests.)

This approach is slightly less sophisticated than what the OpenAI integration uses (see https://github.com/langchain-ai/langchain/blob/ff675c11f6814e88aa338dc3668aa84d1ade3d19/libs/partners/openai/langchain_openai/chat_models/base.py#L1142). I personally don't think that the complexity makes sense right now (i.e., when enforced json schemas are not utilized by other Databricks models) but would be willing to implement it if desired by the project maintainers.

@prithvikannan happy to take feedback or comments