### PR TITLE
Support additional retriever fields

### DIFF
--- a/integrations/langchain/src/databricks_langchain/vector_search_retriever_tool.py
+++ b/integrations/langchain/src/databricks_langchain/vector_search_retriever_tool.py
@@ -44,6 +44,8 @@ class VectorSearchRetrieverTool(BaseTool, VectorSearchRetrieverToolMixin):
             "index_name": self.index_name,
             "embedding": self.embedding,
             "text_column": self.text_column,
+            "doc_uri": self.doc_uri,
+            "chunk_id": self.chunk_id,
             "columns": self.columns,
             "workspace_client": self.workspace_client,
         }

--- a/integrations/langchain/src/databricks_langchain/vector_search_retriever_tool.py
+++ b/integrations/langchain/src/databricks_langchain/vector_search_retriever_tool.py
@@ -45,7 +45,7 @@ class VectorSearchRetrieverTool(BaseTool, VectorSearchRetrieverToolMixin):
             "embedding": self.embedding,
             "text_column": self.text_column,
             "doc_uri": self.doc_uri,
-            "chunk_id": self.chunk_id,
+            "primary_key": self.primary_key,
             "columns": self.columns,
             "workspace_client": self.workspace_client,
         }

--- a/integrations/langchain/src/databricks_langchain/vectorstores.py
+++ b/integrations/langchain/src/databricks_langchain/vectorstores.py
@@ -279,7 +279,7 @@ class DatabricksVectorSearch(VectorStore):
         self._embeddings = embedding
         self._text_column = validate_and_get_text_column(text_column, self._index_details)
         self._columns = validate_and_get_return_columns(
-            columns or [], self._text_column, self._index_details
+            columns or [], self._text_column, self._index_details, doc_uri, primary_key
         )
         self._primary_key = self._index_details.primary_key
         self._retriever_schema = RetrieverSchema(

--- a/integrations/langchain/src/databricks_langchain/vectorstores.py
+++ b/integrations/langchain/src/databricks_langchain/vectorstores.py
@@ -286,7 +286,7 @@ class DatabricksVectorSearch(VectorStore):
             text_column=self._text_column,
             doc_uri=doc_uri,
             primary_key=primary_key,
-            other_columns=columns,
+            other_columns=self._columns,
         )
 
     @property

--- a/integrations/langchain/src/databricks_langchain/vectorstores.py
+++ b/integrations/langchain/src/databricks_langchain/vectorstores.py
@@ -223,7 +223,7 @@ class DatabricksVectorSearch(VectorStore):
         embedding: Optional[Embeddings] = None,
         text_column: Optional[str] = None,
         doc_uri: Optional[str] = None,
-        chunk_id: Optional[str] = None,
+        primary_key: Optional[str] = None,
         columns: Optional[List[str]] = None,
         workspace_client: Optional[WorkspaceClient] = None,
         client_args: Optional[Dict[str, Any]] = None,
@@ -283,7 +283,7 @@ class DatabricksVectorSearch(VectorStore):
         )
         self._primary_key = self._index_details.primary_key
         self._retriever_schema = RetrieverSchema(
-            text_column=self._text_column, doc_uri=doc_uri, chunk_id=chunk_id, other_columns=columns
+            text_column=self._text_column, doc_uri=doc_uri, primary_key=primary_key, other_columns=columns
         )
 
     @property

--- a/integrations/langchain/src/databricks_langchain/vectorstores.py
+++ b/integrations/langchain/src/databricks_langchain/vectorstores.py
@@ -283,10 +283,7 @@ class DatabricksVectorSearch(VectorStore):
         )
         self._primary_key = self._index_details.primary_key
         self._retriever_schema = RetrieverSchema(
-            text_column=self._text_column,
-            doc_uri=doc_uri,
-            chunk_id=chunk_id,
-            other_columns=columns
+            text_column=self._text_column, doc_uri=doc_uri, chunk_id=chunk_id, other_columns=columns
         )
 
     @property
@@ -467,7 +464,7 @@ class DatabricksVectorSearch(VectorStore):
             query_type=query_type,
         )
         return parse_vector_search_response(
-            search_resp, self._index_details, self._retriever_schema, document_class=Document
+            search_resp, self._retriever_schema, document_class=Document
         )
 
     def _select_relevance_score_fn(self) -> Callable[[float], float]:
@@ -579,7 +576,7 @@ class DatabricksVectorSearch(VectorStore):
             query_type=query_type,
         )
         return parse_vector_search_response(
-            search_resp, self._index_details, self._retriever_schema, document_class=Document
+            search_resp, self._retriever_schema, document_class=Document
         )
 
     def max_marginal_relevance_search(
@@ -715,7 +712,6 @@ class DatabricksVectorSearch(VectorStore):
         ignore_cols: List = [embedding_column] if embedding_column not in self._columns else []
         candidates = parse_vector_search_response(
             search_resp,
-            self._index_details,
             self._retriever_schema,
             ignore_cols=ignore_cols,
             document_class=Document,

--- a/integrations/langchain/src/databricks_langchain/vectorstores.py
+++ b/integrations/langchain/src/databricks_langchain/vectorstores.py
@@ -283,7 +283,10 @@ class DatabricksVectorSearch(VectorStore):
         )
         self._primary_key = self._index_details.primary_key
         self._retriever_schema = RetrieverSchema(
-            text_column=self._text_column, doc_uri=doc_uri, primary_key=primary_key, other_columns=columns
+            text_column=self._text_column,
+            doc_uri=doc_uri,
+            primary_key=primary_key,
+            other_columns=columns,
         )
 
     @property

--- a/integrations/langchain/tests/unit_tests/test_vector_search_retriever_tool.py
+++ b/integrations/langchain/tests/unit_tests/test_vector_search_retriever_tool.py
@@ -124,7 +124,7 @@ def test_vector_search_retriever_tool_combinations() -> None:
     )
     assert isinstance(vector_search_tool, BaseTool)
     result = vector_search_tool.invoke("Databricks Agent Framework")
