### PR TITLE
Update Genie to optionally take in a workspace client

### DIFF
--- a/integrations/langchain/src/databricks_langchain/genie.py
+++ b/integrations/langchain/src/databricks_langchain/genie.py
@@ -1,7 +1,9 @@
-import mlflow
-from databricks_ai_bridge.genie import Genie
-from databricks.sdk import WorkspaceClient
 from typing import Optional
+
+import mlflow
+from databricks.sdk import WorkspaceClient
+from databricks_ai_bridge.genie import Genie
+
 
 @mlflow.trace()
 def _concat_messages_array(messages):
@@ -37,7 +39,12 @@ def _query_genie_as_agent(input, genie_space_id, genie_agent_name, client):
 
 
 @mlflow.trace(span_type="AGENT")
-def GenieAgent(genie_space_id, genie_agent_name: str = "Genie", description: str = "", client: Optional["WorkspaceClient"] = None):
+def GenieAgent(
+    genie_space_id,
+    genie_agent_name: str = "Genie",
+    description: str = "",
+    client: Optional["WorkspaceClient"] = None,
+):
     """Create a genie agent that can be used to query the API"""
     from functools import partial
 
@@ -48,7 +55,7 @@ def GenieAgent(genie_space_id, genie_agent_name: str = "Genie", description: str
         _query_genie_as_agent,
         genie_space_id=genie_space_id,
         genie_agent_name=genie_agent_name,
-        client=client
+        client=client,
     )
 
     # Use the partial function in the RunnableLambda

--- a/integrations/langchain/src/databricks_langchain/genie.py
+++ b/integrations/langchain/src/databricks_langchain/genie.py
@@ -1,6 +1,7 @@
 import mlflow
 from databricks_ai_bridge.genie import Genie
-
+from databricks.sdk import WorkspaceClient
+from typing import Optional
 
 @mlflow.trace()
 def _concat_messages_array(messages):
@@ -16,10 +17,10 @@ def _concat_messages_array(messages):
 
 
 @mlflow.trace()
-def _query_genie_as_agent(input, genie_space_id, genie_agent_name):
+def _query_genie_as_agent(input, genie_space_id, genie_agent_name, client):
     from langchain_core.messages import AIMessage
 
-    genie = Genie(genie_space_id)
+    genie = Genie(genie_space_id, client=client)
 
     message = f"I will provide you a chat history, where your name is {genie_agent_name}. Please help with the described information in the chat history.\n"
 
@@ -36,7 +37,7 @@ def _query_genie_as_agent(input, genie_space_id, genie_agent_name):
 
 
 @mlflow.trace(span_type="AGENT")
-def GenieAgent(genie_space_id, genie_agent_name: str = "Genie", description: str = ""):
+def GenieAgent(genie_space_id, genie_agent_name: str = "Genie", description: str = "", client: Optional["WorkspaceClient"] = None):
     """Create a genie agent that can be used to query the API"""
     from functools import partial
 
@@ -47,6 +48,7 @@ def GenieAgent(genie_space_id, genie_agent_name: str = "Genie", description: str
         _query_genie_as_agent,
         genie_space_id=genie_space_id,
         genie_agent_name=genie_agent_name,
+        client=client
     )
 
     # Use the partial function in the RunnableLambda

--- a/integrations/langchain/tests/unit_tests/test_genie.py
+++ b/integrations/langchain/tests/unit_tests/test_genie.py
@@ -70,3 +70,17 @@ def test_create_genie_agent(MockRunnableLambda):
 
     # Check that the partial function is created with the correct arguments
     MockRunnableLambda.assert_called()
+
+
+@patch("databricks.sdk.WorkspaceClient")
+def test_query_genie_with_client(mock_workspace_client):
+    mock_workspace_client.genie._api.do.side_effect = [
+        {"conversation_id": "123", "message_id": "abc"},
+        {"status": "COMPLETED", "attachments": [{"text": {"content": "It is sunny."}}]},
+    ]
+
+    input_data = {"messages": [{"role": "user", "content": "What is the weather?"}]}
+    result = _query_genie_as_agent(input_data, "space-id", "Genie", mock_workspace_client)
+
+    expected_message = {"messages": [AIMessage(content="It is sunny.")]}
+    assert result == expected_message

--- a/integrations/langchain/tests/unit_tests/test_genie.py
+++ b/integrations/langchain/tests/unit_tests/test_genie.py
@@ -48,14 +48,14 @@ def test_query_genie_as_agent(MockGenie):
     mock_genie.ask_question.return_value = GenieResponse(result="It is sunny.")
 
     input_data = {"messages": [{"role": "user", "content": "What is the weather?"}]}
-    result = _query_genie_as_agent(input_data, "space-id", "Genie")
+    result = _query_genie_as_agent(input_data, "space-id", "Genie", None)
 
     expected_message = {"messages": [AIMessage(content="It is sunny.")]}
     assert result == expected_message
 
     # Test the case when genie_response is empty
     mock_genie.ask_question.return_value = GenieResponse(result=None)
-    result = _query_genie_as_agent(input_data, "space-id", "Genie")
+    result = _query_genie_as_agent(input_data, "space-id", "Genie", None)
 
     expected_message = {"messages": [AIMessage(content="")]}
     assert result == expected_message

--- a/src/databricks_ai_bridge/genie.py
+++ b/src/databricks_ai_bridge/genie.py
@@ -71,9 +71,9 @@ def _parse_query_result(resp) -> Union[str, pd.DataFrame]:
 
 
 class Genie:
-    def __init__(self, space_id):
+    def __init__(self, space_id, client: Optional["WorkspaceClient"] = None):
         self.space_id = space_id
-        workspace_client = WorkspaceClient()
+        workspace_client = client or WorkspaceClient()
         self.genie = workspace_client.genie
         self.headers = {
             "Accept": "application/json",


### PR DESCRIPTION
Updating Genie Integration to optionally take in a Workspace Client. This will be used in invokers rights in order for users to pass in an optional Workspace Client.

Test Notebook: https://e2-dogfood.staging.cloud.databricks.com/editor/notebooks/490640693269456?o=6051921418418893