### PR TITLE
Add MLflow tracing for langchain and openai implementations of VectorSearchRetrieverTool

### DIFF
--- a/integrations/langchain/src/databricks_langchain/vector_search_retriever_tool.py
+++ b/integrations/langchain/src/databricks_langchain/vector_search_retriever_tool.py
@@ -4,6 +4,7 @@ from databricks_ai_bridge.utils.vector_search import IndexDetails
 from databricks_ai_bridge.vector_search_retriever_tool import (
     VectorSearchRetrieverToolInput,
     VectorSearchRetrieverToolMixin,
+    vector_search_retriever_tool_trace,
 )
 from langchain_core.embeddings import Embeddings
 from langchain_core.tools import BaseTool
@@ -54,6 +55,7 @@ class VectorSearchRetrieverTool(BaseTool, VectorSearchRetrieverToolMixin):
 
         return self
 
+    @vector_search_retriever_tool_trace
     def _run(self, query: str) -> str:
         return self._vector_store.similarity_search(
             query, k=self.num_results, filter=self.filters, query_type=self.query_type

--- a/integrations/langchain/tests/unit_tests/test_vector_search_retriever_tool.py
+++ b/integrations/langchain/tests/unit_tests/test_vector_search_retriever_tool.py
@@ -1,5 +1,6 @@
 from typing import Any, Dict, List, Optional
 
+import mlflow
 import pytest
 from databricks_ai_bridge.test_utils.vector_search import (  # noqa: F401
     ALL_INDEX_NAMES,
@@ -9,12 +10,12 @@ from databricks_ai_bridge.test_utils.vector_search import (  # noqa: F401
 )
 from langchain_core.embeddings import Embeddings
 from langchain_core.tools import BaseTool
+from mlflow.entities import SpanType
 
 from databricks_langchain import ChatDatabricks, VectorSearchRetrieverTool
 from tests.utils.chat_models import llm, mock_client  # noqa: F401
 from tests.utils.vector_search import EMBEDDING_MODEL
-import mlflow
-from mlflow.entities import SpanType
+
 
 def init_vector_search_tool(
     index_name: str,
@@ -105,10 +106,10 @@ def test_vector_search_retriever_tool_description_generation(index_name: str) ->
         "vectors and return the associated documents."
     )
 
+
 @pytest.mark.parametrize("index_name", ALL_INDEX_NAMES)
 @pytest.mark.parametrize("tool_name", [None, "test_tool"])
-def test_vs_tool_tracing(index_name: str,
-                         tool_name: Optional[str]) -> None:
+def test_vs_tool_tracing(index_name: str, tool_name: Optional[str]) -> None:
     vector_search_tool = init_vector_search_tool(index_name, tool_name=tool_name)
     vector_search_tool._run("Databricks Agent Framework")
     trace = mlflow.get_last_active_trace()

--- a/integrations/openai/src/databricks_openai/vector_search_retriever_tool.py
+++ b/integrations/openai/src/databricks_openai/vector_search_retriever_tool.py
@@ -11,6 +11,7 @@ from databricks_ai_bridge.utils.vector_search import (
 from databricks_ai_bridge.vector_search_retriever_tool import (
     VectorSearchRetrieverToolInput,
     VectorSearchRetrieverToolMixin,
+    vector_search_retriever_tool_trace,
 )
 from pydantic import Field, PrivateAttr, model_validator
 
@@ -84,6 +85,7 @@ class VectorSearchRetrieverTool(VectorSearchRetrieverToolMixin):
         )
         return self
 
+    @vector_search_retriever_tool_trace
     def execute_calls(
         self,
         response: ChatCompletion,

--- a/integrations/openai/tests/unit_tests/test_vector_search_retriever_tool.py
+++ b/integrations/openai/tests/unit_tests/test_vector_search_retriever_tool.py
@@ -2,6 +2,7 @@ import os
 from typing import Any, Dict, List, Optional
 from unittest.mock import MagicMock, Mock, patch
 
+import mlflow
 import pytest
 from databricks_ai_bridge.test_utils.vector_search import (  # noqa: F401
     ALL_INDEX_NAMES,
@@ -10,6 +11,7 @@ from databricks_ai_bridge.test_utils.vector_search import (  # noqa: F401
     mock_vs_client,
     mock_workspace_client,
 )
+from mlflow.entities import SpanType
 from openai.types.chat import (
     ChatCompletion,
     ChatCompletionMessage,
@@ -21,8 +23,7 @@ from openai.types.chat.chat_completion_message_tool_call_param import Function
 from pydantic import BaseModel, TypeAdapter
 
 from databricks_openai import VectorSearchRetrieverTool
-import mlflow
-from mlflow.entities import SpanType
+
 
 @pytest.fixture(autouse=True)
 def mock_openai_client():
@@ -172,15 +173,16 @@ def test_open_ai_client_from_env(
     )
     assert response is not None
 
+
 @pytest.mark.parametrize("index_name", ALL_INDEX_NAMES)
 @pytest.mark.parametrize("columns", [None, ["id", "text"]])
 @pytest.mark.parametrize("tool_name", [None, "test_tool"])
 @pytest.mark.parametrize("tool_description", [None, "Test tool for vector search"])
 def test_vector_search_retriever_tool_init(
-        index_name: str,
-        columns: Optional[List[str]],
-        tool_name: Optional[str],
-        tool_description: Optional[str],
+    index_name: str,
+    columns: Optional[List[str]],
+    tool_name: Optional[str],
+    tool_description: Optional[str],
 ) -> None:
     if index_name == DELTA_SYNC_INDEX:
         self_managed_embeddings_test = SelfManagedEmbeddingsTest()

--- a/src/databricks_ai_bridge/vector_search_retriever_tool.py
+++ b/src/databricks_ai_bridge/vector_search_retriever_tool.py
@@ -1,34 +1,38 @@
+from functools import wraps
 from typing import Any, Dict, List, Optional
 
+import mlflow
+from mlflow.entities import SpanType
 from pydantic import BaseModel, Field
 
 from databricks_ai_bridge.utils.vector_search import IndexDetails
-import mlflow
-from mlflow.entities import SpanType
-from functools import wraps
 
 DEFAULT_TOOL_DESCRIPTION = "A vector search-based retrieval tool for querying indexed embeddings."
+
 
 def vector_search_retriever_tool_trace(func):
     """
     Decorator factory to trace VectorSearchRetrieverTool with the tool name
     """
+
     @wraps(func)
     def wrapper(self, *args, **kwargs):
         # Create a new decorator with the instance's name
         traced_func = mlflow.trace(
-            name=self.tool_name or self.index_name,
-            span_type=SpanType.RETRIEVER
+            name=self.tool_name or self.index_name, span_type=SpanType.RETRIEVER
         )(func)
         # Call the traced function with self
         return traced_func(self, *args, **kwargs)
+
     return wrapper
+
 
 class VectorSearchRetrieverToolInput(BaseModel):
     query: str = Field(
         description="The string used to query the index with and identify the most similar "
         "vectors and return the associated documents."
     )
+
 
 class VectorSearchRetrieverToolMixin(BaseModel):
     """
@@ -70,4 +74,3 @@ class VectorSearchRetrieverToolMixin(BaseModel):
                     + f" The queried index uses the source table {source_table}"
                 )
         return DEFAULT_TOOL_DESCRIPTION
-


### PR DESCRIPTION
This PR adds tracing to the VectorSearchRetrieverTool across the Langchain and Openai implementations. In order to name the trace correctly I've implemented a reusable decorator factory:
```
def vector_search_retriever_tool_trace(func):
    """
    Decorator factory to trace VectorSearchRetrieverTool with the tool name
    """
```
Our tools are named based on the user input tool_name otherwise it defaults to the index name.