### PR TITLE
Remove default temperature for ChatDatabricks

### DIFF
--- a/integrations/langchain/src/databricks_langchain/chat_models.py
+++ b/integrations/langchain/src/databricks_langchain/chat_models.py
@@ -215,6 +215,7 @@ class ChatDatabricks(BaseChatModel):
     target_uri: str = "databricks"
     """The target URI to use. Defaults to ``databricks``."""
     temperature: Optional[float] = 0.0
+    # TODO: bbqiu log a deprecated warning when temperature is not set
     """Sampling temperature. Higher values make the model more creative."""
     n: int = 1
     """The number of completion choices to generate."""

--- a/integrations/langchain/src/databricks_langchain/chat_models.py
+++ b/integrations/langchain/src/databricks_langchain/chat_models.py
@@ -214,7 +214,7 @@ class ChatDatabricks(BaseChatModel):
     """Name of Databricks Model Serving endpoint to query."""
     target_uri: str = "databricks"
     """The target URI to use. Defaults to ``databricks``."""
-    temperature: float
+    temperature: Optional[float] = None
     """Sampling temperature. Higher values make the model more creative."""
     n: int = 1
     """The number of completion choices to generate."""

--- a/integrations/langchain/src/databricks_langchain/chat_models.py
+++ b/integrations/langchain/src/databricks_langchain/chat_models.py
@@ -214,7 +214,7 @@ class ChatDatabricks(BaseChatModel):
     """Name of Databricks Model Serving endpoint to query."""
     target_uri: str = "databricks"
     """The target URI to use. Defaults to ``databricks``."""
-    temperature: Optional[float] = None
+    temperature: Optional[float] = 0.0
     """Sampling temperature. Higher values make the model more creative."""
     n: int = 1
     """The number of completion choices to generate."""

--- a/integrations/langchain/src/databricks_langchain/chat_models.py
+++ b/integrations/langchain/src/databricks_langchain/chat_models.py
@@ -214,7 +214,7 @@ class ChatDatabricks(BaseChatModel):
     """Name of Databricks Model Serving endpoint to query."""
     target_uri: str = "databricks"
     """The target URI to use. Defaults to ``databricks``."""
-    temperature: float = 0.0
+    temperature: float
     """Sampling temperature. Higher values make the model more creative."""
     n: int = 1
     """The number of completion choices to generate."""
@@ -620,7 +620,7 @@ class ChatDatabricks(BaseChatModel):
         if method == "function_calling":
             if schema is None:
                 raise ValueError(
-                    "schema must be specified when method is 'function_calling'. " "Received None."
+                    "schema must be specified when method is 'function_calling'. Received None."
                 )
             tool_name = convert_to_openai_tool(schema)["function"]["name"]
             llm = self.bind_tools([schema], tool_choice=tool_name)
@@ -641,7 +641,7 @@ class ChatDatabricks(BaseChatModel):
         elif method == "json_schema":
             if schema is None:
                 raise ValueError(
-                    "schema must be specified when method is 'json_schema'. " "Received None."
+                    "schema must be specified when method is 'json_schema'. Received None."
                 )
             response_format = {
                 "type": "json_schema",

--- a/integrations/langchain/src/databricks_langchain/chat_models.py
+++ b/integrations/langchain/src/databricks_langchain/chat_models.py
@@ -215,7 +215,6 @@ class ChatDatabricks(BaseChatModel):
     target_uri: str = "databricks"
     """The target URI to use. Defaults to ``databricks``."""
     temperature: Optional[float] = 0.0
-    # TODO: bbqiu log a deprecated warning when temperature is not set
     """Sampling temperature. Higher values make the model more creative."""
     n: int = 1
     """The number of completion choices to generate."""

--- a/integrations/langchain/src/databricks_langchain/chat_models.py
+++ b/integrations/langchain/src/databricks_langchain/chat_models.py
@@ -257,14 +257,18 @@ class ChatDatabricks(BaseChatModel):
 
     @property
     def _default_params(self) -> Dict[str, Any]:
-        params: Dict[str, Any] = {
-            "target_uri": self.target_uri,
-            "model": self.model,
+        exclude_if_none = {
             "temperature": self.temperature,
             "n": self.n,
             "stop": self.stop,
             "max_tokens": self.max_tokens,
             "extra_params": self.extra_params,
+        }
+
+        params = {
+            "model": self.model,
+            "target_uri": self.target_uri,
+            **{k: v for k, v in exclude_if_none.items() if v is not None},
         }
         return params
 
@@ -287,11 +291,12 @@ class ChatDatabricks(BaseChatModel):
     ) -> Dict[str, Any]:
         data: Dict[str, Any] = {
             "messages": [_convert_message_to_dict(msg) for msg in messages],
-            "temperature": self.temperature,
             "n": self.n,
             **self.extra_params,  # type: ignore
             **kwargs,
         }
+        if self.temperature is not None:
+            data["temperature"] = self.temperature
         if stop := self.stop or stop:
             data["stop"] = stop
         if self.max_tokens is not None:

--- a/integrations/langchain/src/databricks_langchain/chat_models.py
+++ b/integrations/langchain/src/databricks_langchain/chat_models.py
@@ -253,6 +253,14 @@ class ChatDatabricks(BaseChatModel):
 
     def __init__(self, **kwargs: Any):
         super().__init__(**kwargs)
+        if "temperature" not in kwargs:
+            warnings.warn(
+                "Currently, temperature defaults to 0.0 if not specified. "
+                "In the next release, temperature will need to be explicitly set. "
+                "Please update your code to specify a temperature value.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
         self.client = get_deployment_client(self.target_uri)
         self.extra_params = self.extra_params or {}
 


### PR DESCRIPTION
- no deprecation warning when temperature is passed in (either None or 0)
  - allow None to be compatible w/ EMs like o1
- deprecation warning when temperature is not passed
  - need to keep default at 0 since FMAPI default is not 0  ([slack msg](https://databricks.slack.com/archives/C03RVD95PU6/p1742588626045899)) ([additional discussion](https://databricks.slack.com/archives/C06KX8NAV8D/p1742598890036829?thread_ts=1742520999.407119&cid=C06KX8NAV8D))

tested here w/ o1 + llama: https://e2-dogfood.staging.cloud.databricks.com/editor/notebooks/1016946506451086?o=6051921418418893#command/7321788187864732

![screenshot 2025-03-24-13-59-52-Arc](https://github.com/user-attachments/assets/e0fcfcf5-efa5-44fe-9ccb-df0385752bbf)

![screenshot 2025-03-24-13-56-54-Arc](https://github.com/user-attachments/assets/87a619b3-a2d0-4602-b266-efc998601354)