### PR TITLE
add logprobs to generation_info (metadata)

### DIFF
--- a/integrations/langchain/src/databricks_langchain/chat_models.py
+++ b/integrations/langchain/src/databricks_langchain/chat_models.py
@@ -303,7 +303,10 @@ class ChatDatabricks(BaseChatModel):
         generations = [
             ChatGeneration(
                 message=_convert_dict_to_message(choice["message"]),
-                generation_info=choice.get("usage", {}),
+                generation_info={
+                    **choice.get("usage", {}),
+                    "logprobs": choice.get("logprobs"),
+                },
             )
             for choice in response["choices"]
         ]


### PR DESCRIPTION
This PR adds logprobs to the `response_metadata` of the chat completion request. If there are no logprobs available the logprobs will be None.

Merging this PR will enable you to turn this logprobs ❌ into a ✅: https://python.langchain.com/docs/integrations/chat/databricks/

Implements #69 