### PR TITLE
[ML-51170] Update Genie for PuPr APIs

### DIFF
--- a/src/databricks_ai_bridge/genie.py
+++ b/src/databricks_ai_bridge/genie.py
@@ -28,34 +28,31 @@ class GenieResponse:
 
 @mlflow.trace(span_type="PARSER")
 def _parse_query_result(resp) -> Union[str, pd.DataFrame]:
-    columns = resp["manifest"]["schema"]["columns"]
-    header = [str(col["name"]) for col in columns]
-    rows = []
     output = resp["result"]
     if not output:
         return "EMPTY"
 
-    for item in resp["result"]["data_typed_array"]:
+    columns = resp["manifest"]["schema"]["columns"]
+    header = [str(col["name"]) for col in columns]
+    rows = []
+
+    for item in output["data_array"]:
         row = []
-        for column, value in zip(columns, item["values"]):
+        for column, value in zip(columns, item):
             type_name = column["type_name"]
-            str_value = value.get("str", None)
-            if str_value is None:
-                row.append(None)
-                continue
 
             if type_name in ["INT", "LONG", "SHORT", "BYTE"]:
-                row.append(int(str_value))
+                row.append(int(value))
             elif type_name in ["FLOAT", "DOUBLE", "DECIMAL"]:
-                row.append(float(str_value))
+                row.append(float(value))
             elif type_name == "BOOLEAN":
-                row.append(str_value.lower() == "true")
+                row.append(value.lower() == "true")
             elif type_name == "DATE" or type_name == "TIMESTAMP":
-                row.append(datetime.strptime(str_value[:10], "%Y-%m-%d").date())
+                row.append(datetime.strptime(value[:10], "%Y-%m-%d").date())
             elif type_name == "BINARY":
-                row.append(bytes(str_value, "utf-8"))
+                row.append(bytes(value, "utf-8"))
             else:
-                row.append(str_value)
+                row.append(value)
 
         rows.append(row)
 
@@ -103,27 +100,29 @@ class Genie:
     @mlflow.trace()
     def poll_for_result(self, conversation_id, message_id):
         @mlflow.trace()
-        def poll_query_results(query, description):
+        def poll_query_results(attachment_id, query_str, description):
             iteration_count = 0
             while iteration_count < MAX_ITERATIONS:
                 iteration_count += 1
                 resp = self.genie._api.do(
                     "GET",
-                    f"/api/2.0/genie/spaces/{self.space_id}/conversations/{conversation_id}/messages/{message_id}/query-result",
+                    f"/api/2.0/genie/spaces/{self.space_id}/conversations/{conversation_id}/messages/{message_id}/attachments/{attachment_id}/query-result",
                     headers=self.headers,
                 )["statement_response"]
                 state = resp["status"]["state"]
                 if state == "SUCCEEDED":
                     result = _parse_query_result(resp)
-                    return GenieResponse(result, query, description)
+                    return GenieResponse(result, query_str, description)
                 elif state in ["RUNNING", "PENDING"]:
                     logging.debug("Waiting for query result...")
                     time.sleep(5)
                 else:
-                    return GenieResponse(f"No query result: {resp['state']}", query, description)
+                    return GenieResponse(
+                        f"No query result: {resp['state']}", query_str, description
+                    )
             return GenieResponse(
                 f"Genie query for result timed out after {MAX_ITERATIONS} iterations of 5 seconds",
-                query,
+                query_str,
                 description,
             )
 
@@ -137,12 +136,14 @@ class Genie:
                     f"/api/2.0/genie/spaces/{self.space_id}/conversations/{conversation_id}/messages/{message_id}",
                     headers=self.headers,
                 )
-                if resp["status"] in {"EXECUTING_QUERY", "COMPLETED"}:
-                    query_attachment = next((r for r in resp["attachments"] if "query" in r), None)
-                    if query_attachment:
-                        query = query_attachment["query"]["query"]
-                        description = query_attachment["query"].get("description", "")
-                        return poll_query_results(query, description)
+                if resp["status"] == "COMPLETED":
+                    attachment = next((r for r in resp["attachments"] if "query" in r), None)
+                    if attachment:
+                        query_obj = attachment["query"]
+                        description = query_obj.get("description", "")
+                        query_str = query_obj.get("query", "")
+                        attachment_id = attachment["attachment_id"]
+                        return poll_query_results(attachment_id, query_str, description)
                     if resp["status"] == "COMPLETED":
                         text_content = next(r for r in resp["attachments"] if "text" in r)["text"][
                             "content"
@@ -154,13 +155,12 @@ class Genie:
                     return GenieResponse(
                         result=f"Genie query failed with error: {resp.get('error', 'Unknown error')}"
                     )
+                # includes EXECUTING_QUERY, Genie can retry after this status
                 else:
                     logging.debug(f"Waiting...: {resp['status']}")
                     time.sleep(5)
             return GenieResponse(
-                f"Genie query timed out after {MAX_ITERATIONS} iterations of 5 seconds",
-                query,
-                description,
+                f"Genie query timed out after {MAX_ITERATIONS} iterations of 5 seconds"
             )
 
         return poll_result()

--- a/src/databricks_ai_bridge/genie.py
+++ b/src/databricks_ai_bridge/genie.py
@@ -40,6 +40,9 @@ def _parse_query_result(resp) -> Union[str, pd.DataFrame]:
         row = []
         for column, value in zip(columns, item):
             type_name = column["type_name"]
+            if value is None:
+                row.append(None)
+                continue
 
             if type_name in ["INT", "LONG", "SHORT", "BYTE"]:
                 row.append(int(value))

--- a/tests/databricks_ai_bridge/test_genie.py
+++ b/tests/databricks_ai_bridge/test_genie.py
@@ -141,20 +141,8 @@ def test_parse_query_result_with_data():
         },
         "result": {
             "data_array": [
-                {
-                    "values": [
-                        {"str": "1"},
-                        {"str": "Alice"},
-                        {"str": "2023-10-01T00:00:00Z"},
-                    ]
-                },
-                {
-                    "values": [
-                        {"str": "2"},
-                        {"str": "Bob"},
-                        {"str": "2023-10-02T00:00:00Z"},
-                    ]
-                },
+                ["1", "Alice", "2023-10-01T00:00:00Z"],
+                ["2", "Bob", "2023-10-02T00:00:00Z"],
             ]
         },
     }
