### PR TITLE
Support Credential Strategy in Vector Search Client

### DIFF
--- a/integrations/langchain/pyproject.toml
+++ b/integrations/langchain/pyproject.toml
@@ -10,7 +10,7 @@ license = { text="Apache-2.0" }
 requires-python = ">=3.10"
 dependencies = [
     "langchain>=0.3.0",
-    "databricks-vectorsearch>=0.40",
+    "databricks-vectorsearch>=0.50",
     "databricks-ai-bridge>=0.1.0",
     "mlflow>=2.20.1",
     "pydantic>2.10.0",

--- a/integrations/langchain/src/databricks_langchain/vector_search_retriever_tool.py
+++ b/integrations/langchain/src/databricks_langchain/vector_search_retriever_tool.py
@@ -45,7 +45,7 @@ class VectorSearchRetrieverTool(BaseTool, VectorSearchRetrieverToolMixin):
             "embedding": self.embedding,
             "text_column": self.text_column,
             "columns": self.columns,
-            "credential_strategy": self.credential_strategy
+            "client_args": {"credential_strategy" : self.credential_strategy}
         }
         dbvs = DatabricksVectorSearch(**kwargs)
         self._vector_store = dbvs

--- a/integrations/langchain/src/databricks_langchain/vector_search_retriever_tool.py
+++ b/integrations/langchain/src/databricks_langchain/vector_search_retriever_tool.py
@@ -45,6 +45,7 @@ class VectorSearchRetrieverTool(BaseTool, VectorSearchRetrieverToolMixin):
             "embedding": self.embedding,
             "text_column": self.text_column,
             "columns": self.columns,
+            "credential_strategy": self.credential_strategy
         }
         dbvs = DatabricksVectorSearch(**kwargs)
         self._vector_store = dbvs

--- a/integrations/langchain/src/databricks_langchain/vector_search_retriever_tool.py
+++ b/integrations/langchain/src/databricks_langchain/vector_search_retriever_tool.py
@@ -45,7 +45,7 @@ class VectorSearchRetrieverTool(BaseTool, VectorSearchRetrieverToolMixin):
             "embedding": self.embedding,
             "text_column": self.text_column,
             "columns": self.columns,
-            "client_args": {"credential_strategy" : self.credential_strategy}
+            "workspace_client": self.workspace_client,
         }
         dbvs = DatabricksVectorSearch(**kwargs)
         self._vector_store = dbvs

--- a/integrations/langchain/tests/unit_tests/test_vector_search_retriever_tool.py
+++ b/integrations/langchain/tests/unit_tests/test_vector_search_retriever_tool.py
@@ -3,6 +3,7 @@ from typing import Any, Dict, List, Optional
 
 import mlflow
 import pytest
