### PR TITLE
Simplify OpenAI VectorSearchRetrieverTool tool execution function

### DIFF
--- a/integrations/openai/src/databricks_openai/vector_search_retriever_tool.py
+++ b/integrations/openai/src/databricks_openai/vector_search_retriever_tool.py
@@ -31,7 +31,7 @@ class VectorSearchRetrieverTool(VectorSearchRetrieverToolMixin):
             messages=initial_messages,
             tools=tools,
         )
-        tool_call = chat_completion_resp.choices[0].message.tool_calls[0]
+        tool_call = response.choices[0].message.tool_calls[0]
         args = json.loads(tool_call.function.arguments)
         retriever_resp = vector_search_tool.execute(query=args["query"])
     """

--- a/integrations/openai/src/databricks_openai/vector_search_retriever_tool.py
+++ b/integrations/openai/src/databricks_openai/vector_search_retriever_tool.py
@@ -1,5 +1,4 @@
-import json
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Dict, List, Optional, Tuple
 
 from databricks.vector_search.client import VectorSearchIndex
 from databricks_ai_bridge.utils.vector_search import (
@@ -15,7 +14,7 @@ from databricks_ai_bridge.vector_search_retriever_tool import (
 from pydantic import Field, PrivateAttr, model_validator
 
 from openai import OpenAI, pydantic_function_tool
-from openai.types.chat import ChatCompletion, ChatCompletionMessageToolCall, ChatCompletionToolParam
+from openai.types.chat import ChatCompletionToolParam
 
 
 class VectorSearchRetrieverTool(VectorSearchRetrieverToolMixin):
@@ -44,9 +43,10 @@ class VectorSearchRetrieverTool(VectorSearchRetrieverToolMixin):
         "self-managed embeddings.",
     )
     embedding_model_name: Optional[str] = Field(
-        None, description="The name of the embedding model to use for embedding the query text."
-                          "Required for direct-access index or delta-sync index with "
-                          "self-managed embeddings.",
+        None,
+        description="The name of the embedding model to use for embedding the query text."
+        "Required for direct-access index or delta-sync index with "
+        "self-managed embeddings.",
     )
 
     tool: ChatCompletionToolParam = Field(
@@ -68,7 +68,10 @@ class VectorSearchRetrieverTool(VectorSearchRetrieverToolMixin):
             self.columns or [], self.text_column, self._index_details
         )
 
-        if not self._index_details.is_databricks_managed_embeddings() and not self.embedding_model_name:
+        if (
+            not self._index_details.is_databricks_managed_embeddings()
+            and not self.embedding_model_name
+        ):
             raise ValueError(
                 "The embedding model name is required for non-Databricks-managed "
                 "embeddings Vector Search indexes in order to generate embeddings for retrieval queries."

--- a/integrations/openai/src/databricks_openai/vector_search_retriever_tool.py
+++ b/integrations/openai/src/databricks_openai/vector_search_retriever_tool.py
@@ -130,7 +130,7 @@ class VectorSearchRetrieverTool(VectorSearchRetrieverToolMixin):
         self,
         query: str,
         openai_client: OpenAI = None,
-    ) -> List[Tuple[Dict, float]]:
+    ) -> List[Dict]:
         """
         Execute the VectorSearchIndex tool calls from the ChatCompletions response that correspond to the
         self.tool VectorSearchRetrieverToolInput and attach the retrieved documents into tool call messages.
@@ -141,7 +141,7 @@ class VectorSearchRetrieverTool(VectorSearchRetrieverToolMixin):
                            the default OpenAI client in the current environment will be used.
 
         Returns:
-            A list of documents with their corresponding similarity scores.
+            A list of documents
         """
 
         if self._index_details.is_databricks_managed_embeddings():

--- a/integrations/openai/src/databricks_openai/vector_search_retriever_tool.py
+++ b/integrations/openai/src/databricks_openai/vector_search_retriever_tool.py
@@ -1,3 +1,4 @@
+import logging
 from typing import Dict, List, Optional, Tuple
 
 from databricks.vector_search.client import VectorSearchIndex
@@ -15,10 +16,9 @@ from pydantic import Field, PrivateAttr, model_validator
 
 from openai import OpenAI, pydantic_function_tool
 from openai.types.chat import ChatCompletionToolParam
-import logging
-
 
 _logger = logging.getLogger(__name__)
+
 
 class VectorSearchRetrieverTool(VectorSearchRetrieverToolMixin):
     """
