### PR TITLE
bump openai and uc-ai required versions

### DIFF
--- a/integrations/langchain/pyproject.toml
+++ b/integrations/langchain/pyproject.toml
@@ -14,7 +14,7 @@ dependencies = [
     "databricks-ai-bridge>=0.4.0",
     "mlflow>=2.20.1",
     "pydantic>2.10.0",
-    "unitycatalog-langchain[databricks]>=0.3.0",
+    "unitycatalog-langchain[databricks]>=0.2.0",
 ]
 
 [project.optional-dependencies]

--- a/integrations/langchain/pyproject.toml
+++ b/integrations/langchain/pyproject.toml
@@ -14,7 +14,7 @@ dependencies = [
     "databricks-ai-bridge>=0.4.0",
     "mlflow>=2.20.1",
     "pydantic>2.10.0",
-    "unitycatalog-langchain[databricks]>=0.1.1",
+    "unitycatalog-langchain[databricks]>=0.3.0",
 ]
 
 [project.optional-dependencies]

--- a/integrations/openai/pyproject.toml
+++ b/integrations/openai/pyproject.toml
@@ -11,7 +11,7 @@ requires-python = ">=3.10"
 dependencies = [
     "databricks-vectorsearch>=0.50",
     "databricks-ai-bridge>=0.4.0",
-    "openai>=1.46.1",
+    "openai>=1.66.0",
     "pydantic>2.10.0",
     "mlflow>=2.20.1",
     "unitycatalog-openai[databricks]>=0.1.0",

--- a/integrations/openai/pyproject.toml
+++ b/integrations/openai/pyproject.toml
@@ -14,7 +14,7 @@ dependencies = [
     "openai>=1.66.0",
     "pydantic>2.10.0",
     "mlflow>=2.20.1",
-    "unitycatalog-openai[databricks]>=0.1.0",
+    "unitycatalog-openai[databricks]>=0.2.0",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
- to ensure OpenAI client has responses API: https://pypi.org/project/openai/1.66.0/
- get the latest versions of uc-ai