-    assert all(item.metadata.keys() == {"doc_uri", "chunk_id", "text_vector"} for item in result)
+    assert all(item.metadata.keys() == {"doc_uri", "chunk_id"} for item in result)
     assert all(item.page_content for item in result)
 
 

--- a/integrations/langchain/tests/unit_tests/test_vector_search_retriever_tool.py
+++ b/integrations/langchain/tests/unit_tests/test_vector_search_retriever_tool.py
@@ -46,6 +46,8 @@ def init_vector_search_tool(
     tool_description: Optional[str] = None,
     embedding: Optional[Embeddings] = None,
     text_column: Optional[str] = None,
+    doc_uri: Optional[str] = None,
+    primary_key: Optional[str] = None,
 ) -> VectorSearchRetrieverTool:
     kwargs: Dict[str, Any] = {
         "index_name": index_name,
@@ -54,6 +56,8 @@ def init_vector_search_tool(
         "tool_description": tool_description,
         "embedding": embedding,
         "text_column": text_column,
+        "doc_uri": doc_uri,
+        "primary_key": primary_key,
     }
     if index_name != DELTA_SYNC_INDEX:
         kwargs.update(
@@ -110,6 +114,18 @@ def test_vector_search_retriever_tool_combinations(
     assert isinstance(vector_search_tool, BaseTool)
     result = vector_search_tool.invoke("Databricks Agent Framework")
     assert result is not None
+
+
+def test_vector_search_retriever_tool_combinations() -> None:
+    vector_search_tool = init_vector_search_tool(
+        index_name=DELTA_SYNC_INDEX,
+        doc_uri="uri",
+        primary_key="id",
+    )
+    assert isinstance(vector_search_tool, BaseTool)
+    result = vector_search_tool.invoke("Databricks Agent Framework")
+    assert all(item.metadata.keys() == {"doc_uri", "chunk_id", "text_vector"} for item in result)
+    assert all(item.page_content for item in result)
 
 
 @pytest.mark.parametrize("index_name", ALL_INDEX_NAMES)

--- a/integrations/llamaindex/src/databricks_llamaindex/vector_search_retriever_tool.py
+++ b/integrations/llamaindex/src/databricks_llamaindex/vector_search_retriever_tool.py
@@ -67,7 +67,7 @@ class VectorSearchRetrieverTool(FunctionTool, VectorSearchRetrieverToolMixin):
         self._retriever_schema = RetrieverSchema(
             text_column=self.text_column,
             doc_uri=self.doc_uri,
-            chunk_id=self.chunk_id,
+            primary_key=self.primary_key,
             other_columns=self.columns,
         )
 

--- a/integrations/llamaindex/src/databricks_llamaindex/vector_search_retriever_tool.py
+++ b/integrations/llamaindex/src/databricks_llamaindex/vector_search_retriever_tool.py
@@ -62,7 +62,7 @@ class VectorSearchRetrieverTool(FunctionTool, VectorSearchRetrieverToolMixin):
         # Validate columns
         self.text_column = validate_and_get_text_column(self.text_column, self._index_details)
         self.columns = validate_and_get_return_columns(
-            self.columns or [], self.text_column, self._index_details
+            self.columns or [], self.text_column, self._index_details, self.doc_uri, self.primary_key
         )
         self._retriever_schema = RetrieverSchema(
             text_column=self.text_column,

--- a/integrations/llamaindex/src/databricks_llamaindex/vector_search_retriever_tool.py
+++ b/integrations/llamaindex/src/databricks_llamaindex/vector_search_retriever_tool.py
@@ -61,7 +61,7 @@ class VectorSearchRetrieverTool(FunctionTool, VectorSearchRetrieverToolMixin):
         self.columns = validate_and_get_return_columns(
             self.columns or [], self.text_column, self._index_details
         )
-        self.retriever_schema = RetrieverSchema(
+        self._retriever_schema = RetrieverSchema(
             text_column=self.text_column,
             doc_uri=self.doc_uri,
             chunk_id=self.chunk_id,
@@ -107,7 +107,7 @@ class VectorSearchRetrieverTool(FunctionTool, VectorSearchRetrieverToolMixin):
                 query_type=self.query_type,
             )
             return parse_vector_search_response(
-                search_resp, self.retriever_schema, document_class=dict
+                search_resp, self._retriever_schema, document_class=dict
             )
 
         # Create tool metadata

--- a/integrations/llamaindex/src/databricks_llamaindex/vector_search_retriever_tool.py
+++ b/integrations/llamaindex/src/databricks_llamaindex/vector_search_retriever_tool.py
@@ -62,7 +62,11 @@ class VectorSearchRetrieverTool(FunctionTool, VectorSearchRetrieverToolMixin):
         # Validate columns
         self.text_column = validate_and_get_text_column(self.text_column, self._index_details)
         self.columns = validate_and_get_return_columns(
-            self.columns or [], self.text_column, self._index_details, self.doc_uri, self.primary_key
+            self.columns or [],
+            self.text_column,
+            self._index_details,
+            self.doc_uri,
+            self.primary_key,
         )
         self._retriever_schema = RetrieverSchema(
             text_column=self.text_column,

--- a/integrations/llamaindex/src/databricks_llamaindex/vector_search_retriever_tool.py
+++ b/integrations/llamaindex/src/databricks_llamaindex/vector_search_retriever_tool.py
@@ -65,7 +65,7 @@ class VectorSearchRetrieverTool(FunctionTool, VectorSearchRetrieverToolMixin):
             text_column=self.text_column,
             doc_uri=self.doc_uri,
             chunk_id=self.chunk_id,
-            other_columns=self.columns
+            other_columns=self.columns,
         )
 
         # Define the similarity search function
@@ -107,7 +107,7 @@ class VectorSearchRetrieverTool(FunctionTool, VectorSearchRetrieverToolMixin):
                 query_type=self.query_type,
             )
             return parse_vector_search_response(
-                search_resp, self._index_details, self.retriever_schema, document_class=dict
+                search_resp, self.retriever_schema, document_class=dict
             )
 
         # Create tool metadata

--- a/integrations/llamaindex/src/databricks_llamaindex/vector_search_retriever_tool.py
+++ b/integrations/llamaindex/src/databricks_llamaindex/vector_search_retriever_tool.py
@@ -2,6 +2,7 @@ from typing import Any, Dict, List, Optional, Tuple
 
 from databricks_ai_bridge.utils.vector_search import (
     IndexDetails,
+    RetrieverSchema,
     parse_vector_search_response,
     validate_and_get_return_columns,
     validate_and_get_text_column,
@@ -60,6 +61,12 @@ class VectorSearchRetrieverTool(FunctionTool, VectorSearchRetrieverToolMixin):
         self.columns = validate_and_get_return_columns(
             self.columns or [], self.text_column, self._index_details
         )
+        self.retriever_schema = RetrieverSchema(
+            text_column=self.text_column,
+            doc_uri=self.doc_uri,
+            chunk_id=self.chunk_id,
+            other_columns=self.columns
+        )
 
         # Define the similarity search function
         def similarity_search(query: str) -> List[Dict[str, Any]]:
@@ -100,7 +107,7 @@ class VectorSearchRetrieverTool(FunctionTool, VectorSearchRetrieverToolMixin):
                 query_type=self.query_type,
             )
             return parse_vector_search_response(
-                search_resp, self._index_details, self.text_column, document_class=dict
+                search_resp, self._index_details, self.retriever_schema, document_class=dict
             )
 
         # Create tool metadata

--- a/integrations/openai/src/databricks_openai/vector_search_retriever_tool.py
+++ b/integrations/openai/src/databricks_openai/vector_search_retriever_tool.py
@@ -116,7 +116,7 @@ class VectorSearchRetrieverTool(VectorSearchRetrieverToolMixin):
         self._retriever_schema = RetrieverSchema(
             text_column=self.text_column,
             doc_uri=self.doc_uri,
-            chunk_id=self.chunk_id,
+            primary_key=self.primary_key,
             other_columns=self.columns,
         )
 

--- a/integrations/openai/src/databricks_openai/vector_search_retriever_tool.py
+++ b/integrations/openai/src/databricks_openai/vector_search_retriever_tool.py
@@ -111,7 +111,11 @@ class VectorSearchRetrieverTool(VectorSearchRetrieverToolMixin):
         self._index_details = IndexDetails(self._index)
         self.text_column = validate_and_get_text_column(self.text_column, self._index_details)
         self.columns = validate_and_get_return_columns(
-            self.columns or [], self.text_column, self._index_details, self.doc_uri, self.primary_key
+            self.columns or [],
+            self.text_column,
+            self._index_details,
+            self.doc_uri,
+            self.primary_key,
         )
         self._retriever_schema = RetrieverSchema(
             text_column=self.text_column,

--- a/integrations/openai/src/databricks_openai/vector_search_retriever_tool.py
+++ b/integrations/openai/src/databricks_openai/vector_search_retriever_tool.py
@@ -4,6 +4,7 @@ from typing import Dict, List, Optional, Tuple
 from databricks.vector_search.client import VectorSearchIndex
 from databricks_ai_bridge.utils.vector_search import (
     IndexDetails,
+    RetrieverSchema,
     parse_vector_search_response,
     validate_and_get_return_columns,
     validate_and_get_text_column,
@@ -112,6 +113,12 @@ class VectorSearchRetrieverTool(VectorSearchRetrieverToolMixin):
         self.columns = validate_and_get_return_columns(
             self.columns or [], self.text_column, self._index_details
         )
+        self.retriever_schema = RetrieverSchema(
+            text_column=self.text_column,
+            doc_uri=self.doc_uri,
+            chunk_id=self.chunk_id,
+            other_columns=self.columns
+        )
 
         if (
             not self._index_details.is_databricks_managed_embeddings()
@@ -200,7 +207,7 @@ class VectorSearchRetrieverTool(VectorSearchRetrieverToolMixin):
         docs_with_score: List[Tuple[Dict, float]] = parse_vector_search_response(
             search_resp=search_resp,
             index_details=self._index_details,
-            text_column=self.text_column,
+            retriever_schema=self.retriever_schema,
             document_class=dict,
         )
         return [doc for doc, _ in docs_with_score]

--- a/integrations/openai/src/databricks_openai/vector_search_retriever_tool.py
+++ b/integrations/openai/src/databricks_openai/vector_search_retriever_tool.py
@@ -111,7 +111,7 @@ class VectorSearchRetrieverTool(VectorSearchRetrieverToolMixin):
         self._index_details = IndexDetails(self._index)
         self.text_column = validate_and_get_text_column(self.text_column, self._index_details)
         self.columns = validate_and_get_return_columns(
-            self.columns or [], self.text_column, self._index_details
+            self.columns or [], self.text_column, self._index_details, self.doc_uri, self.primary_key
         )
         self._retriever_schema = RetrieverSchema(
             text_column=self.text_column,

--- a/integrations/openai/src/databricks_openai/vector_search_retriever_tool.py
+++ b/integrations/openai/src/databricks_openai/vector_search_retriever_tool.py
@@ -117,7 +117,7 @@ class VectorSearchRetrieverTool(VectorSearchRetrieverToolMixin):
             text_column=self.text_column,
             doc_uri=self.doc_uri,
             chunk_id=self.chunk_id,
-            other_columns=self.columns
+            other_columns=self.columns,
         )
 
         if (
@@ -206,7 +206,6 @@ class VectorSearchRetrieverTool(VectorSearchRetrieverToolMixin):
         )
         docs_with_score: List[Tuple[Dict, float]] = parse_vector_search_response(
             search_resp=search_resp,
-            index_details=self._index_details,
             retriever_schema=self.retriever_schema,
             document_class=dict,
         )

--- a/integrations/openai/src/databricks_openai/vector_search_retriever_tool.py
+++ b/integrations/openai/src/databricks_openai/vector_search_retriever_tool.py
@@ -113,7 +113,7 @@ class VectorSearchRetrieverTool(VectorSearchRetrieverToolMixin):
         self.columns = validate_and_get_return_columns(
             self.columns or [], self.text_column, self._index_details
         )
-        self.retriever_schema = RetrieverSchema(
+        self._retriever_schema = RetrieverSchema(
             text_column=self.text_column,
             doc_uri=self.doc_uri,
             chunk_id=self.chunk_id,
@@ -206,7 +206,7 @@ class VectorSearchRetrieverTool(VectorSearchRetrieverToolMixin):
         )
         docs_with_score: List[Tuple[Dict, float]] = parse_vector_search_response(
             search_resp=search_resp,
-            retriever_schema=self.retriever_schema,
+            retriever_schema=self._retriever_schema,
             document_class=dict,
         )
         return [doc for doc, _ in docs_with_score]

--- a/src/databricks_ai_bridge/test_utils/vector_search.py
+++ b/src/databricks_ai_bridge/test_utils/vector_search.py
@@ -26,6 +26,7 @@ EXAMPLE_SEARCH_RESPONSE = {
             {"name": "id"},
             {"name": "text"},
             {"name": "text_vector"},
+            {"name": "uri"},
             {"name": "score"},
         ],
     },
@@ -33,7 +34,7 @@ EXAMPLE_SEARCH_RESPONSE = {
         "row_count": len(INPUT_TEXTS),
         "data_array": sorted(
             [
-                [str(uuid.uuid4()), s, e, 0.5]
+                [str(uuid.uuid4()), s, e, "doc_uri", 0.5]
                 for s, e in zip(INPUT_TEXTS, embed_documents(INPUT_TEXTS))
             ],
             key=lambda x: x[2],  # type: ignore

--- a/src/databricks_ai_bridge/utils/vector_search.py
+++ b/src/databricks_ai_bridge/utils/vector_search.py
@@ -76,8 +76,9 @@ def get_metadata(columns: List[str], result: List[], doc_uri, chunk_id, other_co
             metadata["doc_uri"] = value
         elif col == chunk_id:
             metadata["chunk_id"] = value
-        elif other_columns and col in other_columns:
-            metadata[col] = value
+        elif other_columns:
+            if col in other_columns:
+                metadata[col] = value
         elif col not in ignore_cols:
             metadata[col] = value
     return metadata

--- a/src/databricks_ai_bridge/utils/vector_search.py
+++ b/src/databricks_ai_bridge/utils/vector_search.py
@@ -76,6 +76,10 @@ def get_metadata(columns: List[str], result: List[Any], retriever_schema, ignore
             metadata["doc_uri"] = value
         elif col == retriever_schema.primary_key:
             metadata["chunk_id"] = value
+        elif col == "doc_uri" and retriever_schema.doc_uri:
+            continue
+        elif col == "chunk_id" and retriever_schema.primary_key:
+            continue
         elif col in ignore_cols:  # ignore_cols has precedence over other_columns
             continue
         elif retriever_schema.other_columns is not None:

--- a/src/databricks_ai_bridge/utils/vector_search.py
+++ b/src/databricks_ai_bridge/utils/vector_search.py
@@ -86,7 +86,7 @@ def get_metadata(columns: List[str], result: List[Any], retriever_schema, ignore
         Dict[str, Any]: A dictionary containing extracted metadata.
     """
     metadata = {}
-    
+
     # Skipping the last column, which is always the score
     for col, value in zip(columns[:-1], result[:-1]):
         if col == retriever_schema.doc_uri:

--- a/src/databricks_ai_bridge/utils/vector_search.py
+++ b/src/databricks_ai_bridge/utils/vector_search.py
@@ -65,7 +65,7 @@ class IndexDetails:
 class RetrieverSchema:
     text_column: str = None
     doc_uri: Optional[str] = None
-    chunk_id: Optional[str] = None
+    primary_key: Optional[str] = None
     other_columns: Optional[List[str]] = None
 
 
@@ -74,7 +74,7 @@ def get_metadata(columns: List[str], result: List[Any], retriever_schema, ignore
     for col, value in zip(columns[:-1], result[:-1]):
         if col == retriever_schema.doc_uri:
             metadata["doc_uri"] = value
-        elif col == retriever_schema.chunk_id:
+        elif col == retriever_schema.primary_key:
             metadata["chunk_id"] = value
         elif col in ignore_cols:  # ignore_cols has precedence over other_columns
             continue

--- a/src/databricks_ai_bridge/utils/vector_search.py
+++ b/src/databricks_ai_bridge/utils/vector_search.py
@@ -138,7 +138,11 @@ def validate_and_get_text_column(text_column: Optional[str], index_details: Inde
 
 
 def validate_and_get_return_columns(
-    columns: List[str], text_column: str, index_details: IndexDetails, doc_uri: str, primary_key: str
+    columns: List[str],
+    text_column: str,
+    index_details: IndexDetails,
+    doc_uri: str,
+    primary_key: str,
 ) -> List[str]:
     """
     Get a list of columns to retrieve from the index.

--- a/src/databricks_ai_bridge/utils/vector_search.py
+++ b/src/databricks_ai_bridge/utils/vector_search.py
@@ -78,7 +78,7 @@ def get_metadata(columns: List[str], result: List[Any], retriever_schema, ignore
             metadata["chunk_id"] = value
         elif col in ignore_cols:  # ignore_cols has precedence over other_columns
             continue
-        elif retriever_schema.other_columns:
+        elif retriever_schema.other_columns is not None:
             if col in retriever_schema.other_columns:
                 metadata[col] = value
         else:

--- a/src/databricks_ai_bridge/utils/vector_search.py
+++ b/src/databricks_ai_bridge/utils/vector_search.py
@@ -138,7 +138,7 @@ def validate_and_get_text_column(text_column: Optional[str], index_details: Inde
 
 
 def validate_and_get_return_columns(
-    columns: List[str], text_column: str, index_details: IndexDetails
+    columns: List[str], text_column: str, index_details: IndexDetails, doc_uri: str, primary_key: str
 ) -> List[str]:
     """
     Get a list of columns to retrieve from the index.
@@ -149,6 +149,10 @@ def validate_and_get_return_columns(
         columns.append(index_details.primary_key)
     if text_column and text_column not in columns:
         columns.append(text_column)
+    if doc_uri and doc_uri not in columns:
+        columns.append(doc_uri)
+    if primary_key and primary_key not in columns:
+        columns.append(primary_key)
 
     # Validate specified columns are in the index
     if index_details.is_direct_access_index() and (index_schema := index_details.schema):

--- a/src/databricks_ai_bridge/vector_search_retriever_tool.py
+++ b/src/databricks_ai_bridge/vector_search_retriever_tool.py
@@ -74,7 +74,7 @@ class VectorSearchRetrieverToolMixin(BaseModel):
     doc_uri: Optional[str] = Field(
         None, description="The URI for the document, used for rendering a link in the UI."
     )
-    chunk_id: Optional[str] = Field(
+    primary_key: Optional[str] = Field(
         None,
         description="Identifies the chunk that the document is a part of. This is used by some evaluation metrics.",
     )

--- a/src/databricks_ai_bridge/vector_search_retriever_tool.py
+++ b/src/databricks_ai_bridge/vector_search_retriever_tool.py
@@ -54,22 +54,38 @@ class VectorSearchRetrieverToolMixin(BaseModel):
     index_name: str = Field(
         ..., description="The name of the index to use, format: 'catalog.schema.index'."
     )
-    num_results: int = Field(5, description="The number of results to return.")
+    num_results: int = Field(
+        5, description="The number of results to return."
+    )
     columns: Optional[List[str]] = Field(
         None, description="Columns to return when doing the search."
     )
-    filters: Optional[Dict[str, Any]] = Field(None, description="Filters to apply to the search.")
+    filters: Optional[Dict[str, Any]] = Field(
+        None, description="Filters to apply to the search."
+    )
     query_type: str = Field(
         "ANN", description="The type of this query. Supported values are 'ANN' and 'HYBRID'."
     )
-    tool_name: Optional[str] = Field(None, description="The name of the retrieval tool.")
-    tool_description: Optional[str] = Field(None, description="A description of the tool.")
+    tool_name: Optional[str] = Field(
+        None, description="The name of the retrieval tool."
+    )
+    tool_description: Optional[str] = Field(
+        None, description="A description of the tool."
+    )
     resources: Optional[List[dict]] = Field(
         None, description="Resources required to log a model that uses this tool."
     )
     workspace_client: Optional[WorkspaceClient] = Field(
-        default=None,
-        description="When specified, will use workspace client credential strategy to instantiate VectorSearchClient",
+        None,
+        description="When specified, will use workspace client credential strategy to instantiate VectorSearchClient"
+    )
+    doc_uri: Optional[str] = Field(
+        None,
+        description="The URI for the document, used for rendering a link in the UI."
+    )
+    chunk_id: Optional[str] = Field(
+        None,
+        description="Identifies the chunk that the document is a part of. This is used by some evaluation metrics."
     )
 
     @validator("tool_name")

--- a/src/databricks_ai_bridge/vector_search_retriever_tool.py
+++ b/src/databricks_ai_bridge/vector_search_retriever_tool.py
@@ -54,38 +54,29 @@ class VectorSearchRetrieverToolMixin(BaseModel):
     index_name: str = Field(
         ..., description="The name of the index to use, format: 'catalog.schema.index'."
     )
-    num_results: int = Field(
-        5, description="The number of results to return."
-    )
+    num_results: int = Field(5, description="The number of results to return.")
     columns: Optional[List[str]] = Field(
         None, description="Columns to return when doing the search."
     )
-    filters: Optional[Dict[str, Any]] = Field(
-        None, description="Filters to apply to the search."
-    )
+    filters: Optional[Dict[str, Any]] = Field(None, description="Filters to apply to the search.")
     query_type: str = Field(
         "ANN", description="The type of this query. Supported values are 'ANN' and 'HYBRID'."
     )
-    tool_name: Optional[str] = Field(
-        None, description="The name of the retrieval tool."
-    )
-    tool_description: Optional[str] = Field(
-        None, description="A description of the tool."
-    )
+    tool_name: Optional[str] = Field(None, description="The name of the retrieval tool.")
+    tool_description: Optional[str] = Field(None, description="A description of the tool.")
     resources: Optional[List[dict]] = Field(
         None, description="Resources required to log a model that uses this tool."
     )
     workspace_client: Optional[WorkspaceClient] = Field(
         None,
-        description="When specified, will use workspace client credential strategy to instantiate VectorSearchClient"
+        description="When specified, will use workspace client credential strategy to instantiate VectorSearchClient",
     )
     doc_uri: Optional[str] = Field(
-        None,
-        description="The URI for the document, used for rendering a link in the UI."
+        None, description="The URI for the document, used for rendering a link in the UI."
     )
     chunk_id: Optional[str] = Field(
         None,
-        description="Identifies the chunk that the document is a part of. This is used by some evaluation metrics."
+        description="Identifies the chunk that the document is a part of. This is used by some evaluation metrics.",
     )
 
     @validator("tool_name")

--- a/tests/databricks_ai_bridge/utils/test_vector_search.py
+++ b/tests/databricks_ai_bridge/utils/test_vector_search.py
@@ -110,8 +110,8 @@ def construct_docs_with_score(
                 column_4=None,
             ),
         ),
-        (  # Test mapping doc_uri and chunk_id
-            RetrieverSchema(text_column="column_1", doc_uri="column_2", chunk_id="column_3"),
+        (  # Test mapping doc_uri and primary_key
+            RetrieverSchema(text_column="column_1", doc_uri="column_2", primary_key="column_3"),
             None,
             construct_docs_with_score(
                 page_content="column_1",
@@ -120,8 +120,8 @@ def construct_docs_with_score(
                 column_3="chunk_id",
             ),
         ),
-        (  # doc_uri and chunk_id takes precendence over ignore_cols
-            RetrieverSchema(text_column="column_2", doc_uri="column_1", chunk_id="column_3"),
+        (  # doc_uri and primary_key takes precendence over ignore_cols
+            RetrieverSchema(text_column="column_2", doc_uri="column_1", primary_key="column_3"),
             ["column_1", "column_3"],
             construct_docs_with_score(
                 page_content="column_2",

--- a/tests/databricks_ai_bridge/utils/test_vector_search.py
+++ b/tests/databricks_ai_bridge/utils/test_vector_search.py
@@ -1,0 +1,168 @@
+import pytest
+from langchain_core.documents import Document
+
+from databricks_ai_bridge.utils.vector_search import RetrieverSchema, parse_vector_search_response
+
+search_resp = {
+    "manifest": {
+        "column_count": 2,
+        "columns": [{"name": f"column_{i}"} for i in range(1, 5)] + [{"name": "score"}],
+    },
+    "result": {
+        "data_array": [
+            ["row 1, column 1", "row 1, column 2", 100, 5.8, 0.673],
+            ["row 2, column 1", "row 2, column 2", 200, 4.1, 0.236],
+        ]
+    },
+}
+
+
+def construct_docs_with_score(
+    page_content,
+    column_1="column_1",
+    column_2="column_2",
+    column_3="column_3",
+    column_4="column_4",
+    document_class=dict,
+):
+    """
+    Constructs a list of documents with associated scores for a search response,
+    using a provided document class (e.g., dict or a custom class).
+
+    Args:
+        page_content (str): The name of the column whose value should be mapped to the "page_content" field
+            in the constructed document. Must match one of the column names.
+        column_1 (str or None): Optional. If None, this column is excluded from the output. Otherwise,
+            includes this column in the output documents under the specified key. Defaults to "column_1".
+        column_2 (str or None): Optional. Same behavior as column_1.
+        column_3 (str or None): Optional. Same behavior as above.
+        column_4 (str or None): Optional. Same behavior as above.
+        document_class (type): The class to use when constructing the document objects. Typically `dict`,
+            but can be a custom class. Defaults to `dict`.
+
+    Returns:
+        List[document_class]: A list of constructed document objects containing the selected columns,
+        with one of them mapped as "page_content".
+    """
+
+    return [
+        (
+            document_class(
+                page_content=f"row 1, column {page_content[-1]}",
+                metadata={
+                    **({column_1: "row 1, column 1"} if column_1 else {}),
+                    **({column_2: "row 1, column 2"} if column_2 else {}),
+                    **({column_3: 100} if column_3 else {}),
+                    **({column_4: 5.8} if column_4 else {}),
+                },
+            ),
+            0.673,
+        ),
+        (
+            document_class(
+                page_content=f"row 2, column {page_content[-1]}",
+                metadata={
+                    **({column_1: "row 2, column 1"} if column_1 else {}),
+                    **({column_2: "row 2, column 2"} if column_2 else {}),
+                    **({column_3: 200} if column_3 else {}),
+                    **({column_4: 4.1} if column_4 else {}),
+                },
+            ),
+            0.236,
+        ),
+    ]
+
+
+def generate_parse_vector_search_response_test_cases():
+    test_cases = []
+    for document_class in [dict, Document]:
+        test_cases.extend(
+            [
+                (  # Simple test case, only setting text_column
+                    document_class,
+                    RetrieverSchema(text_column="column_1"),
+                    None,
+                    construct_docs_with_score(
+                        page_content="column_1", column_1=None, document_class=document_class
+                    ),
+                ),
+                (  # Ensure that "ignore_cols" works
+                    document_class,
+                    RetrieverSchema(text_column="column_1"),
+                    ["column_3"],
+                    construct_docs_with_score(
+                        page_content="column_1",
+                        column_1=None,
+                        column_3=None,
+                        document_class=document_class,
+                    ),
+                ),
+                (  # ignore_cols takes precedence over other_cols
+                    document_class,
+                    RetrieverSchema(text_column="column_1", other_columns=["column_3", "column_4"]),
+                    ["column_3"],
+                    construct_docs_with_score(
+                        page_content="column_1",
+                        column_1=None,
+                        column_2=None,
+                        column_3=None,
+                        document_class=document_class,
+                    ),
+                ),
+                (  # page_content takes precedence over other_cols (shouldn't be included in metadata)
+                    document_class,
+                    RetrieverSchema(text_column="column_1", other_columns=["column_1"]),
+                    None,
+                    construct_docs_with_score(
+                        page_content="column_1",
+                        column_1=None,
+                        column_2=None,
+                        column_3=None,
+                        column_4=None,
+                        document_class=document_class,
+                    ),
+                ),
+                (  # Test mapping doc_uri and chunk_id
+                    document_class,
+                    RetrieverSchema(
+                        text_column="column_1", doc_uri="column_2", chunk_id="column_3"
+                    ),
+                    None,
+                    construct_docs_with_score(
+                        page_content="column_1",
+                        column_1=None,
+                        column_2="doc_uri",
+                        column_3="chunk_id",
+                        document_class=document_class,
+                    ),
+                ),
+                (  # doc_uri and chunk_id takes precendence over ignore_cols
+                    document_class,
+                    RetrieverSchema(
+                        text_column="column_2", doc_uri="column_1", chunk_id="column_3"
+                    ),
+                    ["column_1", "column_3"],
+                    construct_docs_with_score(
+                        page_content="column_2",
+                        column_1="doc_uri",
+                        column_2=None,
+                        column_3="chunk_id",
+                        document_class=document_class,
+                    ),
+                ),
+            ]
+        )
+    return test_cases
+
+
+@pytest.mark.parametrize(
+    "document_class,retriever_schema,ignore_cols,docs_with_score",
+    generate_parse_vector_search_response_test_cases(),
+)
+def test_parse_vector_search_response(
+    retriever_schema, ignore_cols, document_class, docs_with_score
+):
+    assert (
+        parse_vector_search_response(search_resp, retriever_schema, ignore_cols, document_class)
+        == docs_with_score
+    )

--- a/tests/databricks_ai_bridge/utils/test_vector_search.py
+++ b/tests/databricks_ai_bridge/utils/test_vector_search.py
@@ -73,7 +73,7 @@ def construct_docs_with_score(
 
 
 @pytest.mark.parametrize(
-    "document_class,retriever_schema,ignore_cols,docs_with_score",
+    "retriever_schema,ignore_cols,docs_with_score",
     [
         (  # Simple test case, only setting text_column
             RetrieverSchema(text_column="column_1"),

--- a/tests/databricks_ai_bridge/utils/test_vector_search.py
+++ b/tests/databricks_ai_bridge/utils/test_vector_search.py
@@ -17,59 +17,42 @@ search_resp = {
 
 
 def construct_docs_with_score(
-    page_content,
-    column_1="column_1",
-    column_2="column_2",
-    column_3="column_3",
-    column_4="column_4",
+    page_content_column: str,
+    column_1: str = None,
+    column_2: str = None,
+    column_3: str = None,
+    column_4: str = None,
     document_class=dict,
 ):
     """
-    Constructs a list of documents with associated scores for a search response,
-    using a provided document class (e.g., dict or a custom class).
+    Constructs a list of (document, score) tuples based on simulated search response data.
 
     Args:
-        page_content (str): The name of the column whose value should be mapped to the "page_content" field
-            in the constructed document. Must match one of the column names.
-        column_1 (str or None): Optional. If None, this column is excluded from the output. Otherwise,
-            includes this column in the output documents under the specified key. Defaults to "column_1".
-        column_2 (str or None): Optional. Same behavior as column_1.
-        column_3 (str or None): Optional. Same behavior as above.
-        column_4 (str or None): Optional. Same behavior as above.
-        document_class (type): The class to use when constructing the document objects. Typically `dict`,
-            but can be a custom class. Defaults to `dict`.
+        page_content_column: The name of the column to use for page_content.
+        column_1, column_2, column_3, column_4: Column names to include in metadata. Excluded if set to None.
+        document_class: Type used to construct each document (e.g., dict or custom class).
 
     Returns:
-        List[document_class]: A list of constructed document objects containing the selected columns,
-        with one of them mapped as "page_content".
+        List of (document_class, score) tuples.
     """
 
-    return [
-        (
-            document_class(
-                page_content=f"row 1, column {page_content[-1]}",
-                metadata={
-                    **({column_1: "row 1, column 1"} if column_1 else {}),
-                    **({column_2: "row 1, column 2"} if column_2 else {}),
-                    **({column_3: 100} if column_3 else {}),
-                    **({column_4: 5.8} if column_4 else {}),
-                },
-            ),
-            0.673,
-        ),
-        (
-            document_class(
-                page_content=f"row 2, column {page_content[-1]}",
-                metadata={
-                    **({column_1: "row 2, column 1"} if column_1 else {}),
-                    **({column_2: "row 2, column 2"} if column_2 else {}),
-                    **({column_3: 200} if column_3 else {}),
-                    **({column_4: 4.1} if column_4 else {}),
-                },
-            ),
-            0.236,
-        ),
-    ]
+    def make_document(row_index: int, score: float):
+        num_cols = [[100, 5.8], [200, 4.1]]
+
+        metadata = {}
+        if column_1:
+            metadata[column_1] = f"row {row_index+1}, column 1"
+        if column_2:
+            metadata[column_2] = f"row {row_index+1}, column 2"
+        if column_3:
+            metadata[column_3] = num_cols[row_index][0]
+        if column_4:
+            metadata[column_4] = num_cols[row_index][1]
+
+        page_content = f"row {row_index+1}, column {page_content_column[-1]}"
+        return (document_class(page_content=page_content, metadata=metadata), score)
+
+    return [make_document(0, 0.673), make_document(1, 0.236)]
 
 
 @pytest.mark.parametrize(
@@ -78,56 +61,50 @@ def construct_docs_with_score(
         (  # Simple test case, only setting text_column
             RetrieverSchema(text_column="column_1"),
             None,
-            construct_docs_with_score(page_content="column_1", column_1=None),
+            construct_docs_with_score(
+                page_content_column="column_1",
+                column_2="column_2",
+                column_3="column_3",
+                column_4="column_4",
+            ),
         ),
         (  # Ensure that "ignore_cols" works
             RetrieverSchema(text_column="column_1"),
             ["column_3"],
             construct_docs_with_score(
-                page_content="column_1",
-                column_1=None,
-                column_3=None,
+                page_content_column="column_1",
+                column_2="column_2",
+                column_4="column_4",
             ),
         ),
         (  # ignore_cols takes precedence over other_cols
             RetrieverSchema(text_column="column_1", other_columns=["column_3", "column_4"]),
             ["column_3"],
-            construct_docs_with_score(
-                page_content="column_1",
-                column_1=None,
-                column_2=None,
-                column_3=None,
-            ),
+            construct_docs_with_score(page_content_column="column_1", column_4="column_4"),
         ),
         (  # page_content takes precedence over other_cols (shouldn't be included in metadata)
             RetrieverSchema(text_column="column_1", other_columns=["column_1"]),
             None,
-            construct_docs_with_score(
-                page_content="column_1",
-                column_1=None,
-                column_2=None,
-                column_3=None,
-                column_4=None,
-            ),
+            construct_docs_with_score(page_content_column="column_1"),
         ),
         (  # Test mapping doc_uri and primary_key
             RetrieverSchema(text_column="column_1", doc_uri="column_2", primary_key="column_3"),
             None,
             construct_docs_with_score(
-                page_content="column_1",
-                column_1=None,
+                page_content_column="column_1",
                 column_2="doc_uri",
                 column_3="chunk_id",
+                column_4="column_4",
             ),
         ),
         (  # doc_uri and primary_key takes precendence over ignore_cols
             RetrieverSchema(text_column="column_2", doc_uri="column_1", primary_key="column_3"),
             ["column_1", "column_3"],
             construct_docs_with_score(
-                page_content="column_2",
+                page_content_column="column_2",
                 column_1="doc_uri",
-                column_2=None,
                 column_3="chunk_id",
+                column_4="column_4",
             ),
         ),
     ],

--- a/tests/databricks_ai_bridge/utils/test_vector_search.py
+++ b/tests/databricks_ai_bridge/utils/test_vector_search.py
@@ -1,5 +1,4 @@
 import pytest
-from langchain_core.documents import Document
 
 from databricks_ai_bridge.utils.vector_search import RetrieverSchema, parse_vector_search_response
 
@@ -73,96 +72,67 @@ def construct_docs_with_score(
     ]
 
 
-def generate_parse_vector_search_response_test_cases():
-    test_cases = []
-    for document_class in [dict, Document]:
-        test_cases.extend(
-            [
-                (  # Simple test case, only setting text_column
-                    document_class,
-                    RetrieverSchema(text_column="column_1"),
-                    None,
-                    construct_docs_with_score(
-                        page_content="column_1", column_1=None, document_class=document_class
-                    ),
-                ),
-                (  # Ensure that "ignore_cols" works
-                    document_class,
-                    RetrieverSchema(text_column="column_1"),
-                    ["column_3"],
-                    construct_docs_with_score(
-                        page_content="column_1",
-                        column_1=None,
-                        column_3=None,
-                        document_class=document_class,
-                    ),
-                ),
-                (  # ignore_cols takes precedence over other_cols
-                    document_class,
-                    RetrieverSchema(text_column="column_1", other_columns=["column_3", "column_4"]),
-                    ["column_3"],
-                    construct_docs_with_score(
-                        page_content="column_1",
-                        column_1=None,
-                        column_2=None,
-                        column_3=None,
-                        document_class=document_class,
-                    ),
-                ),
-                (  # page_content takes precedence over other_cols (shouldn't be included in metadata)
-                    document_class,
-                    RetrieverSchema(text_column="column_1", other_columns=["column_1"]),
-                    None,
-                    construct_docs_with_score(
-                        page_content="column_1",
-                        column_1=None,
-                        column_2=None,
-                        column_3=None,
-                        column_4=None,
-                        document_class=document_class,
-                    ),
-                ),
-                (  # Test mapping doc_uri and chunk_id
-                    document_class,
-                    RetrieverSchema(
-                        text_column="column_1", doc_uri="column_2", chunk_id="column_3"
-                    ),
-                    None,
-                    construct_docs_with_score(
-                        page_content="column_1",
-                        column_1=None,
-                        column_2="doc_uri",
-                        column_3="chunk_id",
-                        document_class=document_class,
-                    ),
-                ),
-                (  # doc_uri and chunk_id takes precendence over ignore_cols
-                    document_class,
-                    RetrieverSchema(
-                        text_column="column_2", doc_uri="column_1", chunk_id="column_3"
-                    ),
-                    ["column_1", "column_3"],
-                    construct_docs_with_score(
-                        page_content="column_2",
-                        column_1="doc_uri",
-                        column_2=None,
-                        column_3="chunk_id",
-                        document_class=document_class,
-                    ),
-                ),
-            ]
-        )
-    return test_cases
-
-
 @pytest.mark.parametrize(
     "document_class,retriever_schema,ignore_cols,docs_with_score",
-    generate_parse_vector_search_response_test_cases(),
+    [
+        (  # Simple test case, only setting text_column
+            RetrieverSchema(text_column="column_1"),
+            None,
+            construct_docs_with_score(page_content="column_1", column_1=None),
+        ),
+        (  # Ensure that "ignore_cols" works
+            RetrieverSchema(text_column="column_1"),
+            ["column_3"],
+            construct_docs_with_score(
+                page_content="column_1",
+                column_1=None,
+                column_3=None,
+            ),
+        ),
+        (  # ignore_cols takes precedence over other_cols
+            RetrieverSchema(text_column="column_1", other_columns=["column_3", "column_4"]),
+            ["column_3"],
+            construct_docs_with_score(
+                page_content="column_1",
+                column_1=None,
+                column_2=None,
+                column_3=None,
+            ),
+        ),
+        (  # page_content takes precedence over other_cols (shouldn't be included in metadata)
+            RetrieverSchema(text_column="column_1", other_columns=["column_1"]),
+            None,
+            construct_docs_with_score(
+                page_content="column_1",
+                column_1=None,
+                column_2=None,
+                column_3=None,
+                column_4=None,
+            ),
+        ),
+        (  # Test mapping doc_uri and chunk_id
+            RetrieverSchema(text_column="column_1", doc_uri="column_2", chunk_id="column_3"),
+            None,
+            construct_docs_with_score(
+                page_content="column_1",
+                column_1=None,
+                column_2="doc_uri",
+                column_3="chunk_id",
+            ),
+        ),
+        (  # doc_uri and chunk_id takes precendence over ignore_cols
+            RetrieverSchema(text_column="column_2", doc_uri="column_1", chunk_id="column_3"),
+            ["column_1", "column_3"],
+            construct_docs_with_score(
+                page_content="column_2",
+                column_1="doc_uri",
+                column_2=None,
+                column_3="chunk_id",
+            ),
+        ),
+    ],
 )
-def test_parse_vector_search_response(
-    retriever_schema, ignore_cols, document_class, docs_with_score
-):
+def test_parse_vector_search_response(retriever_schema, ignore_cols, docs_with_score):
     assert (
-        parse_vector_search_response(search_resp, retriever_schema, ignore_cols, document_class)
-        == docs_with_score
+        parse_vector_search_response(search_resp, retriever_schema, ignore_cols) == docs_with_score
     )


### PR DESCRIPTION
## What changes are proposed in this pull request?
- Support passing additional retriever fields like `doc_uri` and `chunk_id`
- Supporting fields as provided in `set_retriever_schema` https://mlflow.org/docs/latest/tracing/tracing-schema#retriever-spans and https://mlflow.org/docs/latest/tracing/tracing-schema#retriever-spans
- `primary_key` is mapped to the key `"chunk_id"` in metadata, but calling it `primary_key` in the `RetrieverSchema` to be consistent with the existing behavior of `set_retriever_schema`

## How is this tested?
- Unit tests
- Manual testing
<img width="272" alt="Screenshot 2025-04-10 at 5 13 09 PM" src="https://github.com/user-attachments/assets/39731d5b-a51f-4cdd-bf64-33497c6b7826" />
<img width="1533" alt="Screenshot 2025-04-10 at 5 13 03 PM" src="https://github.com/user-attachments/assets/feb5b678-dae0-4b53-9902-2357bf1956f6" />
