### PR TITLE
Update base version for integration packages

### DIFF
--- a/integrations/langchain/pyproject.toml
+++ b/integrations/langchain/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "databricks-langchain"
-version = "0.4.1.dev0"
+version = "0.4.2.dev0"
 description = "Support for Databricks AI support in LangChain"
 authors = [
     { name="Databricks", email="agent-feedback@databricks.com" },
@@ -11,7 +11,7 @@ requires-python = ">=3.10"
 dependencies = [
     "langchain>=0.3.0",
     "databricks-vectorsearch>=0.50",
-    "databricks-ai-bridge>=0.4.0",
+    "databricks-ai-bridge>=0.4.1",
     "mlflow>=2.20.1",
     "pydantic>2.10.0",
     "unitycatalog-langchain[databricks]>=0.2.0",

--- a/integrations/openai/pyproject.toml
+++ b/integrations/openai/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "databricks-openai"
-version = "0.3.1.dev"
+version = "0.3.2.dev"
 description = "Support for Databricks AI support with OpenAI"
 authors = [
     { name="Databricks", email="agent-feedback@databricks.com" },
@@ -10,7 +10,7 @@ license = { text="Apache-2.0" }
 requires-python = ">=3.10"
 dependencies = [
     "databricks-vectorsearch>=0.50",
-    "databricks-ai-bridge>=0.4.0",
+    "databricks-ai-bridge>=0.4.1",
     "openai>=1.66.0",
     "pydantic>2.10.0",
     "mlflow>=2.20.1",


### PR DESCRIPTION
Update Databricks-langchain and Databricks-openai to depend on newly released Databricks-ai-bridge 0.4.1