@@ -182,14 +170,8 @@ def test_parse_query_result_with_null_values():
         },
         "result": {
             "data_array": [
-                {
-                    "values": [
-                        {"str": "1"},
-                        {"str": None},
-                        {"str": "2023-10-01T00:00:00Z"},
-                    ]
-                },
-                {"values": [{"str": "2"}, {"str": "Bob"}, {"str": None}]},
+                ["1", None, "2023-10-01T00:00:00Z"],
+                ["2", "Bob", None],
             ]
         },
     }
@@ -219,76 +201,16 @@ def test_parse_query_result_trims_large_data():
             },
             "result": {
                 "data_array": [
-                    {
-                        "values": [
-                            {"str": "1"},
-                            {"str": "Alice"},
-                            {"str": "2023-10-01T00:00:00Z"},
-                        ]
-                    },
-                    {
-                        "values": [
-                            {"str": "2"},
-                            {"str": "Bob"},
-                            {"str": "2023-10-02T00:00:00Z"},
-                        ]
-                    },
-                    {
-                        "values": [
-                            {"str": "3"},
-                            {"str": "Charlie"},
-                            {"str": "2023-10-03T00:00:00Z"},
-                        ]
-                    },
-                    {
-                        "values": [
-                            {"str": "4"},
-                            {"str": "David"},
-                            {"str": "2023-10-04T00:00:00Z"},
-                        ]
-                    },
-                    {
-                        "values": [
-                            {"str": "5"},
-                            {"str": "Eve"},
-                            {"str": "2023-10-05T00:00:00Z"},
-                        ]
-                    },
-                    {
-                        "values": [
-                            {"str": "6"},
-                            {"str": "Frank"},
-                            {"str": "2023-10-06T00:00:00Z"},
-                        ]
-                    },
-                    {
-                        "values": [
-                            {"str": "7"},
-                            {"str": "Grace"},
-                            {"str": "2023-10-07T00:00:00Z"},
-                        ]
-                    },
-                    {
-                        "values": [
-                            {"str": "8"},
-                            {"str": "Hank"},
-                            {"str": "2023-10-08T00:00:00Z"},
-                        ]
-                    },
-                    {
-                        "values": [
-                            {"str": "9"},
-                            {"str": "Ivy"},
-                            {"str": "2023-10-09T00:00:00Z"},
-                        ]
-                    },
-                    {
-                        "values": [
-                            {"str": "10"},
-                            {"str": "Jack"},
-                            {"str": "2023-10-10T00:00:00Z"},
-                        ]
-                    },
+                    ["1", "Alice", "2023-10-01T00:00:00Z"],
+                    ["2", "Bob", "2023-10-02T00:00:00Z"],
+                    ["3", "Charlie", "2023-10-03T00:00:00Z"],
+                    ["4", "David", "2023-10-04T00:00:00Z"],
+                    ["5", "Eve", "2023-10-05T00:00:00Z"],
+                    ["6", "Frank", "2023-10-06T00:00:00Z"],
+                    ["7", "Grace", "2023-10-07T00:00:00Z"],
+                    ["8", "Hank", "2023-10-08T00:00:00Z"],
+                    ["9", "Ivy", "2023-10-09T00:00:00Z"],
+                    ["10", "Jack", "2023-10-10T00:00:00Z"],
                 ]
             },
         }
@@ -318,7 +240,7 @@ def test_poll_query_results_max_iterations(genie, mock_workspace_client):
     ):
         mock_workspace_client.genie._api.do.side_effect = [
             {
-                "status": "SUCCEEDED",
+                "status": "COMPLETED",
                 "attachments": [{"attachment_id": "123", "query": {"query": "SELECT *"}}],
             },
             {"statement_response": {"status": {"state": "PENDING"}}},


### PR DESCRIPTION
- update genie client to no longer use [getmessgequeryresult](https://openapi.dev.databricks.com/api/workspace/genie/getmessagequeryresult) and to start using [getmessageattachmentqueryresult](https://openapi.dev.databricks.com/api/workspace/genie/getmessageattachmentqueryresult)
- adjust logic so that `executing_query` status doesn't lead us to poll for query results bc genie may retry