### PR TITLE
Ensure additionalProperties is not set for filters

### DIFF
--- a/integrations/langchain/src/databricks_langchain/vector_search_retriever_tool.py
+++ b/integrations/langchain/src/databricks_langchain/vector_search_retriever_tool.py
@@ -68,6 +68,8 @@ class VectorSearchRetrieverTool(BaseTool, VectorSearchRetrieverToolMixin):
     @vector_search_retriever_tool_trace
     def _run(self, query: str, filters: Optional[List[FilterItem]] = None, **kwargs) -> str:
         kwargs = {**kwargs, **(self.model_extra or {})}
+        if isinstance(filters, dict):
+            filters = FilterItem(filters)
         filters_dict = {item.key: item.value for item in (filters or [])}
         combined_filters = {**filters_dict, **(self.filters or {})}
         # Ensure that we don't have duplicate keys

--- a/integrations/langchain/src/databricks_langchain/vector_search_retriever_tool.py
+++ b/integrations/langchain/src/databricks_langchain/vector_search_retriever_tool.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, Optional, Type, List
+from typing import List, Optional, Type
 
 from databricks_ai_bridge.utils.vector_search import IndexDetails
 from databricks_ai_bridge.vector_search_retriever_tool import (

--- a/integrations/langchain/src/databricks_langchain/vector_search_retriever_tool.py
+++ b/integrations/langchain/src/databricks_langchain/vector_search_retriever_tool.py
@@ -68,6 +68,7 @@ class VectorSearchRetrieverTool(BaseTool, VectorSearchRetrieverToolMixin):
     @vector_search_retriever_tool_trace
     def _run(self, query: str, filters: Optional[List[FilterItem]] = None, **kwargs) -> str:
         kwargs = {**kwargs, **(self.model_extra or {})}
+        # Since LLM can generate either a dict or FilterItem, convert to dict always
         filters_dict = {dict(item)["key"]: dict(item)["value"] for item in (filters or [])}
         combined_filters = {**filters_dict, **(self.filters or {})}
         # Ensure that we don't have duplicate keys

--- a/integrations/langchain/src/databricks_langchain/vector_search_retriever_tool.py
+++ b/integrations/langchain/src/databricks_langchain/vector_search_retriever_tool.py
@@ -68,9 +68,7 @@ class VectorSearchRetrieverTool(BaseTool, VectorSearchRetrieverToolMixin):
     @vector_search_retriever_tool_trace
     def _run(self, query: str, filters: Optional[List[FilterItem]] = None, **kwargs) -> str:
         kwargs = {**kwargs, **(self.model_extra or {})}
-        if isinstance(filters, dict):
-            filters = FilterItem(filters)
-        filters_dict = {item.key: item.value for item in (filters or [])}
+        filters_dict = {dict(item)["key"]: dict(item)["value"] for item in (filters or [])}
         combined_filters = {**filters_dict, **(self.filters or {})}
         # Ensure that we don't have duplicate keys
         kwargs.update(

--- a/integrations/langchain/src/databricks_langchain/vector_search_retriever_tool.py
+++ b/integrations/langchain/src/databricks_langchain/vector_search_retriever_tool.py
@@ -68,7 +68,7 @@ class VectorSearchRetrieverTool(BaseTool, VectorSearchRetrieverToolMixin):
     @vector_search_retriever_tool_trace
     def _run(self, query: str, filters: Optional[List[FilterItem]] = None, **kwargs) -> str:
         kwargs = {**kwargs, **(self.model_extra or {})}
-        filters_dict = {item["key"]: item["value"] for item in (filters or [])}
+        filters_dict = {item.key: item.value for item in (filters or [])}
         combined_filters = {**filters_dict, **(self.filters or {})}
         # Ensure that we don't have duplicate keys
         kwargs.update(

--- a/integrations/langchain/src/databricks_langchain/vector_search_retriever_tool.py
+++ b/integrations/langchain/src/databricks_langchain/vector_search_retriever_tool.py
@@ -1,7 +1,8 @@
-from typing import Any, Dict, Optional, Type
+from typing import Any, Dict, Optional, Type, List
 
 from databricks_ai_bridge.utils.vector_search import IndexDetails
 from databricks_ai_bridge.vector_search_retriever_tool import (
+    FilterItem,
     VectorSearchRetrieverToolInput,
     VectorSearchRetrieverToolMixin,
     vector_search_retriever_tool_trace,
@@ -65,9 +66,10 @@ class VectorSearchRetrieverTool(BaseTool, VectorSearchRetrieverToolMixin):
         return self
 
     @vector_search_retriever_tool_trace
-    def _run(self, query: str, filters: Optional[Dict[str, Any]] = None, **kwargs) -> str:
+    def _run(self, query: str, filters: Optional[List[FilterItem]] = None, **kwargs) -> str:
         kwargs = {**kwargs, **(self.model_extra or {})}
-        combined_filters = {**(filters or {}), **(self.filters or {})}
+        filters_dict = {item["key"]: item["value"] for item in (filters or [])}
+        combined_filters = {**filters_dict, **(self.filters or {})}
         # Ensure that we don't have duplicate keys
         kwargs.update(
             {

--- a/integrations/langchain/tests/unit_tests/test_vector_search_retriever_tool.py
+++ b/integrations/langchain/tests/unit_tests/test_vector_search_retriever_tool.py
@@ -80,7 +80,7 @@ def init_vector_search_tool(
 def test_init(index_name: str) -> None:
     vector_search_tool = init_vector_search_tool(index_name)
     assert isinstance(vector_search_tool, BaseTool)
-    assert '"additionalProperties": true' not in str(vector_search_tool.args)
+    assert "'additionalProperties': true" not in str(vector_search_tool.args)
 
 
 @pytest.mark.parametrize("index_name", ALL_INDEX_NAMES)

--- a/integrations/langchain/tests/unit_tests/test_vector_search_retriever_tool.py
+++ b/integrations/langchain/tests/unit_tests/test_vector_search_retriever_tool.py
@@ -9,6 +9,7 @@ import pytest
 from databricks.sdk import WorkspaceClient
 from databricks.sdk.credentials_provider import ModelServingUserCredentials
 from databricks.vector_search.utils import CredentialStrategy
+from databricks_ai_bridge.vector_search_retriever_tool import FilterItem
 from databricks_ai_bridge.test_utils.vector_search import (  # noqa: F401
     ALL_INDEX_NAMES,
     DELTA_SYNC_INDEX,
@@ -79,8 +80,7 @@ def init_vector_search_tool(
 def test_init(index_name: str) -> None:
     vector_search_tool = init_vector_search_tool(index_name)
     assert isinstance(vector_search_tool, BaseTool)
-    schema_str = json.dumps(vector_search_tool.args_schema.model_json_schema())
-    assert '"additionalProperties": true' not in schema_str
+    assert '"additionalProperties": true' not in str(vector_search_tool.args)
 
 
 @pytest.mark.parametrize("index_name", ALL_INDEX_NAMES)
@@ -98,7 +98,7 @@ def test_filters_are_passed_through() -> None:
     vector_search_tool._vector_store.similarity_search = MagicMock()
 
     vector_search_tool.invoke(
-        {"query": "what cities are in Germany", "filters": [{"key": "country", "value": "Germany"}]}
+        {"query": "what cities are in Germany", "filters": [FilterItem(key="country", value="Germany")]}
     )
     vector_search_tool._vector_store.similarity_search.assert_called_once_with(
         query="what cities are in Germany",
@@ -113,7 +113,7 @@ def test_filters_are_combined() -> None:
     vector_search_tool._vector_store.similarity_search = MagicMock()
 
     vector_search_tool.invoke(
-        {"query": "what cities are in Germany", "filters": [{"key": "country", "value": "Germany"}]}
+        {"query": "what cities are in Germany", "filters": [FilterItem(key="country", value="Germany")]}
     )
     vector_search_tool._vector_store.similarity_search.assert_called_once_with(
         query="what cities are in Germany",

--- a/integrations/langchain/tests/unit_tests/test_vector_search_retriever_tool.py
+++ b/integrations/langchain/tests/unit_tests/test_vector_search_retriever_tool.py
@@ -79,6 +79,8 @@ def init_vector_search_tool(
 def test_init(index_name: str) -> None:
     vector_search_tool = init_vector_search_tool(index_name)
     assert isinstance(vector_search_tool, BaseTool)
+    schema_str = json.dumps(vector_search_tool.args_schema.model_json_schema())
+    assert '"additionalProperties": true' not in schema_str
 
 
 @pytest.mark.parametrize("index_name", ALL_INDEX_NAMES)
@@ -96,7 +98,7 @@ def test_filters_are_passed_through() -> None:
     vector_search_tool._vector_store.similarity_search = MagicMock()
 
     vector_search_tool.invoke(
-        {"query": "what cities are in Germany", "filters": {"country": "Germany"}}
+        {"query": "what cities are in Germany", "filters": [{"key": "country", "value": "Germany"}]}
     )
     vector_search_tool._vector_store.similarity_search.assert_called_once_with(
         query="what cities are in Germany",
@@ -111,7 +113,7 @@ def test_filters_are_combined() -> None:
     vector_search_tool._vector_store.similarity_search = MagicMock()
 
     vector_search_tool.invoke(
-        {"query": "what cities are in Germany", "filters": {"country": "Germany"}}
+        {"query": "what cities are in Germany", "filters": [{"key": "country", "value": "Germany"}]}
     )
     vector_search_tool._vector_store.similarity_search.assert_called_once_with(
         query="what cities are in Germany",

--- a/integrations/langchain/tests/unit_tests/test_vector_search_retriever_tool.py
+++ b/integrations/langchain/tests/unit_tests/test_vector_search_retriever_tool.py
@@ -9,7 +9,6 @@ import pytest
 from databricks.sdk import WorkspaceClient
 from databricks.sdk.credentials_provider import ModelServingUserCredentials
 from databricks.vector_search.utils import CredentialStrategy
-from databricks_ai_bridge.vector_search_retriever_tool import FilterItem
 from databricks_ai_bridge.test_utils.vector_search import (  # noqa: F401
     ALL_INDEX_NAMES,
     DELTA_SYNC_INDEX,
@@ -19,6 +18,7 @@ from databricks_ai_bridge.test_utils.vector_search import (  # noqa: F401
     mock_vs_client,
     mock_workspace_client,
 )
+from databricks_ai_bridge.vector_search_retriever_tool import FilterItem
 from langchain_core.embeddings import Embeddings
 from langchain_core.tools import BaseTool
 from mlflow.entities import SpanType
@@ -98,7 +98,10 @@ def test_filters_are_passed_through() -> None:
     vector_search_tool._vector_store.similarity_search = MagicMock()
 
     vector_search_tool.invoke(
-        {"query": "what cities are in Germany", "filters": [FilterItem(key="country", value="Germany")]}
+        {
+            "query": "what cities are in Germany",
+            "filters": [FilterItem(key="country", value="Germany")],
+        }
     )
     vector_search_tool._vector_store.similarity_search.assert_called_once_with(
         query="what cities are in Germany",
@@ -113,7 +116,10 @@ def test_filters_are_combined() -> None:
     vector_search_tool._vector_store.similarity_search = MagicMock()
 
     vector_search_tool.invoke(
-        {"query": "what cities are in Germany", "filters": [FilterItem(key="country", value="Germany")]}
+        {
+            "query": "what cities are in Germany",
+            "filters": [FilterItem(key="country", value="Germany")],
+        }
     )
     vector_search_tool._vector_store.similarity_search.assert_called_once_with(
         query="what cities are in Germany",

--- a/integrations/llamaindex/src/databricks_llamaindex/vector_search_retriever_tool.py
+++ b/integrations/llamaindex/src/databricks_llamaindex/vector_search_retriever_tool.py
@@ -109,6 +109,7 @@ class VectorSearchRetrieverTool(FunctionTool, VectorSearchRetrieverToolMixin):
                 return text, vector
 
             query_text, query_vector = get_query_text_vector(query)
+            # Since LLM can generate either a dict or FilterItem, convert to dict always
             filters_dict = {dict(item)["key"]: dict(item)["value"] for item in (filters or [])}
             combined_filters = {**filters_dict, **(self.filters or {})}
 

--- a/integrations/llamaindex/src/databricks_llamaindex/vector_search_retriever_tool.py
+++ b/integrations/llamaindex/src/databricks_llamaindex/vector_search_retriever_tool.py
@@ -2,7 +2,6 @@ import inspect
 from typing import Any, Dict, List, Optional, Tuple
 
 from databricks_ai_bridge.utils.vector_search import (
-    FilterItem,
     IndexDetails,
     RetrieverSchema,
     parse_vector_search_response,
@@ -10,6 +9,7 @@ from databricks_ai_bridge.utils.vector_search import (
     validate_and_get_text_column,
 )
 from databricks_ai_bridge.vector_search_retriever_tool import (
+    FilterItem,
     VectorSearchRetrieverToolInput,
     VectorSearchRetrieverToolMixin,
 )

--- a/integrations/llamaindex/src/databricks_llamaindex/vector_search_retriever_tool.py
+++ b/integrations/llamaindex/src/databricks_llamaindex/vector_search_retriever_tool.py
@@ -109,6 +109,8 @@ class VectorSearchRetrieverTool(FunctionTool, VectorSearchRetrieverToolMixin):
                 return text, vector
 
             query_text, query_vector = get_query_text_vector(query)
+            if isinstance(filters, dict):
+                filters = FilterItem(filters)
             filters_dict = {item.key: item.value for item in (filters or [])}
             combined_filters = {**filters_dict, **(self.filters or {})}
 

--- a/integrations/llamaindex/src/databricks_llamaindex/vector_search_retriever_tool.py
+++ b/integrations/llamaindex/src/databricks_llamaindex/vector_search_retriever_tool.py
@@ -2,6 +2,7 @@ import inspect
 from typing import Any, Dict, List, Optional, Tuple
 
 from databricks_ai_bridge.utils.vector_search import (
+    FilterItem,
     IndexDetails,
     RetrieverSchema,
     parse_vector_search_response,
@@ -78,7 +79,7 @@ class VectorSearchRetrieverTool(FunctionTool, VectorSearchRetrieverToolMixin):
 
         # Define the similarity search function
         def similarity_search(
-            query: str, filters: Optional[Dict[str, Any]] = None, **kwargs: Any
+            query: str, filters: Optional[List[FilterItem]] = None, **kwargs: Any
         ) -> List[Dict[str, Any]]:
             def get_query_text_vector(query: str) -> Tuple[Optional[str], Optional[List[float]]]:
                 if self._index_details.is_databricks_managed_embeddings():
@@ -108,7 +109,8 @@ class VectorSearchRetrieverTool(FunctionTool, VectorSearchRetrieverToolMixin):
                 return text, vector
 
             query_text, query_vector = get_query_text_vector(query)
-            combined_filters = {**(filters or {}), **(self.filters or {})}
+            filters_dict = {item["key"]: item["value"] for item in (filters or [])}
+            combined_filters = {**filters_dict, **(self.filters or {})}
 
             signature = inspect.signature(self._index.similarity_search)
             kwargs = {**kwargs, **(self.model_extra or {})}

--- a/integrations/llamaindex/src/databricks_llamaindex/vector_search_retriever_tool.py
+++ b/integrations/llamaindex/src/databricks_llamaindex/vector_search_retriever_tool.py
@@ -109,9 +109,7 @@ class VectorSearchRetrieverTool(FunctionTool, VectorSearchRetrieverToolMixin):
                 return text, vector
 
             query_text, query_vector = get_query_text_vector(query)
-            if isinstance(filters, dict):
-                filters = FilterItem(filters)
-            filters_dict = {item.key: item.value for item in (filters or [])}
+            filters_dict = {dict(item)["key"]: dict(item)["value"] for item in (filters or [])}
             combined_filters = {**filters_dict, **(self.filters or {})}
 
             signature = inspect.signature(self._index.similarity_search)

--- a/integrations/llamaindex/src/databricks_llamaindex/vector_search_retriever_tool.py
+++ b/integrations/llamaindex/src/databricks_llamaindex/vector_search_retriever_tool.py
@@ -109,7 +109,7 @@ class VectorSearchRetrieverTool(FunctionTool, VectorSearchRetrieverToolMixin):
                 return text, vector
 
             query_text, query_vector = get_query_text_vector(query)
-            filters_dict = {item["key"]: item["value"] for item in (filters or [])}
+            filters_dict = {item.key: item.value for item in (filters or [])}
             combined_filters = {**filters_dict, **(self.filters or {})}
 
             signature = inspect.signature(self._index.similarity_search)

--- a/integrations/llamaindex/tests/unit_tests/test_vector_search_retriever_tool.py
+++ b/integrations/llamaindex/tests/unit_tests/test_vector_search_retriever_tool.py
@@ -15,7 +15,7 @@ from databricks_ai_bridge.test_utils.vector_search import (  # noqa: F401
     mock_vs_client,
     mock_workspace_client,
 )
-from databricks_ai_bridge.vector_search_retriever_tool import VectorSearchRetrieverToolInput
+from databricks_ai_bridge.vector_search_retriever_tool import VectorSearchRetrieverToolInput, FilterItem
 from llama_index.core.agent import ReActAgent
 from llama_index.core.embeddings import BaseEmbedding
 from llama_index.core.tools import FunctionTool
@@ -81,6 +81,7 @@ def init_vector_search_tool(
 def test_init(index_name: str) -> None:
     vector_search_tool = init_vector_search_tool(index_name)
     assert isinstance(vector_search_tool, FunctionTool)
+    assert '"additionalProperties": true' not in str(vector_search_tool.dict())
 
 
 @pytest.mark.parametrize("index_name", ALL_INDEX_NAMES)
@@ -208,7 +209,7 @@ def test_filters_are_passed_through() -> None:
     vector_search_tool = init_vector_search_tool(DELTA_SYNC_INDEX)
     vector_search_tool._index.similarity_search = MagicMock()
 
-    vector_search_tool.call(query="what cities are in Germany", filters={"country": "Germany"})
+    vector_search_tool.call(query="what cities are in Germany", filters=[FilterItem(key="country", value="Germany")])
     vector_search_tool._index.similarity_search.assert_called_once_with(
         columns=vector_search_tool.columns,
         query_text="what cities are in Germany",
@@ -223,7 +224,7 @@ def test_filters_are_combined() -> None:
     vector_search_tool = init_vector_search_tool(DELTA_SYNC_INDEX, filters={"city LIKE": "Berlin"})
     vector_search_tool._index.similarity_search = MagicMock()
 
-    vector_search_tool.call(query="what cities are in Germany", filters={"country": "Germany"})
+    vector_search_tool.call(query="what cities are in Germany", filters=[FilterItem(key="country", value="Germany")])
     vector_search_tool._index.similarity_search.assert_called_once_with(
         columns=vector_search_tool.columns,
         query_text="what cities are in Germany",

--- a/integrations/llamaindex/tests/unit_tests/test_vector_search_retriever_tool.py
+++ b/integrations/llamaindex/tests/unit_tests/test_vector_search_retriever_tool.py
@@ -84,7 +84,9 @@ def init_vector_search_tool(
 def test_init(index_name: str) -> None:
     vector_search_tool = init_vector_search_tool(index_name)
     assert isinstance(vector_search_tool, FunctionTool)
-    assert '"additionalProperties": true' not in str(vector_search_tool.dict())
+    assert "'additionalProperties': true" not in str(
+        vector_search_tool.metadata.fn_schema.model_json_schema()
+    )
 
 
 @pytest.mark.parametrize("index_name", ALL_INDEX_NAMES)

--- a/integrations/llamaindex/tests/unit_tests/test_vector_search_retriever_tool.py
+++ b/integrations/llamaindex/tests/unit_tests/test_vector_search_retriever_tool.py
@@ -15,7 +15,10 @@ from databricks_ai_bridge.test_utils.vector_search import (  # noqa: F401
     mock_vs_client,
     mock_workspace_client,
 )
-from databricks_ai_bridge.vector_search_retriever_tool import VectorSearchRetrieverToolInput, FilterItem
+from databricks_ai_bridge.vector_search_retriever_tool import (
+    FilterItem,
+    VectorSearchRetrieverToolInput,
+)
 from llama_index.core.agent import ReActAgent
 from llama_index.core.embeddings import BaseEmbedding
 from llama_index.core.tools import FunctionTool
@@ -209,7 +212,9 @@ def test_filters_are_passed_through() -> None:
     vector_search_tool = init_vector_search_tool(DELTA_SYNC_INDEX)
     vector_search_tool._index.similarity_search = MagicMock()
 
-    vector_search_tool.call(query="what cities are in Germany", filters=[FilterItem(key="country", value="Germany")])
+    vector_search_tool.call(
+        query="what cities are in Germany", filters=[FilterItem(key="country", value="Germany")]
+    )
     vector_search_tool._index.similarity_search.assert_called_once_with(
         columns=vector_search_tool.columns,
         query_text="what cities are in Germany",
@@ -224,7 +229,9 @@ def test_filters_are_combined() -> None:
     vector_search_tool = init_vector_search_tool(DELTA_SYNC_INDEX, filters={"city LIKE": "Berlin"})
     vector_search_tool._index.similarity_search = MagicMock()
 
-    vector_search_tool.call(query="what cities are in Germany", filters=[FilterItem(key="country", value="Germany")])
+    vector_search_tool.call(
+        query="what cities are in Germany", filters=[FilterItem(key="country", value="Germany")]
+    )
     vector_search_tool._index.similarity_search.assert_called_once_with(
         columns=vector_search_tool.columns,
         query_text="what cities are in Germany",

--- a/integrations/openai/pyproject.toml
+++ b/integrations/openai/pyproject.toml
@@ -10,6 +10,7 @@ license = { text="Apache-2.0" }
 requires-python = ">=3.10"
 dependencies = [
     "databricks-vectorsearch>=0.50",
+    "langchain>=0.3.0",
     "databricks-ai-bridge>=0.4.2",
     "openai>=1.66.0",
     "pydantic>2.10.0",

--- a/integrations/openai/src/databricks_openai/vector_search_retriever_tool.py
+++ b/integrations/openai/src/databricks_openai/vector_search_retriever_tool.py
@@ -11,6 +11,7 @@ from databricks_ai_bridge.utils.vector_search import (
     validate_and_get_text_column,
 )
 from databricks_ai_bridge.vector_search_retriever_tool import (
+    FilterItem,
     VectorSearchRetrieverToolInput,
     VectorSearchRetrieverToolMixin,
     vector_search_retriever_tool_trace,
@@ -166,7 +167,7 @@ class VectorSearchRetrieverTool(VectorSearchRetrieverToolMixin):
     def execute(
         self,
         query: str,
-        filters: Optional[Dict[str, Any]] = None,
+        filters: Optional[List[FilterItem]] = None,
         openai_client: OpenAI = None,
         **kwargs: Any,
     ) -> List[Dict]:
@@ -209,7 +210,8 @@ class VectorSearchRetrieverTool(VectorSearchRetrieverToolMixin):
                     f"Expected embedding dimension {index_embedding_dimension} but got {len(query_vector)}"
                 )
 
-        combined_filters = {**(filters or {}), **(self.filters or {})}
+        filters_dict = {item["key"]: item["value"] for item in (filters or [])}
+        combined_filters = {**filters_dict, **(self.filters or {})}
 
         signature = inspect.signature(self._index.similarity_search)
         kwargs = {**kwargs, **(self.model_extra or {})}

--- a/integrations/openai/src/databricks_openai/vector_search_retriever_tool.py
+++ b/integrations/openai/src/databricks_openai/vector_search_retriever_tool.py
@@ -210,7 +210,7 @@ class VectorSearchRetrieverTool(VectorSearchRetrieverToolMixin):
                     f"Expected embedding dimension {index_embedding_dimension} but got {len(query_vector)}"
                 )
 
-        filters_dict = {item["key"]: item["value"] for item in (filters or [])}
+        filters_dict = {item.key: item.value for item in (filters or [])}
         combined_filters = {**filters_dict, **(self.filters or {})}
 
         signature = inspect.signature(self._index.similarity_search)

--- a/integrations/openai/src/databricks_openai/vector_search_retriever_tool.py
+++ b/integrations/openai/src/databricks_openai/vector_search_retriever_tool.py
@@ -217,8 +217,7 @@ class VectorSearchRetrieverTool(VectorSearchRetrieverToolMixin):
                     f"Expected embedding dimension {index_embedding_dimension} but got {len(query_vector)}"
                 )
 
-        if isinstance(filters, dict):
-            filters = FilterItem(filters)
+        # Since LLM can generate either a dict or FilterItem, convert to dict always
         filters_dict = {dict(item)["key"]: dict(item)["value"] for item in (filters or [])}
         combined_filters = {**filters_dict, **(self.filters or {})}
 

--- a/integrations/openai/src/databricks_openai/vector_search_retriever_tool.py
+++ b/integrations/openai/src/databricks_openai/vector_search_retriever_tool.py
@@ -147,7 +147,11 @@ class VectorSearchRetrieverTool(VectorSearchRetrieverToolMixin):
         if "function" in self.tool and "strict" in self.tool["function"]:
             del self.tool["function"]["strict"]
         # We need to remove additionalProperties from the tool in order to support arbitrary kwargs
-        if "function" in self.tool and "parameters" in self.tool["function"] and "additionalProperties" in self.tool["function"]["parameters"]:
+        if (
+            "function" in self.tool
+            and "parameters" in self.tool["function"]
+            and "additionalProperties" in self.tool["function"]["parameters"]
+        ):
             del self.tool["function"]["parameters"]["additionalProperties"]
 
         try:

--- a/integrations/openai/src/databricks_openai/vector_search_retriever_tool.py
+++ b/integrations/openai/src/databricks_openai/vector_search_retriever_tool.py
@@ -217,6 +217,8 @@ class VectorSearchRetrieverTool(VectorSearchRetrieverToolMixin):
                     f"Expected embedding dimension {index_embedding_dimension} but got {len(query_vector)}"
                 )
 
+        if isinstance(filters, dict):
+            filters = FilterItem(filters)
         filters_dict = {item.key: item.value for item in (filters or [])}
         combined_filters = {**filters_dict, **(self.filters or {})}
 

--- a/integrations/openai/src/databricks_openai/vector_search_retriever_tool.py
+++ b/integrations/openai/src/databricks_openai/vector_search_retriever_tool.py
@@ -219,7 +219,7 @@ class VectorSearchRetrieverTool(VectorSearchRetrieverToolMixin):
 
         if isinstance(filters, dict):
             filters = FilterItem(filters)
-        filters_dict = {item.key: item.value for item in (filters or [])}
+        filters_dict = {dict(item)["key"]: dict(item)["value"] for item in (filters or [])}
         combined_filters = {**filters_dict, **(self.filters or {})}
 
         signature = inspect.signature(self._index.similarity_search)

--- a/integrations/openai/src/databricks_openai/vector_search_retriever_tool.py
+++ b/integrations/openai/src/databricks_openai/vector_search_retriever_tool.py
@@ -146,6 +146,9 @@ class VectorSearchRetrieverTool(VectorSearchRetrieverToolMixin):
         # We need to remove strict: True from the tool in order to support arbitrary filters
         if "function" in self.tool and "strict" in self.tool["function"]:
             del self.tool["function"]["strict"]
+        # We need to remove additionalProperties from the tool in order to support arbitrary kwargs
+        if "function" in self.tool and "parameters" in self.tool["function"] and "additionalProperties" in self.tool["function"]["parameters"]:
+            del self.tool["function"]["parameters"]["additionalProperties"]
 
         try:
             from databricks.sdk import WorkspaceClient

--- a/integrations/openai/tests/unit_tests/test_vector_search_retriever_tool.py
+++ b/integrations/openai/tests/unit_tests/test_vector_search_retriever_tool.py
@@ -10,6 +10,7 @@ from databricks.sdk import WorkspaceClient
 from databricks.sdk.credentials_provider import ModelServingUserCredentials
 from databricks.vector_search.client import VectorSearchIndex
 from databricks.vector_search.utils import CredentialStrategy
+from databricks_ai_bridge.vector_search_retriever_tool import FilterItem
 from databricks_ai_bridge.test_utils.vector_search import (  # noqa: F401
     ALL_INDEX_NAMES,
     DELTA_SYNC_INDEX,
@@ -190,6 +191,9 @@ def test_vector_search_retriever_tool_init(
     outputs = json.loads(trace.to_dict()["data"]["spans"][0]["attributes"]["mlflow.spanOutputs"])
     assert [d["page_content"] in INPUT_TEXTS for d in outputs]
 
+    # Ensure that there aren't additional properties (not compatible with llama)
+    assert '"additionalProperties": true' not in str(vector_search_tool.dict())
+
 
 @pytest.mark.parametrize("columns", [None, ["id", "text"]])
 @pytest.mark.parametrize("tool_name", [None, "test_tool"])
@@ -331,7 +335,7 @@ def test_filters_are_passed_through() -> None:
     vector_search_tool._index.similarity_search = MagicMock()
 
     vector_search_tool.execute(
-        {"query": "what cities are in Germany"}, filters={"country": "Germany"}
+        {"query": "what cities are in Germany"}, filters=[FilterItem(key="country", value="Germany")]
     )
     vector_search_tool._index.similarity_search.assert_called_once_with(
         columns=vector_search_tool.columns,
@@ -347,7 +351,7 @@ def test_filters_are_combined() -> None:
     vector_search_tool = init_vector_search_tool(DELTA_SYNC_INDEX, filters={"city LIKE": "Berlin"})
     vector_search_tool._index.similarity_search = MagicMock()
 
-    vector_search_tool.execute(query="what cities are in Germany", filters={"country": "Germany"})
+    vector_search_tool.execute(query="what cities are in Germany", filters=[FilterItem(key="country", value="Germany")])
     vector_search_tool._index.similarity_search.assert_called_once_with(
         columns=vector_search_tool.columns,
         query_text="what cities are in Germany",

--- a/integrations/openai/tests/unit_tests/test_vector_search_retriever_tool.py
+++ b/integrations/openai/tests/unit_tests/test_vector_search_retriever_tool.py
@@ -192,7 +192,7 @@ def test_vector_search_retriever_tool_init(
     assert [d["page_content"] in INPUT_TEXTS for d in outputs]
 
     # Ensure that there aren't additional properties (not compatible with llama)
-    assert '"additionalProperties": true' not in str(vector_search_tool.dict())
+    assert "'additionalProperties': True" not in str(vector_search_tool.tool)
 
 
 @pytest.mark.parametrize("columns", [None, ["id", "text"]])

--- a/integrations/openai/tests/unit_tests/test_vector_search_retriever_tool.py
+++ b/integrations/openai/tests/unit_tests/test_vector_search_retriever_tool.py
@@ -10,7 +10,6 @@ from databricks.sdk import WorkspaceClient
 from databricks.sdk.credentials_provider import ModelServingUserCredentials
 from databricks.vector_search.client import VectorSearchIndex
 from databricks.vector_search.utils import CredentialStrategy
-from databricks_ai_bridge.vector_search_retriever_tool import FilterItem
 from databricks_ai_bridge.test_utils.vector_search import (  # noqa: F401
     ALL_INDEX_NAMES,
     DELTA_SYNC_INDEX,
@@ -20,6 +19,7 @@ from databricks_ai_bridge.test_utils.vector_search import (  # noqa: F401
     mock_vs_client,
     mock_workspace_client,
 )
+from databricks_ai_bridge.vector_search_retriever_tool import FilterItem
 from mlflow.entities import SpanType
 from mlflow.models.resources import (
     DatabricksServingEndpoint,
@@ -335,7 +335,8 @@ def test_filters_are_passed_through() -> None:
     vector_search_tool._index.similarity_search = MagicMock()
 
     vector_search_tool.execute(
-        {"query": "what cities are in Germany"}, filters=[FilterItem(key="country", value="Germany")]
+        {"query": "what cities are in Germany"},
+        filters=[FilterItem(key="country", value="Germany")],
     )
     vector_search_tool._index.similarity_search.assert_called_once_with(
         columns=vector_search_tool.columns,
@@ -351,7 +352,9 @@ def test_filters_are_combined() -> None:
     vector_search_tool = init_vector_search_tool(DELTA_SYNC_INDEX, filters={"city LIKE": "Berlin"})
     vector_search_tool._index.similarity_search = MagicMock()
 
-    vector_search_tool.execute(query="what cities are in Germany", filters=[FilterItem(key="country", value="Germany")])
+    vector_search_tool.execute(
+        query="what cities are in Germany", filters=[FilterItem(key="country", value="Germany")]
+    )
     vector_search_tool._index.similarity_search.assert_called_once_with(
         columns=vector_search_tool.columns,
         query_text="what cities are in Germany",

--- a/src/databricks_ai_bridge/vector_search_retriever_tool.py
+++ b/src/databricks_ai_bridge/vector_search_retriever_tool.py
@@ -37,8 +37,12 @@ def vector_search_retriever_tool_trace(func):
 
 
 class FilterItem(BaseModel):
-    key: str = Field(description="The filter key, which includes the column name and can include operators like 'NOT', '<', '>=', 'LIKE', 'OR'")
-    value: Any = Field(description="The filter value, which can be a single value or an array of values")
+    key: str = Field(
+        description="The filter key, which includes the column name and can include operators like 'NOT', '<', '>=', 'LIKE', 'OR'"
+    )
+    value: Any = Field(
+        description="The filter value, which can be a single value or an array of values"
+    )
 
 
 class VectorSearchRetrieverToolInput(BaseModel):

--- a/src/databricks_ai_bridge/vector_search_retriever_tool.py
+++ b/src/databricks_ai_bridge/vector_search_retriever_tool.py
@@ -36,21 +36,26 @@ def vector_search_retriever_tool_trace(func):
     return wrapper
 
 
+class FilterItem(BaseModel):
+    key: str = Field(description="The filter key, which includes the column name and can include operators like 'NOT', '<', '>=', 'LIKE', 'OR'")
+    value: Any = Field(description="The filter value, which can be a single value or an array of values")
+
+
 class VectorSearchRetrieverToolInput(BaseModel):
     model_config = ConfigDict(extra="allow")
     query: str = Field(
         description="The string used to query the index with and identify the most similar "
         "vectors and return the associated documents."
     )
-    filters: Dict[str, Any] = Field(
+    filters: Optional[List[FilterItem]] = Field(
         default=None,
         description=(
-            "Optional filters to refine vector search results. Supports the following operators:\n\n"
-            '- Inclusion: {"column": value} or {"column": [value1, value2]} (matches if the column equals any of the provided values)\n'
-            '- Exclusion: {"column NOT": value}\n'
-            '- Comparisons: {"column <": value}, {"column >=": value}, etc.\n'
-            '- Pattern match: {"column LIKE": "word"} (matches full tokens separated by whitespace)\n'
-            '- OR logic: {"column1 OR column2": [value1, value2]} '
+            "Optional filters to refine vector search results as an array of key-value pairs. Supports the following operators:\n\n"
+            '- Inclusion: [{"key": "column", "value": value}] or [{"key": "column", "value": [value1, value2]}] (matches if the column equals any of the provided values)\n'
+            '- Exclusion: [{"key": "column NOT", "value": value}]\n'
+            '- Comparisons: [{"key": "column <", "value": value}], [{"key": "column >=", "value": value}], etc.\n'
+            '- Pattern match: [{"key": "column LIKE", "value": "word"}] (matches full tokens separated by whitespace)\n'
+            '- OR logic: [{"key": "column1 OR column2", "value": [value1, value2]}] '
             "(matches if column1 equals value1 or column2 equals value2; matches are position-specific)"
         ),
     )


### PR DESCRIPTION
- Llama model does not allow for `"additionalProperties": False`
- Modify the schema to have fixed keys and construct the filters from that

**How is this tested?**
- [x] Unit tests
- [x] Manual test with langchain+llama: https://e2-spog.staging.cloud.databricks.com/editor/notebooks/265854390264338?o=6051921418418893#command/8594113431831710 <img width="1003" alt="Screenshot 2025-05-14 at 6 25 06 PM" src="https://github.com/user-attachments/assets/e1e05e8f-832c-47b2-a05d-74ea7bee0b76" />
- [x] Manual test with langchain+claude: https://e2-spog.staging.cloud.databricks.com/editor/notebooks/265854390290770?o=6051921418418893#command/265854390290783 <img width="1109" alt="Screenshot 2025-05-14 at 10 40 51 PM" src="https://github.com/user-attachments/assets/b2387c8b-120b-4694-8e91-ea92137935ea" />
- [x] Manual test with openai+llama: https://e2-spog.staging.cloud.databricks.com/editor/notebooks/265854390290770?o=6051921418418893#command/265854390290783 <img width="1160" alt="Screenshot 2025-05-15 at 6 35 10 AM" src="https://github.com/user-attachments/assets/8e7f02e5-13f5-4004-863e-1fb7109806fa" />
- [x] Manual test with openai+claude: https://e2-spog.staging.cloud.databricks.com/editor/notebooks/568199609863190?o=6051921418418893#command/568199609863198 <img width="1197" alt="Screenshot 2025-05-15 at 6 43 03 AM" src="https://github.com/user-attachments/assets/4e07fdeb-607b-4d98-a21a-ccd36d407659" />