### PR TITLE
Set min pydantic version

### DIFF
--- a/integrations/langchain/pyproject.toml
+++ b/integrations/langchain/pyproject.toml
@@ -15,6 +15,7 @@ dependencies = [
     "databricks-vectorsearch>=0.40",
     "databricks-ai-bridge>=0.1.0",
     "unitycatalog-langchain",
+    "pydantic>2.10.0",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
databricks-langchain `VectorSearchRetrieverTool` does not work with earlier pydantic versions. 
![image](https://github.com/user-attachments/assets/e989b10c-0994-4660-8663-aef39ffe6716)
