### PR TITLE
[ML-49514] Fix metaclass issue

### DIFF
--- a/integrations/langchain/pyproject.toml
+++ b/integrations/langchain/pyproject.toml
@@ -9,8 +9,8 @@ readme = "README.md"
 license = { text="Apache-2.0" }
 requires-python = ">=3.10"
 dependencies = [
-    "langchain>=0.2.0",
-    "langchain-community>=0.2.0",
+    "langchain>=0.3.0",
+    "langchain-community>=0.3.0",
     "databricks-vectorsearch>=0.40",
     "databricks-ai-bridge>=0.1.0",
     "mlflow>=2.20.1",

--- a/integrations/langchain/pyproject.toml
+++ b/integrations/langchain/pyproject.toml
@@ -10,7 +10,6 @@ license = { text="Apache-2.0" }
 requires-python = ">=3.10"
 dependencies = [
     "langchain>=0.3.0",
-    "langchain-community>=0.3.0",
     "databricks-vectorsearch>=0.40",
     "databricks-ai-bridge>=0.1.0",
     "mlflow>=2.20.1",


### PR DESCRIPTION
Users are running into this error when installing `databricks-langchain`
`metaclass conflict: the metaclass of a derived class must be a (non-strict) subclass of the metaclasses of all its bases`

Reproduced in https://e2-dogfood.staging.cloud.databricks.com/editor/notebooks/2183817319091232?o=6051921418418893#command/8852559416333002.

Left side has the error, right side does not. Upgrading version of LangChain from 0.2.17 --> 0.3.0 fixes this issue, and it's the next release (https://pypi.org/project/langchain/0.3.0/#history).

https://www.diffchecker.com/peml3OxV/