### PR TITLE
Add Model Name and System Fingerprint to `llm_output` in `_convert_response_to_chat_result`

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,6 +10,7 @@ on:
       - synchronize
       - reopened
       - ready_for_review
+  workflow_dispatch:
 
 jobs:
   lint:

--- a/integrations/langchain/src/databricks_langchain/chat_models.py
+++ b/integrations/langchain/src/databricks_langchain/chat_models.py
@@ -308,10 +308,11 @@ class ChatDatabricks(BaseChatModel):
             for choice in response["choices"]
         ]
         llm_output = {
-            "token_usage": response.get("usage", {}),
-            "model_name": response.get("model", self.model),
-            "system_fingerprint": response.get("system_fingerprint", ""),
+            k: v for k, v in response.items() if k not in ("choices", "content", "role", "type")
         }
+        if "model" in llm_output and "model_name" not in llm_output:
+            llm_output["model_name"] = llm_output["model"]
+        
         return ChatResult(generations=generations, llm_output=llm_output)
 
     def _stream(

--- a/integrations/langchain/src/databricks_langchain/chat_models.py
+++ b/integrations/langchain/src/databricks_langchain/chat_models.py
@@ -18,7 +18,6 @@ from typing import (
     Union,
 )
 
-from databricks_langchain.utils import get_deployment_client
 from langchain_core.callbacks import CallbackManagerForLLMRun
 from langchain_core.language_models import BaseChatModel
 from langchain_core.language_models.base import LanguageModelInput
@@ -54,6 +53,8 @@ from langchain_core.utils.function_calling import convert_to_openai_tool
 from langchain_core.utils.pydantic import is_basemodel_subclass
 from mlflow.deployments import BaseDeploymentClient  # type: ignore
 from pydantic import BaseModel, ConfigDict, Field
+
+from databricks_langchain.utils import get_deployment_client
 
 logger = logging.getLogger(__name__)
 

--- a/integrations/langchain/src/databricks_langchain/chat_models.py
+++ b/integrations/langchain/src/databricks_langchain/chat_models.py
@@ -312,7 +312,7 @@ class ChatDatabricks(BaseChatModel):
         }
         if "model" in llm_output and "model_name" not in llm_output:
             llm_output["model_name"] = llm_output["model"]
-        
+
         return ChatResult(generations=generations, llm_output=llm_output)
 
     def _stream(

--- a/integrations/langchain/src/databricks_langchain/chat_models.py
+++ b/integrations/langchain/src/databricks_langchain/chat_models.py
@@ -307,7 +307,6 @@ class ChatDatabricks(BaseChatModel):
             )
             for choice in response["choices"]
         ]
