### PR TITLE
Support passing arbitrary kwargs through VectorSearchRetrieverTool

### DIFF
--- a/integrations/langchain/src/databricks_langchain/vector_search_retriever_tool.py
+++ b/integrations/langchain/src/databricks_langchain/vector_search_retriever_tool.py
@@ -65,7 +65,8 @@ class VectorSearchRetrieverTool(BaseTool, VectorSearchRetrieverToolMixin):
         return self
 
     @vector_search_retriever_tool_trace
-    def _run(self, query: str) -> str:
+    def _run(self, query: str, **kwargs) -> str:
+        combined_kwargs = {**kwargs, **(self.model_extra or {})}
         return self._vector_store.similarity_search(
-            query, k=self.num_results, filter=self.filters, query_type=self.query_type
+            query, k=self.num_results, filter=self.filters, query_type=self.query_type, **combined_kwargs
         )

--- a/integrations/langchain/src/databricks_langchain/vector_search_retriever_tool.py
+++ b/integrations/langchain/src/databricks_langchain/vector_search_retriever_tool.py
@@ -68,5 +68,9 @@ class VectorSearchRetrieverTool(BaseTool, VectorSearchRetrieverToolMixin):
     def _run(self, query: str, **kwargs) -> str:
         combined_kwargs = {**kwargs, **(self.model_extra or {})}
         return self._vector_store.similarity_search(
-            query, k=self.num_results, filter=self.filters, query_type=self.query_type, **combined_kwargs
+            query,
+            k=self.num_results,
+            filter=self.filters,
+            query_type=self.query_type,
+            **combined_kwargs,
         )

--- a/integrations/langchain/src/databricks_langchain/vector_search_retriever_tool.py
+++ b/integrations/langchain/src/databricks_langchain/vector_search_retriever_tool.py
@@ -66,11 +66,12 @@ class VectorSearchRetrieverTool(BaseTool, VectorSearchRetrieverToolMixin):
 
     @vector_search_retriever_tool_trace
     def _run(self, query: str, **kwargs) -> str:
-        combined_kwargs = {**kwargs, **(self.model_extra or {})}
-        return self._vector_store.similarity_search(
-            query,
-            k=self.num_results,
-            filter=self.filters,
-            query_type=self.query_type,
-            **combined_kwargs,
-        )
+        kwargs = {**kwargs, **(self.model_extra or {})}
+        # Ensure that we don't have duplicate keys
+        kwargs.update({
+            "query": query,
+            "k": self.num_results,
+            "filter": self.filters,
+            "query_type": self.query_type
+        })
+        return self._vector_store.similarity_search(**kwargs)

--- a/integrations/langchain/src/databricks_langchain/vector_search_retriever_tool.py
+++ b/integrations/langchain/src/databricks_langchain/vector_search_retriever_tool.py
@@ -69,10 +69,12 @@ class VectorSearchRetrieverTool(BaseTool, VectorSearchRetrieverToolMixin):
         kwargs = {**kwargs, **(self.model_extra or {})}
         combined_filters = {**(filters or {}), **(self.filters or {})}
         # Ensure that we don't have duplicate keys
-        kwargs.update({
-            "query": query,
-            "k": self.num_results,
-            "filter": combined_filters,
-            "query_type": self.query_type
-        })
+        kwargs.update(
+            {
+                "query": query,
+                "k": self.num_results,
+                "filter": combined_filters,
+                "query_type": self.query_type,
+            }
+        )
         return self._vector_store.similarity_search(**kwargs)

--- a/integrations/langchain/src/databricks_langchain/vectorstores.py
+++ b/integrations/langchain/src/databricks_langchain/vectorstores.py
@@ -461,14 +461,16 @@ class DatabricksVectorSearch(VectorStore):
 
         signature = inspect.signature(self.index.similarity_search)
         kwargs = {k: v for k, v in kwargs.items() if k in signature.parameters}
