### PR TITLE
[ML-49589] Changing the default of vectorSearchRetrieverTool docs to be 5 instead of 10

### DIFF
--- a/src/databricks_ai_bridge/vector_search_retriever_tool.py
+++ b/src/databricks_ai_bridge/vector_search_retriever_tool.py
@@ -44,7 +44,7 @@ class VectorSearchRetrieverToolMixin(BaseModel):
     index_name: str = Field(
         ..., description="The name of the index to use, format: 'catalog.schema.index'."
     )
-    num_results: int = Field(10, description="The number of results to return.")
+    num_results: int = Field(5, description="The number of results to return.")
     columns: Optional[List[str]] = Field(
         None, description="Columns to return when doing the search."
     )


### PR DESCRIPTION
Changing the default of vectorSearchRetrieverTool docs to be 5 instead of 10