### PR TITLE
Genie agent metadata

### DIFF
--- a/integrations/langchain/src/databricks_langchain/genie.py
+++ b/integrations/langchain/src/databricks_langchain/genie.py
@@ -8,7 +8,6 @@ from langchain_core.runnables import RunnableLambda
 from typing import Dict, Any
 
 
-@mlflow.trace(span_type="AGENT")
 class GenieAgent(RunnableLambda):
     def __init__(self, genie_space_id,
                  genie_agent_name: str = "Genie",
@@ -19,7 +18,7 @@ class GenieAgent(RunnableLambda):
         self.description = description
         self.return_metadata = return_metadata
         self.genie = Genie(genie_space_id)
-        super().__init__(self._query_genie_as_agent)
+        super().__init__(self._query_genie_as_agent, name="Genie_Agent")
 
     @mlflow.trace()
     def _concat_messages_array(self, messages):

--- a/integrations/langchain/src/databricks_langchain/genie.py
+++ b/integrations/langchain/src/databricks_langchain/genie.py
@@ -18,7 +18,7 @@ class GenieAgent(RunnableLambda):
         self.description = description
         self.return_metadata = return_metadata
         self.genie = Genie(genie_space_id)
-        super().__init__(self._query_genie_as_agent, name="Genie_Agent")
+        super().__init__(self._query_genie_as_agent, name=genie_agent_name)
 
     @mlflow.trace()
     def _concat_messages_array(self, messages):

--- a/integrations/langchain/tests/unit_tests/test_genie.py
+++ b/integrations/langchain/tests/unit_tests/test_genie.py
@@ -1,28 +1,46 @@
 from unittest.mock import patch
 
 from databricks_ai_bridge.genie import GenieResponse
-from langchain_core.messages import AIMessage
+from langchain_core.messages import AIMessage, HumanMessage
 
-from databricks_langchain.genie import (
-    GenieAgent,
-    _concat_messages_array,
-    _query_genie_as_agent,
-)
+from databricks_langchain.genie import GenieAgent
+
+import pytest
 
 
-def test_concat_messages_array():
+@pytest.fixture
+def agent():
+    return GenieAgent("id-1", "Genie")
+
+
+@pytest.fixture
+def agent_with_metadata():
+    return GenieAgent("id-1", "Genie", return_metadata=True)
+
+
+def test_concat_messages_array_base_messages(agent):
+    messages = [HumanMessage("What is the weather?"), AIMessage("It is sunny.")]
+
+    result = agent._concat_messages_array(messages)
+
+    expected_result = "human: What is the weather?\nai: It is sunny."
+
+    assert result == expected_result
+
+
+def test_concat_messages_array(agent):
     # Test a simple case with multiple messages
     messages = [
         {"role": "user", "content": "What is the weather?"},
         {"role": "assistant", "content": "It is sunny."},
     ]
-    result = _concat_messages_array(messages)
+    result = agent._concat_messages_array(messages)
     expected = "user: What is the weather?\nassistant: It is sunny."
     assert result == expected
 
     # Test case with missing content
     messages = [{"role": "user"}, {"role": "assistant", "content": "I don't know."}]
-    result = _concat_messages_array(messages)
+    result = agent._concat_messages_array(messages)
     expected = "user: \nassistant: I don't know."
     assert result == expected
 
@@ -36,37 +54,76 @@ def test_concat_messages_array():
         Message("user", "Tell me a joke."),
         Message("assistant", "Why did the chicken cross the road?"),
     ]
-    result = _concat_messages_array(messages)
+    result = agent._concat_messages_array(messages)
     expected = "user: Tell me a joke.\nassistant: Why did the chicken cross the road?"
     assert result == expected
 
 