-        kwargs.update({
-            "columns": self._columns,
-            "query_text": query_text,
-            "query_vector": query_vector,
-            "filters": filter,
-            "num_results": k,
-            "query_type": query_type,
-        })
+        kwargs.update(
+            {
+                "columns": self._columns,
+                "query_text": query_text,
+                "query_vector": query_vector,
+                "filters": filter,
+                "num_results": k,
+                "query_type": query_type,
+            }
+        )
         search_resp = self.index.similarity_search(**kwargs)
         return parse_vector_search_response(
             search_resp, self._retriever_schema, document_class=Document

--- a/integrations/langchain/src/databricks_langchain/vectorstores.py
+++ b/integrations/langchain/src/databricks_langchain/vectorstores.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import inspect
 import logging
 import uuid
 from functools import partial
@@ -458,15 +459,17 @@ class DatabricksVectorSearch(VectorStore):
                 query_text = None
             query_vector = self._embeddings.embed_query(query)  # type: ignore[union-attr]
 
-        search_resp = self.index.similarity_search(
-            columns=self._columns,
-            query_text=query_text,
-            query_vector=query_vector,
-            filters=filter,
-            num_results=k,
-            query_type=query_type,
-            **kwargs,
-        )
+        signature = inspect.signature(self.index.similarity_search)
+        kwargs = {k: v for k, v in kwargs.items() if k in signature.parameters}
+        kwargs.update({
+            "columns": self._columns,
+            "query_text": query_text,
+            "query_vector": query_vector,
+            "filters": filter,
+            "num_results": k,
+            "query_type": query_type,
+        })
+        search_resp = self.index.similarity_search(**kwargs)
         return parse_vector_search_response(
             search_resp, self._retriever_schema, document_class=Document
         )

--- a/integrations/langchain/src/databricks_langchain/vectorstores.py
+++ b/integrations/langchain/src/databricks_langchain/vectorstores.py
@@ -465,6 +465,7 @@ class DatabricksVectorSearch(VectorStore):
             filters=filter,
             num_results=k,
             query_type=query_type,
+            **kwargs,
         )
         return parse_vector_search_response(
             search_resp, self._retriever_schema, document_class=Document
@@ -577,6 +578,7 @@ class DatabricksVectorSearch(VectorStore):
             filters=filter,
             num_results=k,
             query_type=query_type,
+            **kwargs,
         )
         return parse_vector_search_response(
             search_resp, self._retriever_schema, document_class=Document
@@ -696,6 +698,7 @@ class DatabricksVectorSearch(VectorStore):
             filters=filter,
             num_results=fetch_k,
             query_type=query_type,
+            **kwargs
         )
 
         embeddings_result_index = (

--- a/integrations/langchain/src/databricks_langchain/vectorstores.py
+++ b/integrations/langchain/src/databricks_langchain/vectorstores.py
@@ -698,7 +698,7 @@ class DatabricksVectorSearch(VectorStore):
             filters=filter,
             num_results=fetch_k,
             query_type=query_type,
-            **kwargs
+            **kwargs,
         )
 
         embeddings_result_index = (

--- a/integrations/langchain/tests/unit_tests/test_vector_search_retriever_tool.py
+++ b/integrations/langchain/tests/unit_tests/test_vector_search_retriever_tool.py
@@ -99,7 +99,7 @@ def test_filters_are_passed_through() -> None:
         {"query": "what cities are in Germany", "filters": {"country": "Germany"}}
     )
     vector_search_tool._vector_store.similarity_search.assert_called_once_with(
-        "what cities are in Germany",
+        query="what cities are in Germany",
         k=vector_search_tool.num_results,
         filter={"country": "Germany"},
         query_type=vector_search_tool.query_type,
@@ -114,7 +114,7 @@ def test_filters_are_combined() -> None:
         {"query": "what cities are in Germany", "filters": {"country": "Germany"}}
     )
     vector_search_tool._vector_store.similarity_search.assert_called_once_with(
-        "what cities are in Germany",
+        query="what cities are in Germany",
         k=vector_search_tool.num_results,
         filter={"city LIKE": "Berlin", "country": "Germany"},
         query_type=vector_search_tool.query_type,
@@ -315,10 +315,10 @@ def test_kwargs_are_passed_through() -> None:
         {"query": "what cities are in Germany", "extra_param": "something random"},
     )
     vector_search_tool._vector_store.similarity_search.assert_called_once_with(
-        "what cities are in Germany",
+        query="what cities are in Germany",
         k=vector_search_tool.num_results,
         query_type=vector_search_tool.query_type,
-        filter=None,
+        filter={},
         score_threshold=0.5,
         extra_param="something random",
     )

--- a/integrations/langchain/tests/unit_tests/test_vectorstores.py
+++ b/integrations/langchain/tests/unit_tests/test_vectorstores.py
@@ -304,6 +304,32 @@ def test_similarity_search_hybrid(index_name: str) -> None:
     assert all(["id" in d.metadata for d in search_result])
 
 
