### PR TITLE
Add [databricks] option to unitycatalog in requirements and require python 3.10

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.10"
+          python-version: "3.9"
       - name: Install dependencies
         run: |
           pip install -r requirements/lint-requirements.txt

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.9'
+          python-version: "3.10"
       - name: Install dependencies
         run: |
           pip install -r requirements/lint-requirements.txt
@@ -33,7 +33,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.9', '3.10']
+        python-version: ["3.10"]
     timeout-minutes: 20
     steps:
       - name: Checkout code
@@ -53,7 +53,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.9', '3.10']
+        python-version: ["3.10"]
     timeout-minutes: 20
     steps:
       - name: Checkout code
@@ -74,7 +74,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.9', '3.10']
+        python-version: ["3.10"]
     timeout-minutes: 20
     steps:
       - name: Checkout code

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,7 +33,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.10"]
+        python-version: ["3.9", "3.10"]
     timeout-minutes: 20
     steps:
       - name: Checkout code

--- a/integrations/langchain/pyproject.toml
+++ b/integrations/langchain/pyproject.toml
@@ -7,7 +7,7 @@ authors = [
 ]
 readme = "README.md"
 license = { text="Apache-2.0" }
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 dependencies = [
     "langchain>=0.2.0",
     "langchain-community>=0.2.0",
@@ -15,7 +15,7 @@ dependencies = [
     "databricks-ai-bridge>=0.1.0",
     "mlflow>=2.20.1",
     "pydantic>2.10.0",
-    "unitycatalog-langchain",
+    "unitycatalog-langchain[databricks]>=0.1.1",
 ]
 
 [project.optional-dependencies]

--- a/integrations/openai/pyproject.toml
+++ b/integrations/openai/pyproject.toml
@@ -14,7 +14,7 @@ dependencies = [
     "openai>=1.46.1",
     "pydantic>2.10.0",
     "mlflow>=2.20.1",
-    "unitycatalog-openai>=0.1.0",
+    "unitycatalog-openai[databricks]>=0.1.0",
 ]
 
 [project.optional-dependencies]

--- a/integrations/openai/pyproject.toml
+++ b/integrations/openai/pyproject.toml
@@ -7,14 +7,14 @@ authors = [
 ]
 readme = "README.md"
 license = { text="Apache-2.0" }
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 dependencies = [
     "databricks-vectorsearch>=0.40",
     "databricks-ai-bridge>=0.1.0",
     "openai>=1.46.1",
     "pydantic>2.10.0",
     "mlflow>=2.20.1",
-    "unitycatalog-openai",
+    "unitycatalog-openai>=0.1.0",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ authors = [
     { name="Databricks", email="agent-feedback@databricks.com" },
 ]
 readme = "README.md"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 dependencies = [
   "typing_extensions",
   "pydantic",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ authors = [
     { name="Databricks", email="agent-feedback@databricks.com" },
 ]
 readme = "README.md"
-requires-python = ">=3.10"
+requires-python = ">=3.9"
 dependencies = [
   "typing_extensions",
   "pydantic",


### PR DESCRIPTION
`unitycatalog-*` packages are now using serverless warehouses to execute tool calls, which depends on the package `databricks-connect`, which is only compatible with python>=3.10. to add `unitycatalog-langchain[databricks]` as a core dependency to `databricks-langchain`, we need to bump the min python version for the integration packages.

`databricks-ai-bridge` itself is fine to keep at 3.9.