+from databricks.vector_search.utils import CredentialStrategy
 from databricks_ai_bridge.test_utils.vector_search import (  # noqa: F401
     ALL_INDEX_NAMES,
     DELTA_SYNC_INDEX,
@@ -39,6 +40,7 @@ def init_vector_search_tool(
     tool_description: Optional[str] = None,
     embedding: Optional[Embeddings] = None,
     text_column: Optional[str] = None,
+    credential_strategy: Optional[CredentialStrategy] = None
 ) -> VectorSearchRetrieverTool:
     kwargs: Dict[str, Any] = {
         "index_name": index_name,
@@ -47,6 +49,7 @@ def init_vector_search_tool(
         "tool_description": tool_description,
         "embedding": embedding,
         "text_column": text_column,
+        "credential_strategy": credential_strategy
     }
     if index_name != DELTA_SYNC_INDEX:
         kwargs.update(
@@ -80,6 +83,7 @@ def test_chat_model_bind_tools(llm: ChatDatabricks, index_name: str) -> None:
 @pytest.mark.parametrize("tool_description", [None, "Test tool for vector search"])
 @pytest.mark.parametrize("embedding", [None, EMBEDDING_MODEL])
 @pytest.mark.parametrize("text_column", [None, "text"])
+@pytest.mark.parametrize("credential_strategy", [None, CredentialStrategy.MODEL_SERVING_USER_CREDENTIALS])
 def test_vector_search_retriever_tool_combinations(
     index_name: str,
     columns: Optional[List[str]],
@@ -87,6 +91,7 @@ def test_vector_search_retriever_tool_combinations(
     tool_description: Optional[str],
     embedding: Optional[Any],
     text_column: Optional[str],
+    credential_strategy: Optional[CredentialStrategy]
 ) -> None:
     if index_name == DELTA_SYNC_INDEX:
         embedding = None
@@ -99,6 +104,7 @@ def test_vector_search_retriever_tool_combinations(
         tool_description=tool_description,
         embedding=embedding,
         text_column=text_column,
+        credential_strategy=credential_strategy
     )
     assert isinstance(vector_search_tool, BaseTool)
     result = vector_search_tool.invoke("Databricks Agent Framework")

--- a/integrations/langchain/tests/unit_tests/test_vector_search_retriever_tool.py
+++ b/integrations/langchain/tests/unit_tests/test_vector_search_retriever_tool.py
@@ -46,7 +46,6 @@ def init_vector_search_tool(
     tool_description: Optional[str] = None,
     embedding: Optional[Embeddings] = None,
     text_column: Optional[str] = None,
-    credential_strategy: Optional[CredentialStrategy] = None,
 ) -> VectorSearchRetrieverTool:
     kwargs: Dict[str, Any] = {
         "index_name": index_name,
@@ -55,7 +54,6 @@ def init_vector_search_tool(
         "tool_description": tool_description,
         "embedding": embedding,
         "text_column": text_column,
-        "credential_strategy": credential_strategy,
     }
     if index_name != DELTA_SYNC_INDEX:
         kwargs.update(
@@ -89,9 +87,6 @@ def test_chat_model_bind_tools(llm: ChatDatabricks, index_name: str) -> None:
 @pytest.mark.parametrize("tool_description", [None, "Test tool for vector search"])
 @pytest.mark.parametrize("embedding", [None, EMBEDDING_MODEL])
 @pytest.mark.parametrize("text_column", [None, "text"])
-@pytest.mark.parametrize(
-    "credential_strategy", [None, CredentialStrategy.MODEL_SERVING_USER_CREDENTIALS]
-)
 def test_vector_search_retriever_tool_combinations(
     index_name: str,
     columns: Optional[List[str]],
@@ -99,7 +94,6 @@ def test_vector_search_retriever_tool_combinations(
     tool_description: Optional[str],
     embedding: Optional[Any],
     text_column: Optional[str],
-    credential_strategy: Optional[CredentialStrategy],
 ) -> None:
     if index_name == DELTA_SYNC_INDEX:
         embedding = None
@@ -112,7 +106,6 @@ def test_vector_search_retriever_tool_combinations(
         tool_description=tool_description,
         embedding=embedding,
         text_column=text_column,
-        credential_strategy=credential_strategy,
     )
     assert isinstance(vector_search_tool, BaseTool)
     result = vector_search_tool.invoke("Databricks Agent Framework")

--- a/integrations/llamaindex/src/databricks_llamaindex/vector_search_retriever_tool.py
+++ b/integrations/llamaindex/src/databricks_llamaindex/vector_search_retriever_tool.py
@@ -42,8 +42,17 @@ class VectorSearchRetrieverTool(FunctionTool, VectorSearchRetrieverToolMixin):
 
         # Initialize private attributes
         from databricks.vector_search.client import VectorSearchClient
+        from databricks.vector_search.utils import CredentialStrategy
 
-        self._index = VectorSearchClient().get_index(index_name=self.index_name)
+        credential_strategy = None
+        if (
+            self.workspace_client is not None
+            and self.workspace_client.config.auth_type == "model_serving_user_credentials"
+        ):
+            credential_strategy = CredentialStrategy.MODEL_SERVING_USER_CREDENTIALS
+        self._index = VectorSearchClient(
+            disable_notice=True, credential_strategy=credential_strategy
+        ).get_index(index_name=self.index_name)
         self._index_details = IndexDetails(self._index)
 
         # Validate columns

--- a/integrations/llamaindex/tests/unit_tests/test_vector_search_retriever_tool.py
+++ b/integrations/llamaindex/tests/unit_tests/test_vector_search_retriever_tool.py
@@ -1,6 +1,12 @@
+import os
+import threading
 from typing import Any, Dict, List, Optional
+from unittest.mock import patch
 
 import pytest
+from databricks.sdk import WorkspaceClient
+from databricks.sdk.credentials_provider import ModelServingUserCredentials
+from databricks.vector_search.utils import CredentialStrategy
 from databricks_ai_bridge.test_utils.vector_search import (  # noqa: F401
     ALL_INDEX_NAMES,
     DEFAULT_VECTOR_DIMENSION,
@@ -118,3 +124,55 @@ def test_vector_search_retriever_tool_bind_agent(index_name: str) -> None:
     vector_search_tool = init_vector_search_tool(index_name)
     llm = OpenAI()
     assert ReActAgent.from_tools([vector_search_tool], llm=llm, verbose=True) is not None
+
+
+def test_vector_search_client_model_serving_environment():
+    with patch("os.path.isfile", return_value=True):
+        # Simulate Model Serving Environment
+        os.environ["IS_IN_DB_MODEL_SERVING_ENV"] = "true"
+
+        # Fake credential token
+        current_thread = threading.current_thread()
+        thread_data = current_thread.__dict__
+        thread_data["invokers_token"] = "abc"
+
+        w = WorkspaceClient(
+            host="testDogfod.com", credentials_strategy=ModelServingUserCredentials()
+        )
+
+        with patch("databricks.vector_search.client.VectorSearchClient") as mockVSClient:
+            with patch("databricks.sdk.service.serving.ServingEndpointsAPI.get", return_value=None):
+                vsTool = VectorSearchRetrieverTool(
+                    index_name="catalog.schema.my_index_name",
+                    text_column="abc",
+                    embedding_model_name="text-embedding-3-small",
+                    tool_description="desc",
+                    workspace_client=w,
+                )
+                mockVSClient.assert_called_once_with(
+                    disable_notice=True,
+                    credential_strategy=CredentialStrategy.MODEL_SERVING_USER_CREDENTIALS,
+                )
+
+
+def test_vector_search_client_non_model_serving_environment():
+    with patch("databricks.vector_search.client.VectorSearchClient") as mockVSClient:
+        vsTool = VectorSearchRetrieverTool(
+            index_name="catalog.schema.my_index_name",
+            text_column="abc",
+            embedding_model_name="text-embedding-3-small",
+            tool_description="desc",
+        )
+        mockVSClient.assert_called_once_with(disable_notice=True, credential_strategy=None)
+
+    w = WorkspaceClient(host="testDogfod.com", token="fakeToken")
+    with patch("databricks.vector_search.client.VectorSearchClient") as mockVSClient:
+        with patch("databricks.sdk.service.serving.ServingEndpointsAPI.get", return_value=None):
+            vsTool = VectorSearchRetrieverTool(
+                index_name="catalog.schema.my_index_name",
+                text_column="abc",
+                embedding_model_name="text-embedding-3-small",
+                tool_description="desc",
+                workspace_client=w,
+            )
+            mockVSClient.assert_called_once_with(disable_notice=True, credential_strategy=None)

--- a/integrations/openai/pyproject.toml
+++ b/integrations/openai/pyproject.toml
@@ -9,7 +9,7 @@ readme = "README.md"
 license = { text="Apache-2.0" }
 requires-python = ">=3.10"
 dependencies = [
-    "databricks-vectorsearch>=0.40",
+    "databricks-vectorsearch>=0.50",
     "databricks-ai-bridge>=0.1.0",
     "openai>=1.46.1",
     "pydantic>2.10.0",

--- a/integrations/openai/src/databricks_openai/vector_search_retriever_tool.py
+++ b/integrations/openai/src/databricks_openai/vector_search_retriever_tool.py
@@ -91,13 +91,22 @@ class VectorSearchRetrieverTool(VectorSearchRetrieverToolMixin):
         from databricks.vector_search.client import (
             VectorSearchClient,  # import here so we can mock in tests
         )
+        from databricks.vector_search.utils import CredentialStrategy
 
         splits = self.index_name.split(".")
         if len(splits) != 3:
             raise ValueError(
                 f"Index name {self.index_name} is not in the expected format 'catalog.schema.index'."
             )
-        self._index = VectorSearchClient(disable_notice=True, credential_strategy=self.credential_strategy).get_index(index_name=self.index_name)
+        credential_strategy = None
+        if (
+            self.workspace_client is not None
+            and self.workspace_client.config.auth_type == "model_serving_user_credentials"
+        ):
+            credential_strategy = CredentialStrategy.MODEL_SERVING_USER_CREDENTIALS
+        self._index = VectorSearchClient(
+            disable_notice=True, credential_strategy=credential_strategy
+        ).get_index(index_name=self.index_name)
         self._index_details = IndexDetails(self._index)
         self.text_column = validate_and_get_text_column(self.text_column, self._index_details)
         self.columns = validate_and_get_return_columns(
@@ -130,15 +139,12 @@ class VectorSearchRetrieverTool(VectorSearchRetrieverToolMixin):
             description=self.tool_description
             or self._get_default_tool_description(self._index_details),
         )
-
         try:
             from databricks.sdk import WorkspaceClient
-            from databricks.sdk.credentials_provider import ModelServingUserCredentials
             from databricks.sdk.errors.platform import ResourceDoesNotExist
-            from databricks.vector_search.utils import CredentialStrategy
 
-            if self.credential_strategy is not None and self.credential_strategy == CredentialStrategy.MODEL_SERVING_USER_CREDENTIALS:
-                WorkspaceClient(credentials_strategy = ModelServingUserCredentials()).serving_endpoints.get(self.embedding_model_name)
+            if self.workspace_client is not None:
+                self.workspace_client.serving_endpoints.get(self.embedding_model_name)
             else:
                 WorkspaceClient().serving_endpoints.get(self.embedding_model_name)
             self.resources = self._get_resources(self.index_name, self.embedding_model_name)

--- a/integrations/openai/src/databricks_openai/vector_search_retriever_tool.py
+++ b/integrations/openai/src/databricks_openai/vector_search_retriever_tool.py
@@ -97,7 +97,7 @@ class VectorSearchRetrieverTool(VectorSearchRetrieverToolMixin):
             raise ValueError(
                 f"Index name {self.index_name} is not in the expected format 'catalog.schema.index'."
             )
-        self._index = VectorSearchClient(disable_notice=True).get_index(index_name=self.index_name)
+        self._index = VectorSearchClient(disable_notice=True, credential_strategy=self.credential_strategy).get_index(index_name=self.index_name)
         self._index_details = IndexDetails(self._index)
         self.text_column = validate_and_get_text_column(self.text_column, self._index_details)
         self.columns = validate_and_get_return_columns(

--- a/integrations/openai/src/databricks_openai/vector_search_retriever_tool.py
+++ b/integrations/openai/src/databricks_openai/vector_search_retriever_tool.py
@@ -133,9 +133,14 @@ class VectorSearchRetrieverTool(VectorSearchRetrieverToolMixin):
 
         try:
             from databricks.sdk import WorkspaceClient
+            from databricks.sdk.credentials_provider import ModelServingUserCredentials
             from databricks.sdk.errors.platform import ResourceDoesNotExist
+            from databricks.vector_search.utils import CredentialStrategy
 
-            WorkspaceClient().serving_endpoints.get(self.embedding_model_name)
+            if self.credential_strategy is not None and self.credential_strategy == CredentialStrategy.MODEL_SERVING_USER_CREDENTIALS:
+                WorkspaceClient(credentials_strategy = ModelServingUserCredentials()).serving_endpoints.get(self.embedding_model_name)
+            else:
+                WorkspaceClient().serving_endpoints.get(self.embedding_model_name)
             self.resources = self._get_resources(self.index_name, self.embedding_model_name)
         except ResourceDoesNotExist:
             self.resources = self._get_resources(self.index_name, None)

--- a/integrations/openai/tests/unit_tests/test_vector_search_retriever_tool.py
+++ b/integrations/openai/tests/unit_tests/test_vector_search_retriever_tool.py
@@ -5,6 +5,7 @@ from unittest.mock import MagicMock, Mock, patch
 
 import mlflow
 import pytest
+from databricks.vector_search.utils import CredentialStrategy
 from databricks_ai_bridge.test_utils.vector_search import (  # noqa: F401
     ALL_INDEX_NAMES,
     DELTA_SYNC_INDEX,
@@ -84,6 +85,7 @@ def init_vector_search_tool(
     tool_description: Optional[str] = None,
     text_column: Optional[str] = None,
     embedding_model_name: Optional[str] = None,
+    credential_strategy: Optional[CredentialStrategy] = None
 ) -> VectorSearchRetrieverTool:
     kwargs: Dict[str, Any] = {
         "index_name": index_name,
@@ -92,6 +94,7 @@ def init_vector_search_tool(
         "tool_description": tool_description,
         "text_column": text_column,
         "embedding_model_name": embedding_model_name,
+        "credential_strategy": credential_strategy
     }
     if index_name != DELTA_SYNC_INDEX:
         kwargs.update(
@@ -114,11 +117,13 @@ class SelfManagedEmbeddingsTest:
 @pytest.mark.parametrize("columns", [None, ["id", "text"]])
 @pytest.mark.parametrize("tool_name", [None, "test_tool"])
 @pytest.mark.parametrize("tool_description", [None, "Test tool for vector search"])
+@pytest.mark.parametrize("credential_strategy", [None, CredentialStrategy.MODEL_SERVING_USER_CREDENTIALS])
 def test_vector_search_retriever_tool_init(
     index_name: str,
     columns: Optional[List[str]],
     tool_name: Optional[str],
     tool_description: Optional[str],
+    credential_strategy: Optional[CredentialStrategy]
 ) -> None:
     if index_name == DELTA_SYNC_INDEX:
         self_managed_embeddings_test = SelfManagedEmbeddingsTest()

--- a/integrations/openai/tests/unit_tests/test_vector_search_retriever_tool.py
+++ b/integrations/openai/tests/unit_tests/test_vector_search_retriever_tool.py
@@ -1,10 +1,13 @@
 import json
 import os
+import threading
 from typing import Any, Dict, List, Optional
 from unittest.mock import MagicMock, Mock, patch
 
 import mlflow
 import pytest
+from databricks.sdk import WorkspaceClient
+from databricks.sdk.credentials_provider import ModelServingUserCredentials
 from databricks.vector_search.utils import CredentialStrategy
 from databricks_ai_bridge.test_utils.vector_search import (  # noqa: F401
     ALL_INDEX_NAMES,
@@ -85,7 +88,6 @@ def init_vector_search_tool(
     tool_description: Optional[str] = None,
     text_column: Optional[str] = None,
     embedding_model_name: Optional[str] = None,
-    credential_strategy: Optional[CredentialStrategy] = None
 ) -> VectorSearchRetrieverTool:
     kwargs: Dict[str, Any] = {
         "index_name": index_name,
@@ -94,7 +96,6 @@ def init_vector_search_tool(
         "tool_description": tool_description,
         "text_column": text_column,
         "embedding_model_name": embedding_model_name,
-        "credential_strategy": credential_strategy
     }
     if index_name != DELTA_SYNC_INDEX:
         kwargs.update(
@@ -117,13 +118,11 @@ class SelfManagedEmbeddingsTest:
 @pytest.mark.parametrize("columns", [None, ["id", "text"]])
 @pytest.mark.parametrize("tool_name", [None, "test_tool"])
 @pytest.mark.parametrize("tool_description", [None, "Test tool for vector search"])
-@pytest.mark.parametrize("credential_strategy", [None, CredentialStrategy.MODEL_SERVING_USER_CREDENTIALS])
 def test_vector_search_retriever_tool_init(
     index_name: str,
     columns: Optional[List[str]],
     tool_name: Optional[str],
     tool_description: Optional[str],
-    credential_strategy: Optional[CredentialStrategy]
 ) -> None:
     if index_name == DELTA_SYNC_INDEX:
         self_managed_embeddings_test = SelfManagedEmbeddingsTest()
@@ -249,3 +248,55 @@ def test_vector_search_retriever_long_tool_name(
         embedding_model_name=self_managed_embeddings_test.embedding_model_name,
     )
     assert len(vector_search_tool.tool["function"]["name"]) <= 64
+
+
+def test_vector_search_client_model_serving_environment():
+    with patch("os.path.isfile", return_value=True):
+        # Simulate Model Serving Environment
+        os.environ["IS_IN_DB_MODEL_SERVING_ENV"] = "true"
+
+        # Fake credential token
+        current_thread = threading.current_thread()
+        thread_data = current_thread.__dict__
+        thread_data["invokers_token"] = "abc"
+
+        w = WorkspaceClient(
+            host="testDogfod.com", credentials_strategy=ModelServingUserCredentials()
+        )
+
+        with patch("databricks.vector_search.client.VectorSearchClient") as mockVSClient:
+            with patch("databricks.sdk.service.serving.ServingEndpointsAPI.get", return_value=None):
+                vsTool = VectorSearchRetrieverTool(
+                    index_name="catalog.schema.my_index_name",
+                    text_column="abc",
+                    embedding_model_name="text-embedding-3-small",
+                    tool_description="desc",
+                    workspace_client=w,
+                )
+                mockVSClient.assert_called_once_with(
+                    disable_notice=True,
+                    credential_strategy=CredentialStrategy.MODEL_SERVING_USER_CREDENTIALS,
+                )
+
+
+def test_vector_search_client_non_model_serving_environment():
+    with patch("databricks.vector_search.client.VectorSearchClient") as mockVSClient:
+        vsTool = VectorSearchRetrieverTool(
+            index_name="catalog.schema.my_index_name",
+            text_column="abc",
+            embedding_model_name="text-embedding-3-small",
+            tool_description="desc",
+        )
+        mockVSClient.assert_called_once_with(disable_notice=True, credential_strategy=None)
+
+    w = WorkspaceClient(host="testDogfod.com", token="fakeToken")
+    with patch("databricks.vector_search.client.VectorSearchClient") as mockVSClient:
+        with patch("databricks.sdk.service.serving.ServingEndpointsAPI.get", return_value=None):
+            vsTool = VectorSearchRetrieverTool(
+                index_name="catalog.schema.my_index_name",
+                text_column="abc",
+                embedding_model_name="text-embedding-3-small",
+                tool_description="desc",
+                workspace_client=w,
+            )
+            mockVSClient.assert_called_once_with(disable_notice=True, credential_strategy=None)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ dependencies = [
   "typing_extensions",
   "pydantic",
   "databricks-sdk>=0.34.0",
+  "databricks-vectorsearch>=0.50",
   "pandas",
   "tiktoken>=0.8.0",
   "tabulate",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,8 +10,7 @@ requires-python = ">=3.9"
 dependencies = [
   "typing_extensions",
   "pydantic",
-  "databricks-sdk>=0.34.0",
-  "databricks-vectorsearch>=0.50",
+  "databricks-sdk>=0.44.1",
   "pandas",
   "tiktoken>=0.8.0",
   "tabulate",

--- a/src/databricks_ai_bridge/test_utils/vector_search.py
+++ b/src/databricks_ai_bridge/test_utils/vector_search.py
@@ -113,17 +113,18 @@ INDEX_DETAILS = {
 }
 
 
+def _get_index(
+    endpoint_name: Optional[str] = None,
+    index_name: str = None,  # type: ignore
+) -> MagicMock:
+    index = MagicMock(spec=VectorSearchIndex)
+    index.describe.return_value = INDEX_DETAILS[index_name]
+    index.similarity_search.return_value = EXAMPLE_SEARCH_RESPONSE
+    return index
+
+
 @pytest.fixture(autouse=True)
 def mock_vs_client() -> Generator:
-    def _get_index(
-        endpoint_name: Optional[str] = None,
-        index_name: str = None,  # type: ignore
-    ) -> MagicMock:
-        index = MagicMock(spec=VectorSearchIndex)
-        index.describe.return_value = INDEX_DETAILS[index_name]
-        index.similarity_search.return_value = EXAMPLE_SEARCH_RESPONSE
-        return index
-
     mock_client = MagicMock()
     mock_client.get_index.side_effect = _get_index
     with mock.patch(

--- a/src/databricks_ai_bridge/vector_search_retriever_tool.py
+++ b/src/databricks_ai_bridge/vector_search_retriever_tool.py
@@ -2,6 +2,7 @@ from functools import wraps
 from typing import Any, Dict, List, Optional
 
 import mlflow
+from databricks.vector_search.utils import CredentialStrategy
 from mlflow.entities import SpanType
 from mlflow.models.resources import (
     DatabricksServingEndpoint,
@@ -31,8 +32,6 @@ def vector_search_retriever_tool_trace(func):
 
     return wrapper
 
-class CredentialStrategy(Enum):
-    MODEL_SERVING_USER_CREDENTIALS = 1
 
 class VectorSearchRetrieverToolInput(BaseModel):
     query: str = Field(
@@ -64,7 +63,7 @@ class VectorSearchRetrieverToolMixin(BaseModel):
     resources: Optional[List[dict]] = Field(
         None, description="Resources required to log a model that uses this tool."
     )
-    credential_strategy: Optional[CredentialStrategy] = Field(default=None, description="When set to MODEL_SERVING_USER_CREDENTIALS, the tool will be authorized with invokers rights")
+    credential_strategy: Optional[CredentialStrategy] = Field(default=None, description="When set to MODEL_SERVING_USER_CREDENTIALS, the tool will be authorized with on behalf of user rights")
 
     def _get_default_tool_description(self, index_details: IndexDetails) -> str:
         if index_details.is_delta_sync_index():

--- a/src/databricks_ai_bridge/vector_search_retriever_tool.py
+++ b/src/databricks_ai_bridge/vector_search_retriever_tool.py
@@ -2,14 +2,14 @@ from functools import wraps
 from typing import Any, Dict, List, Optional
 
 import mlflow
-from databricks.vector_search.utils import CredentialStrategy
+from databricks.sdk import WorkspaceClient
 from mlflow.entities import SpanType
 from mlflow.models.resources import (
     DatabricksServingEndpoint,
     DatabricksVectorSearchIndex,
     Resource,
 )
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 
 from databricks_ai_bridge.utils.vector_search import IndexDetails
 
@@ -47,6 +47,7 @@ class VectorSearchRetrieverToolMixin(BaseModel):
     implementations should follow.
     """
 
+    model_config = ConfigDict(arbitrary_types_allowed=True)
     index_name: str = Field(
         ..., description="The name of the index to use, format: 'catalog.schema.index'."
     )
@@ -63,7 +64,10 @@ class VectorSearchRetrieverToolMixin(BaseModel):
     resources: Optional[List[dict]] = Field(
         None, description="Resources required to log a model that uses this tool."
     )
-    credential_strategy: Optional[CredentialStrategy] = Field(default=None, description="When set to MODEL_SERVING_USER_CREDENTIALS, the tool will be authorized with on behalf of user rights")
+    workspace_client: Optional[WorkspaceClient] = Field(
+        default=None,
+        description="When specified, will use workspace client credential strategy to instantiate VectorSearchClient",
+    )
 
     def _get_default_tool_description(self, index_details: IndexDetails) -> str:
         if index_details.is_delta_sync_index():

--- a/src/databricks_ai_bridge/vector_search_retriever_tool.py
+++ b/src/databricks_ai_bridge/vector_search_retriever_tool.py
@@ -31,6 +31,8 @@ def vector_search_retriever_tool_trace(func):
 
     return wrapper
 
+class CredentialStrategy(Enum):
+    MODEL_SERVING_USER_CREDENTIALS = 1
 
 class VectorSearchRetrieverToolInput(BaseModel):
     query: str = Field(
@@ -62,6 +64,7 @@ class VectorSearchRetrieverToolMixin(BaseModel):
     resources: Optional[List[dict]] = Field(
         None, description="Resources required to log a model that uses this tool."
     )
+    credential_strategy: Optional[CredentialStrategy] = Field(default=None, description="When set to MODEL_SERVING_USER_CREDENTIALS, the tool will be authorized with invokers rights")
 
     def _get_default_tool_description(self, index_details: IndexDetails) -> str:
         if index_details.is_delta_sync_index():


### PR DESCRIPTION
Add an extra parameter to pass in credential strategy to vector search client. This will ensure that the tool is called with invokers rights. 

Added unit tests, pending testing on Dogfood