@@ -99,7 +99,8 @@ class VectorSearchRetrieverTool(VectorSearchRetrieverToolMixin):
         self.tool = pydantic_function_tool(
             VectorSearchRetrieverToolInput,
             name=get_tool_name(),
-            description=self.tool_description or self._get_default_tool_description(self._index_details),
+            description=self.tool_description
+            or self._get_default_tool_description(self._index_details),
         )
         return self
 

--- a/integrations/openai/src/databricks_openai/vector_search_retriever_tool.py
+++ b/integrations/openai/src/databricks_openai/vector_search_retriever_tool.py
@@ -80,7 +80,7 @@ class VectorSearchRetrieverTool(VectorSearchRetrieverToolMixin):
         # OpenAI tool names must match the pattern '^[a-zA-Z0-9_-]+$'."
         # The '.' from the index name are not allowed
         def rewrite_index_name(index_name: str):
-            return index_name.replace(".", "_")
+            return index_name.replace(".", "__")
 
         self.tool = pydantic_function_tool(
             VectorSearchRetrieverToolInput,

--- a/integrations/openai/src/databricks_openai/vector_search_retriever_tool.py
+++ b/integrations/openai/src/databricks_openai/vector_search_retriever_tool.py
@@ -182,4 +182,4 @@ class VectorSearchRetrieverTool(VectorSearchRetrieverToolMixin):
             text_column=self.text_column,
             document_class=dict,
         )
-        return docs_with_score
+        return [doc for doc, _ in docs_with_score]

--- a/integrations/openai/src/databricks_openai/vector_search_retriever_tool.py
+++ b/integrations/openai/src/databricks_openai/vector_search_retriever_tool.py
@@ -114,7 +114,7 @@ class VectorSearchRetrieverTool(VectorSearchRetrieverToolMixin):
             tool_name = self.tool_name or self.index_name.replace(".", "__")
             if len(tool_name) > 64:
                 _logger.warning(
-                    f"Function name {tool_name} is too long, truncating to 64 characters {tool_name[-64:]}."
+                    f"Tool name {tool_name} is too long, truncating to 64 characters {tool_name[-64:]}."
                 )
                 return tool_name[-64:]
             return tool_name

--- a/integrations/openai/src/databricks_openai/vector_search_retriever_tool.py
+++ b/integrations/openai/src/databricks_openai/vector_search_retriever_tool.py
@@ -32,17 +32,9 @@ class VectorSearchRetrieverTool(VectorSearchRetrieverToolMixin):
             messages=initial_messages,
             tools=tools,
         )
-        retriever_call_message = dbvs_tool.execute_calls(response)
-
-        ### If needed, execute potential remaining tool calls here ###
-        remaining_tool_call_messages = execute_remaining_tool_calls(response)
-
-        final_response = openai.chat.completions.create(
-            model="gpt-4o",
-            messages=initial_messages + retriever_call_message + remaining_tool_call_messages,
-            tools=tools,
-        )
-        final_response.choices[0].message.content
+        tool_call = chat_completion_resp.choices[0].message.tool_calls[0]
+        args = json.loads(tool_call.function.arguments)
+        retriever_resp = vector_search_tool.execute(query=args["query"])
     """
 
     text_column: Optional[str] = Field(
@@ -50,6 +42,11 @@ class VectorSearchRetrieverTool(VectorSearchRetrieverToolMixin):
         description="The name of the text column to use for the embeddings. "
         "Required for direct-access index or delta-sync index with "
         "self-managed embeddings.",
+    )
+    embedding_model_name: Optional[str] = Field(
+        None, description="The name of the embedding model to use for embedding the query text."
+                          "Required for direct-access index or delta-sync index with "
+                          "self-managed embeddings.",
     )
 
     tool: ChatCompletionToolParam = Field(
@@ -71,6 +68,12 @@ class VectorSearchRetrieverTool(VectorSearchRetrieverToolMixin):
             self.columns or [], self.text_column, self._index_details
         )
 
+        if not self._index_details.is_databricks_managed_embeddings() and not self.embedding_model_name:
+            raise ValueError(
+                "The embedding model name is required for non-Databricks-managed "
+                "embeddings Vector Search indexes in order to generate embeddings for retrieval queries."
+            )
+
         # OpenAI tool names must match the pattern '^[a-zA-Z0-9_-]+$'."
         # The '.' from the index name are not allowed
         def rewrite_index_name(index_name: str):
@@ -84,44 +87,27 @@ class VectorSearchRetrieverTool(VectorSearchRetrieverToolMixin):
         )
         return self
 
-    def execute_calls(
+    def execute(
         self,
-        response: ChatCompletion,
-        choice_index: int = 0,
-        embedding_model_name: str = None,
+        query: str,
         openai_client: OpenAI = None,
-    ) -> List[Dict[str, Any]]:
+    ) -> List[Tuple[Dict, float]]:
         """
         Execute the VectorSearchIndex tool calls from the ChatCompletions response that correspond to the
         self.tool VectorSearchRetrieverToolInput and attach the retrieved documents into tool call messages.
 
         Args:
-            response: The chat completion response object returned by the OpenAI API.
-            choice_index: The index of the choice to process. Defaults to 0. Note that multiple
-                choices are not supported yet.
-            embedding_model_name: The name of the embedding model to use for embedding the query text.
-                                  Required for direct access indexes or delta-sync indexes with self-managed embeddings.
+            query: The query text to use for the retrieval.
             openai_client: The OpenAI client object used to generate embeddings for retrieval queries. If not provided,
                            the default OpenAI client in the current environment will be used.
 
         Returns:
-            A list of messages containing the assistant message and the retriever call results
-            that correspond to the self.tool VectorSearchRetrieverToolInput.
+            A list of documents with their corresponding similarity scores.
         """
 
-        def get_query_text_vector(
-            tool_call: ChatCompletionMessageToolCall,
-        ) -> Tuple[Optional[str], Optional[List[float]]]:
-            query = json.loads(tool_call.function.arguments)["query"]
-            if self._index_details.is_databricks_managed_embeddings():
-                if embedding_model_name:
-                    raise ValueError(
-                        f"The index '{self._index_details.name}' uses Databricks-managed embeddings. "
-                        "Do not pass the `embedding_model_name` parameter when executing retriever calls."
-                    )
-                return query, None
-
-            # For non-Databricks-managed embeddings
+        if self._index_details.is_databricks_managed_embeddings():
+            query_text, query_vector = query, None
+        else:  # For non-Databricks-managed embeddings
             from openai import OpenAI
 
             oai_client = openai_client or OpenAI()
@@ -129,15 +115,10 @@ class VectorSearchRetrieverTool(VectorSearchRetrieverToolMixin):
                 raise ValueError(
                     "OpenAI API key is required to generate embeddings for retrieval queries."
                 )
-            if not embedding_model_name:
-                raise ValueError(
-                    "The embedding model name is required for non-Databricks-managed "
-                    "embeddings Vector Search indexes in order to generate embeddings for retrieval queries."
-                )
 
-            text = query if self.query_type and self.query_type.upper() == "HYBRID" else None
-            vector = (
-                oai_client.embeddings.create(input=query, model=embedding_model_name)
+            query_text = query if self.query_type and self.query_type.upper() == "HYBRID" else None
+            query_vector = (
+                oai_client.embeddings.create(input=query, model=self.embedding_model_name)
                 .data[0]
                 .embedding
             )
@@ -145,54 +126,23 @@ class VectorSearchRetrieverTool(VectorSearchRetrieverToolMixin):
                 index_embedding_dimension := self._index_details.embedding_vector_column.get(
                     "embedding_dimension"
                 )
-            ) and len(vector) != index_embedding_dimension:
+            ) and len(query_vector) != index_embedding_dimension:
                 raise ValueError(
                     f"Expected embedding dimension {index_embedding_dimension} but got {len(vector)}"
                 )
-            return text, vector
 
-        def is_tool_call_for_index(tool_call: ChatCompletionMessageToolCall) -> bool:
-            tool_call_arguments: Set[str] = set(json.loads(tool_call.function.arguments).keys())
-            vs_index_arguments: Set[str] = set(
-                self.tool["function"]["parameters"]["properties"].keys()
-            )
-            return (
-                tool_call.function.name == self.tool["function"]["name"]
-                and tool_call_arguments == vs_index_arguments
-            )
-
-        if type(response) is not ChatCompletion:
-            raise ValueError("response must be an instance of ChatCompletion")
-        message = response.choices[choice_index].message
-        llm_tool_calls = message.tool_calls
-        function_calls = []
-        if llm_tool_calls:
-            for llm_tool_call in llm_tool_calls:
-                # Only process tool calls that correspond to the self.tool VectorSearchRetrieverToolInput
-                if not is_tool_call_for_index(llm_tool_call):
-                    continue
-
-                query_text, query_vector = get_query_text_vector(llm_tool_call)
-                search_resp = self._index.similarity_search(
-                    columns=self.columns,
-                    query_text=query_text,
-                    query_vector=query_vector,
-                    filters=self.filters,
-                    num_results=self.num_results,
-                    query_type=self.query_type,
-                )
-                docs_with_score: List[Tuple[Dict, float]] = parse_vector_search_response(
-                    search_resp=search_resp,
-                    index_details=self._index_details,
-                    text_column=self.text_column,
-                    document_class=dict,
-                )
-
-                function_call_result_message = {
-                    "role": "tool",
-                    "content": json.dumps({"content": docs_with_score}),
-                    "tool_call_id": llm_tool_call.id,
-                }
-                function_calls.append(function_call_result_message)
-        assistant_message = message.to_dict()
-        return [assistant_message, *function_calls]
+        search_resp = self._index.similarity_search(
+            columns=self.columns,
+            query_text=query_text,
+            query_vector=query_vector,
+            filters=self.filters,
+            num_results=self.num_results,
+            query_type=self.query_type,
+        )
+        docs_with_score: List[Tuple[Dict, float]] = parse_vector_search_response(
+            search_resp=search_resp,
+            index_details=self._index_details,
+            text_column=self.text_column,
+            document_class=dict,
+        )
+        return docs_with_score

--- a/integrations/openai/tests/unit_tests/test_vector_search_retriever_tool.py
+++ b/integrations/openai/tests/unit_tests/test_vector_search_retriever_tool.py
@@ -1,3 +1,4 @@
+import json
 import os
 from typing import Any, Dict, List, Optional
 from unittest.mock import MagicMock, Mock, patch
@@ -14,16 +15,13 @@ from databricks_ai_bridge.test_utils.vector_search import (  # noqa: F401
 from openai.types.chat import (
     ChatCompletion,
     ChatCompletionMessage,
-    ChatCompletionMessageParam,
     ChatCompletionMessageToolCall,
 )
 from openai.types.chat.chat_completion import Choice
 from openai.types.chat.chat_completion_message_tool_call_param import Function
-from pydantic import BaseModel, TypeAdapter
+from pydantic import BaseModel
 
 from databricks_openai import VectorSearchRetrieverTool
-
-import json
 
 
 @pytest.fixture(autouse=True)
@@ -138,11 +136,14 @@ def test_vector_search_retriever_tool_init(
     chat_completion_resp = get_chat_completion_response(tool_name, index_name)
     tool_call = chat_completion_resp.choices[0].message.tool_calls[0]
     args = json.loads(tool_call.function.arguments)
-    docs = vector_search_tool.execute(query=args["query"], openai_client=self_managed_embeddings_test.open_ai_client)
+    docs = vector_search_tool.execute(
+        query=args["query"], openai_client=self_managed_embeddings_test.open_ai_client
+    )
     assert docs is not None
     assert len(docs) == len(INPUT_TEXTS)
-    assert sorted([d[0]['page_content'] for d in docs]) == sorted(INPUT_TEXTS)
-    assert all(["id" in d[0]['metadata'] for d in docs])
+    assert sorted([d[0]["page_content"] for d in docs]) == sorted(INPUT_TEXTS)
+    assert all(["id" in d[0]["metadata"] for d in docs])
+
 
 @pytest.mark.parametrize("columns", [None, ["id", "text"]])
 @pytest.mark.parametrize("tool_name", [None, "test_tool"])
@@ -166,8 +167,10 @@ def test_open_ai_client_from_env(
     chat_completion_resp = get_chat_completion_response(tool_name, DIRECT_ACCESS_INDEX)
     tool_call = chat_completion_resp.choices[0].message.tool_calls[0]
     args = json.loads(tool_call.function.arguments)
-    docs = vector_search_tool.execute(query=args["query"], openai_client=self_managed_embeddings_test.open_ai_client)
+    docs = vector_search_tool.execute(
+        query=args["query"], openai_client=self_managed_embeddings_test.open_ai_client
+    )
     assert docs is not None
     assert len(docs) == len(INPUT_TEXTS)
-    assert sorted([d[0]['page_content'] for d in docs]) == sorted(INPUT_TEXTS)
-    assert all(["id" in d[0]['metadata'] for d in docs])
+    assert sorted([d[0]["page_content"] for d in docs]) == sorted(INPUT_TEXTS)
+    assert all(["id" in d[0]["metadata"] for d in docs])

--- a/integrations/openai/tests/unit_tests/test_vector_search_retriever_tool.py
+++ b/integrations/openai/tests/unit_tests/test_vector_search_retriever_tool.py
@@ -55,7 +55,9 @@ def get_chat_completion_response(tool_name: str, index_name: str):
                             function=Function(
                                 arguments='{"query":"Databricks Agent Framework"}',
                                 name=tool_name
-                                or index_name.replace(".", "__"),  # see get_tool_name() in VectorSearchRetrieverTool
+                                or index_name.replace(
+                                    ".", "__"
+                                ),  # see get_tool_name() in VectorSearchRetrieverTool
                             ),
                             type="function",
                         )
@@ -176,7 +178,7 @@ def test_open_ai_client_from_env(
 
 @pytest.mark.parametrize("index_name", ALL_INDEX_NAMES)
 def test_vector_search_retriever_long_idex_name_rewrite(
-        index_name: str,
+    index_name: str,
 ) -> None:
     if index_name == DELTA_SYNC_INDEX:
         self_managed_embeddings_test = SelfManagedEmbeddingsTest()
@@ -194,11 +196,14 @@ def test_vector_search_retriever_long_idex_name_rewrite(
     )
     assert vector_search_tool.tool["function"]["name"] == index_name.replace(".", "__")
 
+
 @pytest.mark.parametrize("index_name", ALL_INDEX_NAMES)
-@pytest.mark.parametrize("tool_name", [None, "really_really_really_long_tool_name_that_should_be_truncated_to_64_chars"])
+@pytest.mark.parametrize(
+    "tool_name", [None, "really_really_really_long_tool_name_that_should_be_truncated_to_64_chars"]
+)
 def test_vector_search_retriever_long_tool_name(
-        index_name: str,
-        tool_name: Optional[str],
+    index_name: str,
+    tool_name: Optional[str],
 ) -> None:
     if index_name == DELTA_SYNC_INDEX:
         self_managed_embeddings_test = SelfManagedEmbeddingsTest()
@@ -216,4 +221,3 @@ def test_vector_search_retriever_long_tool_name(
         embedding_model_name=self_managed_embeddings_test.embedding_model_name,
     )
     assert len(vector_search_tool.tool["function"]["name"]) <= 64
-

--- a/integrations/openai/tests/unit_tests/test_vector_search_retriever_tool.py
+++ b/integrations/openai/tests/unit_tests/test_vector_search_retriever_tool.py
@@ -155,6 +155,7 @@ def test_vector_search_retriever_tool_init(
     outputs = json.loads(trace.to_dict()["data"]["spans"][0]["attributes"]["mlflow.spanOutputs"])
     assert [d["page_content"] in INPUT_TEXTS for d in outputs]
 
+
 @pytest.mark.parametrize("columns", [None, ["id", "text"]])
 @pytest.mark.parametrize("tool_name", [None, "test_tool"])
 @pytest.mark.parametrize("tool_description", [None, "Test tool for vector search"])


### PR DESCRIPTION
This PR refactors the OpenAI VectorSearchRetrieverTool#execute_tools function to be VectorSearchRetrieverTool#execute. The goal here is to do less of the response parsing and instead only focus on executing the retriever call, which is more in line with [how the OpenAI SDK documents function calling](https://platform.openai.com/docs/guides/function-calling). 

The new usage pattern is more along the lines of:
```
dbvs_tool = VectorSearchRetrieverTool("index_name")
tools = [dbvs_tool.tool, ...]
response = openai.chat.completions.create(
  model="gpt-4o",
  messages=initial_messages,
  tools=tools,
)
tool_call = response.choices[0].message.tool_calls[0]
args = json.loads(tool_call.function.arguments)
retriever_resp = vector_search_tool.execute(query=args["query"])
```