-@patch("databricks_langchain.genie.Genie")
-def test_query_genie_as_agent(MockGenie):
-    # Mock the Genie class and its response
-    mock_genie = MockGenie.return_value
-    mock_genie.ask_question.return_value = GenieResponse(result="It is sunny.")
+@patch("databricks_ai_bridge.genie.Genie.ask_question")
+def test_query_genie_as_agent(mock_ask_question, agent):
+
+    genie_response = GenieResponse(result="It is sunny.")
+
+    mock_ask_question.return_value = genie_response
 
     input_data = {"messages": [{"role": "user", "content": "What is the weather?"}]}
-    result = _query_genie_as_agent(input_data, "space-id", "Genie")
+
+    result = agent._query_genie_as_agent(input_data)
 
     expected_message = {"messages": [AIMessage(content="It is sunny.")]}
+
     assert result == expected_message
 
     # Test the case when genie_response is empty
-    mock_genie.ask_question.return_value = GenieResponse(result=None)
-    result = _query_genie_as_agent(input_data, "space-id", "Genie")
+    genie_empty_response = GenieResponse(result=None)
+
+    mock_ask_question.return_value = genie_empty_response
+
+    result = agent._query_genie_as_agent(input_data)
 
     expected_message = {"messages": [AIMessage(content="")]}
+
     assert result == expected_message
 
 
-@patch("langchain_core.runnables.RunnableLambda")
-def test_create_genie_agent(MockRunnableLambda):
-    mock_runnable = MockRunnableLambda.return_value
+@patch("databricks_ai_bridge.genie.Genie.ask_question")
+def test_query_genie_as_agent_with_metadata(mock_ask_question, agent_with_metadata):
 
-    agent = GenieAgent("space-id", "Genie")
-    assert agent == mock_runnable
+    genie_response = GenieResponse(result="It is sunny.", query="select a from data_table", description="description")
 
-    # Check that the partial function is created with the correct arguments
-    MockRunnableLambda.assert_called()
+    mock_ask_question.return_value = genie_response
+
+    input_data = {"messages": [{"role": "user", "content": "What is the weather?"}]}
+
+    result = agent_with_metadata._query_genie_as_agent(input_data)
+
+    expected_message = {"messages": [AIMessage(content="It is sunny.")], "metadata": genie_response}
+
+    assert result == expected_message
+
+    # Test the case when genie_response is empty
+    genie_empty_response = GenieResponse(result=None)
+
+    mock_ask_question.return_value = genie_empty_response
+
+    result = agent_with_metadata._query_genie_as_agent(input_data)
+
+    expected_message = {"messages": [AIMessage(content="")], "metadata": None}
+
+    assert result == expected_message
+
+
+@patch("databricks_ai_bridge.genie.Genie.ask_question")
+def test_query_genie_as_agent_invoke(mock_ask_question, agent):
+
+    genie_response = GenieResponse(result="It is sunny.", query="select a from data_table", description="description")
+
+    mock_ask_question.return_value = genie_response
+
+    input_data = {"messages": [{"role": "user", "content": "What is the weather?"}]}
+
+    result = agent.invoke(input_data)
+
+    expected_message = {"messages": [AIMessage(content="It is sunny.")]}
+
+    assert result == expected_message


### PR DESCRIPTION
In this pull request, I am making the following changes to the GenieAgent:

1) Creating a Python class that extends the RunnableLambda interface to create the GenieAgent instead of having a function to represent the GenieAgent. 
2) Adding a new boolean parameter to the GenieAgent class called "return_metadata." If the flag is True, then the output of the invoke function of the GenieAgent will have two keys: "messages" and "metadata." This metadata contains the direct response from GenieAPI, which is the object GenieResponse.
3) Some minor refactoring of the GenieAgent unit tests. 

If the following screenshots, you can see the output dict and the output trace in both scenarios (return_metadata True and False)

When return_medata is False (this is the default value)

![Screenshot 2025-02-19 at 6 48 13 PM](https://github.com/user-attachments/assets/664b5c85-be42-4ded-a552-1367bb56d199)

When return_metadata is True

![Screenshot 2025-02-19 at 6 49 45 PM](https://github.com/user-attachments/assets/4fb388b1-3ac0-44c2-83fd-3f864e4057ee)