-        usage = response.get("usage", {})
         llm_output = {
             "token_usage": response.get("usage", {}),
             "model_name": response.get("model", self.model),

--- a/integrations/langchain/src/databricks_langchain/chat_models.py
+++ b/integrations/langchain/src/databricks_langchain/chat_models.py
@@ -18,6 +18,7 @@ from typing import (
     Union,
 )
 
+from databricks_langchain.utils import get_deployment_client
 from langchain_core.callbacks import CallbackManagerForLLMRun
 from langchain_core.language_models import BaseChatModel
 from langchain_core.language_models.base import LanguageModelInput
@@ -53,8 +54,6 @@ from langchain_core.utils.function_calling import convert_to_openai_tool
 from langchain_core.utils.pydantic import is_basemodel_subclass
 from mlflow.deployments import BaseDeploymentClient  # type: ignore
 from pydantic import BaseModel, ConfigDict, Field
-
-from databricks_langchain.utils import get_deployment_client
 
 logger = logging.getLogger(__name__)
 

--- a/integrations/langchain/tests/unit_tests/test_chat_models.py
+++ b/integrations/langchain/tests/unit_tests/test_chat_models.py
@@ -4,12 +4,6 @@ import json
 
 import mlflow  # type: ignore # noqa: F401
 import pytest
-from databricks_langchain.chat_models import (
-    ChatDatabricks,
-    _convert_dict_to_message,
-    _convert_dict_to_message_chunk,
-    _convert_message_to_dict,
-)
 from langchain_core.messages import (
     AIMessage,
     AIMessageChunk,
@@ -27,6 +21,12 @@ from langchain_core.messages.tool import ToolCallChunk
 from langchain_core.runnables import RunnableMap
 from pydantic import BaseModel, Field
 
+from databricks_langchain.chat_models import (
+    ChatDatabricks,
+    _convert_dict_to_message,
+    _convert_dict_to_message_chunk,
+    _convert_message_to_dict,
+)
 from tests.utils.chat_models import (  # noqa: F401
     _MOCK_CHAT_RESPONSE,
     _MOCK_STREAM_RESPONSE,

--- a/integrations/langchain/tests/unit_tests/test_chat_models.py
+++ b/integrations/langchain/tests/unit_tests/test_chat_models.py
@@ -345,3 +345,23 @@ def test_convert_tool_message_chunk() -> None:
 def test_convert_message_to_dict_function() -> None:
     with pytest.raises(ValueError, match="Function messages are not supported"):
         _convert_message_to_dict(FunctionMessage(content="", name="name"))
+
+
+def test_convert_response_to_chat_result_llm_output(llm: ChatDatabricks) -> None:
+    """Test that _convert_response_to_chat_result correctly sets llm_output."""
+    
+    result = llm._convert_response_to_chat_result(_MOCK_CHAT_RESPONSE)
+    
+    # Verify that llm_output contains the full response metadata
+    assert "model_name" in result.llm_output
+    assert "usage" in result.llm_output
+    assert result.llm_output["model_name"] == _MOCK_CHAT_RESPONSE["model"]
+    
+    # Verify that usage information is included directly in llm_output
+    assert result.llm_output["usage"] == _MOCK_CHAT_RESPONSE["usage"]
+    
+    # Verify that choices, content, role, and type are excluded from llm_output
+    assert "choices" not in result.llm_output
+    assert "content" not in result.llm_output
+    assert "role" not in result.llm_output
+    assert "type" not in result.llm_output

--- a/integrations/langchain/tests/unit_tests/test_chat_models.py
+++ b/integrations/langchain/tests/unit_tests/test_chat_models.py
@@ -349,17 +349,17 @@ def test_convert_message_to_dict_function() -> None:
 
 def test_convert_response_to_chat_result_llm_output(llm: ChatDatabricks) -> None:
     """Test that _convert_response_to_chat_result correctly sets llm_output."""
-    
+
     result = llm._convert_response_to_chat_result(_MOCK_CHAT_RESPONSE)
-    
+
     # Verify that llm_output contains the full response metadata
     assert "model_name" in result.llm_output
     assert "usage" in result.llm_output
     assert result.llm_output["model_name"] == _MOCK_CHAT_RESPONSE["model"]
-    
+
     # Verify that usage information is included directly in llm_output
     assert result.llm_output["usage"] == _MOCK_CHAT_RESPONSE["usage"]
-    
+
     # Verify that choices, content, role, and type are excluded from llm_output
     assert "choices" not in result.llm_output
     assert "content" not in result.llm_output

--- a/integrations/langchain/tests/unit_tests/test_chat_models.py
+++ b/integrations/langchain/tests/unit_tests/test_chat_models.py
@@ -4,6 +4,12 @@ import json
 
 import mlflow  # type: ignore # noqa: F401
 import pytest
+from databricks_langchain.chat_models import (
+    ChatDatabricks,
+    _convert_dict_to_message,
+    _convert_dict_to_message_chunk,
+    _convert_message_to_dict,
+)
 from langchain_core.messages import (
     AIMessage,
     AIMessageChunk,
@@ -21,12 +27,6 @@ from langchain_core.messages.tool import ToolCallChunk
 from langchain_core.runnables import RunnableMap
 from pydantic import BaseModel, Field
 
-from databricks_langchain.chat_models import (
-    ChatDatabricks,
-    _convert_dict_to_message,
-    _convert_dict_to_message_chunk,
-    _convert_message_to_dict,
-)
 from tests.utils.chat_models import (  # noqa: F401
     _MOCK_CHAT_RESPONSE,
     _MOCK_STREAM_RESPONSE,


### PR DESCRIPTION
This PR enhances `_convert_response_to_chat_result` by including the model name and system fingerprint in `llm_output`. The model name is particularly important for observability tools like LangFuse, which rely on `llm_output["model_name"]` for tracking.  

Currently, Databricks **does not provide** the model name in the metadata—only the endpoint name. This change ensures that external models are properly identified, improving observability and logging.  

**Changes:**  
- Added `model_name` to `llm_output`, defaulting to `self.model` if not in the response.  
- Added `system_fingerprint` to `llm_output` for additional metadata.  
- Updated `llm_output` to include `token_usage` separately for better structure.  

**Why?**  
When using external models with Databricks, the returned metadata only includes the endpoint name, not the actual model name. This change allows users to extract the correct model name for logging and monitoring.

**Testing:**  
- Ensured the new metadata fields are correctly populated when present in the response.  
- Maintains backward compatibility by defaulting to `self.model` if `response["model"]` is missing.  
