### PR TITLE
bump databricks-connect and tabulate version to fix PyPi errors

### DIFF
--- a/integrations/langchain/pyproject.toml
+++ b/integrations/langchain/pyproject.toml
@@ -15,6 +15,7 @@ dependencies = [
     "mlflow>=2.20.1",
     "pydantic>2.10.0",
     "unitycatalog-langchain[databricks]>=0.2.0",
+    "databricks-connect>=16.1.1",
 ]
 
 [project.optional-dependencies]

--- a/integrations/openai/pyproject.toml
+++ b/integrations/openai/pyproject.toml
@@ -15,6 +15,7 @@ dependencies = [
     "pydantic>2.10.0",
     "mlflow>=2.20.1",
     "unitycatalog-openai[databricks]>=0.2.0",
+    "databricks-connect>=16.1.1",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ dependencies = [
   "databricks-sdk>=0.44.1",
   "pandas",
   "tiktoken>=0.8.0",
-  "tabulate",
+  "tabulate>=0.9.0",
   "mlflow-skinny>=2.19.0",
 ]
 


### PR DESCRIPTION
seeing this error:
https://github.com/databricks/databricks-ai-bridge/actions/runs/13984414746/job/39155531496?pr=88#step:4:388

from @harupy
The pip install logs look like:
- pip struggled to find a scipy version that's compatible with other depedencies.
- scipy 1.6.1 doesn't provide a wheel for python 3.10, so build is triggered and hit the error

https://e2-demo-field-eng.cloud.databricks.com/editor/notebooks/893528767896333?o=1444828305810485#command/893528767896335
tabulate seems to cause problems too: [link to error](https://github.com/databricks/databricks-ai-bridge/pull/89/files#r2008383512)