+def test_similarity_search_passing_kwargs() -> None:
+    vectorsearch = init_vector_search(DELTA_SYNC_INDEX)
+    query = "foo"
+    filters = {"some filter": True}
+    query_type="ANN"
+
+    search_result = vectorsearch.similarity_search(
+        query,
+        k=5,
+        filter=filters,
+        query_type=query_type,
+        score_threshold=0.5,
+        num_results=10,
+        random_parameters="not included"
+    )
+    vectorsearch.index.similarity_search.assert_called_once_with(
+        columns=["id", "text"],
+        query_text=query,
+        query_vector=None,
+        filters=filters,
+        query_type=query_type,
+        num_results=5, # maintained
+        score_threshold=0.5 # passed
+    )
+
+
 @pytest.mark.parametrize("index_name", ALL_INDEX_NAMES - {DELTA_SYNC_INDEX})
 @pytest.mark.parametrize(
     "columns, expected_columns",

--- a/integrations/langchain/tests/unit_tests/test_vectorstores.py
+++ b/integrations/langchain/tests/unit_tests/test_vectorstores.py
@@ -304,24 +304,6 @@ def test_similarity_search_hybrid(index_name: str) -> None:
     assert all(["id" in d.metadata for d in search_result])
 
 
-def test_similarity_search_both_filter_and_filters_passed() -> None:
-    vectorsearch = init_vector_search(DIRECT_ACCESS_INDEX)
-    query = "foo"
-    filter = {"some filter": True}
-    filters = {"some other filter": False}
-
-    vectorsearch.similarity_search(query, filter=filter, filters=filters)
-    vectorsearch.index.similarity_search.assert_called_once_with(
-        columns=["id", "text"],
-        query_vector=EMBEDDING_MODEL.embed_query(query),
-        # `filter` should prevail over `filters`
-        filters=filter,
-        num_results=4,
-        query_text=None,
-        query_type=None,
-    )
-
-
 @pytest.mark.parametrize("index_name", ALL_INDEX_NAMES - {DELTA_SYNC_INDEX})
 @pytest.mark.parametrize(
     "columns, expected_columns",

--- a/integrations/langchain/tests/unit_tests/test_vectorstores.py
+++ b/integrations/langchain/tests/unit_tests/test_vectorstores.py
@@ -308,7 +308,7 @@ def test_similarity_search_passing_kwargs() -> None:
     vectorsearch = init_vector_search(DELTA_SYNC_INDEX)
     query = "foo"
     filters = {"some filter": True}
-    query_type="ANN"
+    query_type = "ANN"
 
     search_result = vectorsearch.similarity_search(
         query,
@@ -317,7 +317,7 @@ def test_similarity_search_passing_kwargs() -> None:
         query_type=query_type,
         score_threshold=0.5,
         num_results=10,
-        random_parameters="not included"
+        random_parameters="not included",
     )
     vectorsearch.index.similarity_search.assert_called_once_with(
         columns=["id", "text"],
@@ -325,8 +325,8 @@ def test_similarity_search_passing_kwargs() -> None:
         query_vector=None,
         filters=filters,
         query_type=query_type,
-        num_results=5, # maintained
-        score_threshold=0.5 # passed
+        num_results=5,  # maintained
+        score_threshold=0.5,  # passed
     )
 
 

--- a/integrations/llamaindex/src/databricks_llamaindex/vector_search_retriever_tool.py
+++ b/integrations/llamaindex/src/databricks_llamaindex/vector_search_retriever_tool.py
@@ -76,7 +76,7 @@ class VectorSearchRetrieverTool(FunctionTool, VectorSearchRetrieverToolMixin):
         )
 
         # Define the similarity search function
-        def similarity_search(query: str) -> List[Dict[str, Any]]:
+        def similarity_search(query: str, **kwargs: Any) -> List[Dict[str, Any]]:
             def get_query_text_vector(query: str) -> Tuple[Optional[str], Optional[List[float]]]:
                 if self._index_details.is_databricks_managed_embeddings():
                     if self.embedding:
@@ -105,6 +105,7 @@ class VectorSearchRetrieverTool(FunctionTool, VectorSearchRetrieverToolMixin):
                 return text, vector
 
             query_text, query_vector = get_query_text_vector(query)
+            combined_kwargs = {**kwargs, **(self.model_extra or {})}
             search_resp = self._index.similarity_search(
                 columns=self.columns,
                 query_text=query_text,
@@ -112,6 +113,7 @@ class VectorSearchRetrieverTool(FunctionTool, VectorSearchRetrieverToolMixin):
                 filters=self.filters,
                 num_results=self.num_results,
                 query_type=self.query_type,
+                **combined_kwargs,
             )
             return parse_vector_search_response(
                 search_resp, self._retriever_schema, document_class=dict

--- a/integrations/llamaindex/src/databricks_llamaindex/vector_search_retriever_tool.py
+++ b/integrations/llamaindex/src/databricks_llamaindex/vector_search_retriever_tool.py
@@ -109,11 +109,11 @@ class VectorSearchRetrieverTool(FunctionTool, VectorSearchRetrieverToolMixin):
 
             query_text, query_vector = get_query_text_vector(query)
             combined_filters = {**(filters or {}), **(self.filters or {})}
-            
-            signature = inspect.signature(self.index.similarity_search)
+
+            signature = inspect.signature(self._index.similarity_search)
             kwargs = {**kwargs, **(self.model_extra or {})}
             kwargs = {k: v for k, v in kwargs.items() if k in signature.parameters}
-            
+
             # Ensure that we don't have duplicate keys
             kwargs.update(
                 {

--- a/integrations/llamaindex/src/databricks_llamaindex/vector_search_retriever_tool.py
+++ b/integrations/llamaindex/src/databricks_llamaindex/vector_search_retriever_tool.py
@@ -108,20 +108,23 @@ class VectorSearchRetrieverTool(FunctionTool, VectorSearchRetrieverToolMixin):
 
             query_text, query_vector = get_query_text_vector(query)
             filtered_model_extra = {
-                k: v for k, v in (self.model_extra or {}).items()
-                if k != "requires_context" # don't include extra parameters set by FunctionTool
+                k: v
+                for k, v in (self.model_extra or {}).items()
+                if k != "requires_context"  # don't include extra parameters set by FunctionTool
             }
             kwargs = {**kwargs, **filtered_model_extra}
             combined_filters = {**(filters or {}), **(self.filters or {})}
             # Ensure that we don't have duplicate keys
-            kwargs.update({
-                "query_text": query_text,
-                "query_vector": query_vector,
-                "columns": self.columns,
-                "filters": combined_filters,
-                "num_results": self.num_results,
-                "query_type": self.query_type
-            })
+            kwargs.update(
+                {
+                    "query_text": query_text,
+                    "query_vector": query_vector,
+                    "columns": self.columns,
+                    "filters": combined_filters,
+                    "num_results": self.num_results,
+                    "query_type": self.query_type,
+                }
+            )
             search_resp = self._index.similarity_search(**kwargs)
             return parse_vector_search_response(
                 search_resp, self._retriever_schema, document_class=dict

--- a/integrations/llamaindex/src/databricks_llamaindex/vector_search_retriever_tool.py
+++ b/integrations/llamaindex/src/databricks_llamaindex/vector_search_retriever_tool.py
@@ -107,7 +107,11 @@ class VectorSearchRetrieverTool(FunctionTool, VectorSearchRetrieverToolMixin):
                 return text, vector
 
             query_text, query_vector = get_query_text_vector(query)
-            kwargs = {**kwargs, **(self.model_extra or {})}
+            filtered_model_extra = {
+                k: v for k, v in (self.model_extra or {}).items()
+                if k != "requires_context" # don't include extra parameters set by FunctionTool
+            }
+            kwargs = {**kwargs, **filtered_model_extra}
             combined_filters = {**(filters or {}), **(self.filters or {})}
             # Ensure that we don't have duplicate keys
             kwargs.update({
@@ -118,7 +122,6 @@ class VectorSearchRetrieverTool(FunctionTool, VectorSearchRetrieverToolMixin):
                 "num_results": self.num_results,
                 "query_type": self.query_type
             })
-            print(kwargs)
             search_resp = self._index.similarity_search(**kwargs)
             return parse_vector_search_response(
                 search_resp, self._retriever_schema, document_class=dict

--- a/integrations/llamaindex/src/databricks_llamaindex/vector_search_retriever_tool.py
+++ b/integrations/llamaindex/src/databricks_llamaindex/vector_search_retriever_tool.py
@@ -107,17 +107,19 @@ class VectorSearchRetrieverTool(FunctionTool, VectorSearchRetrieverToolMixin):
                 return text, vector
 
             query_text, query_vector = get_query_text_vector(query)
-            combined_kwargs = {**kwargs, **(self.model_extra or {})}
+            kwargs = {**kwargs, **(self.model_extra or {})}
             combined_filters = {**(filters or {}), **(self.filters or {})}
-            search_resp = self._index.similarity_search(
-                columns=self.columns,
-                query_text=query_text,
-                query_vector=query_vector,
-                filters=combined_filters,
-                num_results=self.num_results,
-                query_type=self.query_type,
-                **combined_kwargs,
-            )
+            # Ensure that we don't have duplicate keys
+            kwargs.update({
+                "query_text": query_text,
+                "query_vector": query_vector,
+                "columns": self.columns,
+                "filters": combined_filters,
+                "num_results": self.num_results,
+                "query_type": self.query_type
+            })
+            print(kwargs)
+            search_resp = self._index.similarity_search(**kwargs)
             return parse_vector_search_response(
                 search_resp, self._retriever_schema, document_class=dict
             )

--- a/integrations/llamaindex/src/databricks_llamaindex/vector_search_retriever_tool.py
+++ b/integrations/llamaindex/src/databricks_llamaindex/vector_search_retriever_tool.py
@@ -1,3 +1,4 @@
+import inspect
 from typing import Any, Dict, List, Optional, Tuple
 
 from databricks_ai_bridge.utils.vector_search import (
@@ -107,13 +108,12 @@ class VectorSearchRetrieverTool(FunctionTool, VectorSearchRetrieverToolMixin):
                 return text, vector
 
             query_text, query_vector = get_query_text_vector(query)
-            filtered_model_extra = {
-                k: v
-                for k, v in (self.model_extra or {}).items()
-                if k != "requires_context"  # don't include extra parameters set by FunctionTool
-            }
-            kwargs = {**kwargs, **filtered_model_extra}
             combined_filters = {**(filters or {}), **(self.filters or {})}
+            
+            signature = inspect.signature(self.index.similarity_search)
+            kwargs = {**kwargs, **(self.model_extra or {})}
+            kwargs = {k: v for k, v in kwargs.items() if k in signature.parameters}
+            
             # Ensure that we don't have duplicate keys
             kwargs.update(
                 {

--- a/integrations/llamaindex/tests/unit_tests/test_vector_search_retriever_tool.py
+++ b/integrations/llamaindex/tests/unit_tests/test_vector_search_retriever_tool.py
@@ -1,11 +1,12 @@
 import os
 import threading
 from typing import Any, Dict, List, Optional
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, create_autospec, patch
 
 import pytest
 from databricks.sdk import WorkspaceClient
 from databricks.sdk.credentials_provider import ModelServingUserCredentials
+from databricks.vector_search.client import VectorSearchIndex
 from databricks.vector_search.utils import CredentialStrategy
 from databricks_ai_bridge.test_utils.vector_search import (  # noqa: F401
     ALL_INDEX_NAMES,
@@ -185,9 +186,12 @@ def test_vector_search_client_non_model_serving_environment():
 
 def test_kwargs_are_passed_through() -> None:
     vector_search_tool = init_vector_search_tool(DELTA_SYNC_INDEX, score_threshold=0.5)
-    vector_search_tool._index.similarity_search = MagicMock()
+    vector_search_tool._index = create_autospec(VectorSearchIndex, instance=True)
 
-    vector_search_tool.call(query="what cities are in Germany", extra_param="something random")
+    # extra_param is ignored because it isn't part of the signature for similarity_search
+    vector_search_tool.call(
+        query="what cities are in Germany", debug_level=2, extra_param="something random"
+    )
     vector_search_tool._index.similarity_search.assert_called_once_with(
         columns=vector_search_tool.columns,
         query_text="what cities are in Germany",
@@ -196,7 +200,7 @@ def test_kwargs_are_passed_through() -> None:
         query_vector=None,
         filters={},
         score_threshold=0.5,
-        extra_param="something random",
+        debug_level=2,
     )
 
 

--- a/integrations/llamaindex/tests/unit_tests/test_vector_search_retriever_tool.py
+++ b/integrations/llamaindex/tests/unit_tests/test_vector_search_retriever_tool.py
@@ -197,7 +197,6 @@ def test_kwargs_are_passed_through() -> None:
         filters={},
         score_threshold=0.5,
         extra_param="something random",
-        requires_context=False,
     )
 
 
@@ -213,7 +212,6 @@ def test_filters_are_passed_through() -> None:
         num_results=vector_search_tool.num_results,
         query_type=vector_search_tool.query_type,
         query_vector=None,
-        requires_context=False,
     )
 
 
@@ -229,5 +227,4 @@ def test_filters_are_combined() -> None:
         num_results=vector_search_tool.num_results,
         query_type=vector_search_tool.query_type,
         query_vector=None,
-        requires_context=False,
     )

--- a/integrations/llamaindex/tests/unit_tests/test_vector_search_retriever_tool.py
+++ b/integrations/llamaindex/tests/unit_tests/test_vector_search_retriever_tool.py
@@ -194,13 +194,13 @@ def test_kwargs_are_passed_through() -> None:
         num_results=vector_search_tool.num_results,
         query_type=vector_search_tool.query_type,
         query_vector=None,
-        filters=None,
+        filters={},
         score_threshold=0.5,
         extra_param="something random",
         requires_context=False,
     )
 
-    
+
 def test_filters_are_passed_through() -> None:
     vector_search_tool = init_vector_search_tool(DELTA_SYNC_INDEX)
     vector_search_tool._index.similarity_search = MagicMock()
@@ -213,6 +213,7 @@ def test_filters_are_passed_through() -> None:
         num_results=vector_search_tool.num_results,
         query_type=vector_search_tool.query_type,
         query_vector=None,
+        requires_context=False,
     )
 
 
@@ -228,4 +229,5 @@ def test_filters_are_combined() -> None:
         num_results=vector_search_tool.num_results,
         query_type=vector_search_tool.query_type,
         query_vector=None,
+        requires_context=False,
     )

--- a/integrations/openai/src/databricks_openai/vector_search_retriever_tool.py
+++ b/integrations/openai/src/databricks_openai/vector_search_retriever_tool.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Dict, List, Optional, Tuple
+from typing import Dict, List, Optional, Tuple, Any
 
 from databricks.vector_search.client import VectorSearchIndex
 from databricks_ai_bridge.utils.vector_search import (
@@ -162,6 +162,7 @@ class VectorSearchRetrieverTool(VectorSearchRetrieverToolMixin):
         self,
         query: str,
         openai_client: OpenAI = None,
+        **kwargs: Any
     ) -> List[Dict]:
         """
         Execute the VectorSearchIndex tool calls from the ChatCompletions response that correspond to the
@@ -202,6 +203,8 @@ class VectorSearchRetrieverTool(VectorSearchRetrieverToolMixin):
                     f"Expected embedding dimension {index_embedding_dimension} but got {len(query_vector)}"
                 )
 
+        combined_kwargs = {**kwargs, **(self.model_extra or {})}
+
         search_resp = self._index.similarity_search(
             columns=self.columns,
             query_text=query_text,
@@ -209,6 +212,7 @@ class VectorSearchRetrieverTool(VectorSearchRetrieverToolMixin):
             filters=self.filters,
             num_results=self.num_results,
             query_type=self.query_type,
+            **combined_kwargs
         )
         docs_with_score: List[Tuple[Dict, float]] = parse_vector_search_response(
             search_resp=search_resp,

--- a/integrations/openai/src/databricks_openai/vector_search_retriever_tool.py
+++ b/integrations/openai/src/databricks_openai/vector_search_retriever_tool.py
@@ -210,8 +210,8 @@ class VectorSearchRetrieverTool(VectorSearchRetrieverToolMixin):
                 )
 
         combined_filters = {**(filters or {}), **(self.filters or {})}
-        
-        signature = inspect.signature(self.index.similarity_search)
+
+        signature = inspect.signature(self._index.similarity_search)
         kwargs = {**kwargs, **(self.model_extra or {})}
         kwargs = {k: v for k, v in kwargs.items() if k in signature.parameters}
         kwargs.update(

--- a/integrations/openai/src/databricks_openai/vector_search_retriever_tool.py
+++ b/integrations/openai/src/databricks_openai/vector_search_retriever_tool.py
@@ -208,17 +208,19 @@ class VectorSearchRetrieverTool(VectorSearchRetrieverToolMixin):
                     f"Expected embedding dimension {index_embedding_dimension} but got {len(query_vector)}"
                 )
 
-        combined_kwargs = {**kwargs, **(self.model_extra or {})}
+        kwargs = {**kwargs, **(self.model_extra or {})}
         combined_filters = {**(filters or {}), **(self.filters or {})}
-        search_resp = self._index.similarity_search(
-            columns=self.columns,
-            query_text=query_text,
-            query_vector=query_vector,
-            filters=combined_filters,
-            num_results=self.num_results,
-            query_type=self.query_type,
-            **combined_kwargs,
+        kwargs.update(
+            {
+                "query_text": query_text,
+                "query_vector": query_vector,
+                "columns": self.columns,
+                "filters": combined_filters,
+                "num_results": self.num_results,
+                "query_type": self.query_type,
+            }
         )
+        search_resp = self._index.similarity_search(**kwargs)
         docs_with_score: List[Tuple[Dict, float]] = parse_vector_search_response(
             search_resp=search_resp,
             retriever_schema=self._retriever_schema,

--- a/integrations/openai/src/databricks_openai/vector_search_retriever_tool.py
+++ b/integrations/openai/src/databricks_openai/vector_search_retriever_tool.py
@@ -1,3 +1,4 @@
+import inspect
 import logging
 from typing import Any, Dict, List, Optional, Tuple
 
@@ -208,8 +209,11 @@ class VectorSearchRetrieverTool(VectorSearchRetrieverToolMixin):
                     f"Expected embedding dimension {index_embedding_dimension} but got {len(query_vector)}"
                 )
 
-        kwargs = {**kwargs, **(self.model_extra or {})}
         combined_filters = {**(filters or {}), **(self.filters or {})}
+        
+        signature = inspect.signature(self.index.similarity_search)
+        kwargs = {**kwargs, **(self.model_extra or {})}
+        kwargs = {k: v for k, v in kwargs.items() if k in signature.parameters}
         kwargs.update(
             {
                 "query_text": query_text,

--- a/integrations/openai/src/databricks_openai/vector_search_retriever_tool.py
+++ b/integrations/openai/src/databricks_openai/vector_search_retriever_tool.py
@@ -167,7 +167,7 @@ class VectorSearchRetrieverTool(VectorSearchRetrieverToolMixin):
         query: str,
         filters: Optional[Dict[str, Any]] = None,
         openai_client: OpenAI = None,
-        **kwargs: Any
+        **kwargs: Any,
     ) -> List[Dict]:
         """
         Execute the VectorSearchIndex tool calls from the ChatCompletions response that correspond to the

--- a/integrations/openai/src/databricks_openai/vector_search_retriever_tool.py
+++ b/integrations/openai/src/databricks_openai/vector_search_retriever_tool.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Dict, List, Optional, Tuple, Any
+from typing import Any, Dict, List, Optional, Tuple
 
 from databricks.vector_search.client import VectorSearchIndex
 from databricks_ai_bridge.utils.vector_search import (
@@ -158,12 +158,7 @@ class VectorSearchRetrieverTool(VectorSearchRetrieverToolMixin):
         return self
 
     @vector_search_retriever_tool_trace
-    def execute(
-        self,
-        query: str,
-        openai_client: OpenAI = None,
-        **kwargs: Any
-    ) -> List[Dict]:
+    def execute(self, query: str, openai_client: OpenAI = None, **kwargs: Any) -> List[Dict]:
         """
         Execute the VectorSearchIndex tool calls from the ChatCompletions response that correspond to the
         self.tool VectorSearchRetrieverToolInput and attach the retrieved documents into tool call messages.
@@ -212,7 +207,7 @@ class VectorSearchRetrieverTool(VectorSearchRetrieverToolMixin):
             filters=self.filters,
             num_results=self.num_results,
             query_type=self.query_type,
-            **combined_kwargs
+            **combined_kwargs,
         )
         docs_with_score: List[Tuple[Dict, float]] = parse_vector_search_response(
             search_resp=search_resp,

--- a/integrations/openai/tests/unit_tests/test_vector_search_retriever_tool.py
+++ b/integrations/openai/tests/unit_tests/test_vector_search_retriever_tool.py
@@ -2,12 +2,13 @@ import json
 import os
 import threading
 from typing import Any, Dict, List, Optional
-from unittest.mock import MagicMock, Mock, patch
+from unittest.mock import MagicMock, Mock, create_autospec, patch
 
 import mlflow
 import pytest
 from databricks.sdk import WorkspaceClient
 from databricks.sdk.credentials_provider import ModelServingUserCredentials
+from databricks.vector_search.client import VectorSearchIndex
 from databricks.vector_search.utils import CredentialStrategy
 from databricks_ai_bridge.test_utils.vector_search import (  # noqa: F401
     ALL_INDEX_NAMES,
@@ -307,9 +308,12 @@ def test_vector_search_client_non_model_serving_environment():
 
 def test_kwargs_are_passed_through() -> None:
     vector_search_tool = init_vector_search_tool(DELTA_SYNC_INDEX, score_threshold=0.5)
-    vector_search_tool._index.similarity_search = MagicMock()
+    vector_search_tool._index = create_autospec(VectorSearchIndex, instance=True)
 
-    vector_search_tool.execute(query="what cities are in Germany", extra_param="something random")
+    # extra_param is ignored because it isn't part of the signature for similarity_search
+    vector_search_tool.execute(
+        query="what cities are in Germany", debug_level=2, extra_param="something random"
+    )
     vector_search_tool._index.similarity_search.assert_called_once_with(
         columns=vector_search_tool.columns,
         query_text="what cities are in Germany",
@@ -318,7 +322,7 @@ def test_kwargs_are_passed_through() -> None:
         query_vector=None,
         filters={},
         score_threshold=0.5,
-        extra_param="something random",
+        debug_level=2,
     )
 
 

--- a/integrations/openai/tests/unit_tests/test_vector_search_retriever_tool.py
+++ b/integrations/openai/tests/unit_tests/test_vector_search_retriever_tool.py
@@ -1,7 +1,7 @@
 import json
 import os
 import threading
-from typing import Any, List, Optional
+from typing import Any, Dict, List, Optional
 from unittest.mock import MagicMock, Mock, patch
 
 import mlflow
@@ -316,7 +316,7 @@ def test_kwargs_are_passed_through() -> None:
         num_results=vector_search_tool.num_results,
         query_type=vector_search_tool.query_type,
         query_vector=None,
-        filters=None,
+        filters={},
         score_threshold=0.5,
         extra_param="something random",
     )

--- a/integrations/openai/tests/unit_tests/test_vector_search_retriever_tool.py
+++ b/integrations/openai/tests/unit_tests/test_vector_search_retriever_tool.py
@@ -298,3 +298,7 @@ def test_vector_search_client_non_model_serving_environment():
                 workspace_client=w,
             )
             mockVSClient.assert_called_once_with(disable_notice=True, credential_strategy=None)
+
+
+def test_pass_in_kwargs():
+    pass

--- a/src/databricks_ai_bridge/test_utils/vector_search.py
+++ b/src/databricks_ai_bridge/test_utils/vector_search.py
@@ -1,7 +1,7 @@
 import uuid
 from typing import Generator, List, Optional
 from unittest import mock
-from unittest.mock import create_autospec, MagicMock, patch
+from unittest.mock import MagicMock, create_autospec, patch
 
 import pytest
 from databricks.vector_search.client import VectorSearchIndex  # type: ignore

--- a/src/databricks_ai_bridge/test_utils/vector_search.py
+++ b/src/databricks_ai_bridge/test_utils/vector_search.py
@@ -1,7 +1,7 @@
 import uuid
 from typing import Generator, List, Optional
 from unittest import mock
-from unittest.mock import MagicMock, patch
+from unittest.mock import create_autospec, MagicMock, patch
 
 import pytest
 from databricks.vector_search.client import VectorSearchIndex  # type: ignore
@@ -132,7 +132,7 @@ def mock_vs_client() -> Generator:
         endpoint_name: Optional[str] = None,
         index_name: str = None,  # type: ignore
     ) -> MagicMock:
-        index = MagicMock(spec=VectorSearchIndex)
+        index = create_autospec(VectorSearchIndex, instance=True)
         if index_name not in INDEX_DETAILS:
             index_name = DIRECT_ACCESS_INDEX
         index.describe.return_value = INDEX_DETAILS[index_name]

--- a/src/databricks_ai_bridge/vector_search_retriever_tool.py
+++ b/src/databricks_ai_bridge/vector_search_retriever_tool.py
@@ -37,6 +37,7 @@ def vector_search_retriever_tool_trace(func):
 
 
 class VectorSearchRetrieverToolInput(BaseModel):
+    model_config = ConfigDict(extra="allow")
     query: str = Field(
         description="The string used to query the index with and identify the most similar "
         "vectors and return the associated documents."

--- a/src/databricks_ai_bridge/vector_search_retriever_tool.py
+++ b/src/databricks_ai_bridge/vector_search_retriever_tool.py
@@ -50,7 +50,7 @@ class VectorSearchRetrieverToolMixin(BaseModel):
     implementations should follow.
     """
 
-    model_config = ConfigDict(arbitrary_types_allowed=True)
+    model_config = ConfigDict(arbitrary_types_allowed=True, extra="allow")
     index_name: str = Field(
         ..., description="The name of the index to use, format: 'catalog.schema.index'."
     )


### PR DESCRIPTION
**Description of Changes**
- Add support for passing arbitrary kwargs through to VS similarity_search
- The user can either pass in kwargs during initialization, which will get passed all the way through, or pass in at query time
- In order for the LLM to be able to pass through arguments at query time, the user will have to update the args schema/tool spec/description appropriately for their use case.

**How is this tested?**
- [x] Unit tests
- [x] Manual test

OpenAI:
<img width="1291" alt="Screenshot 2025-05-06 at 2 39 34 PM" src="https://github.com/user-attachments/assets/a2a38037-a70d-44a8-8eae-c5f69d1f7f63" />

LlamaIndex:
<img width="1294" alt="Screenshot 2025-05-06 at 2 29 09 PM" src="https://github.com/user-attachments/assets/5e94f8d7-acda-467e-a9fd-b3732f9f608e" />

Langchain:
<img width="1143" alt="Screenshot 2025-05-06 at 3 03 07 PM" src="https://github.com/user-attachments/assets/f4ee3d5a-13c6-4877-90ad-404bb2d49226" />
