### PR TITLE
Add back description param to GenieAgent

### DIFF
--- a/integrations/langchain/src/databricks_langchain/genie.py
+++ b/integrations/langchain/src/databricks_langchain/genie.py
@@ -40,9 +40,10 @@ def _query_genie_as_agent(input, genie: Genie, genie_agent_name):
 def GenieAgent(
     genie_space_id,
     genie_agent_name: str = "Genie",
+    description: str = "",
     client: Optional["WorkspaceClient"] = None,
 ):
-    """Create a genie agent that can be used to query the API"""
+    """Create a genie agent that can be used to query the API. If a description is not provided, the description of the genie space will be used."""
     if not genie_space_id:
         raise ValueError("genie_space_id is required to create a GenieAgent")
 
@@ -61,5 +62,5 @@ def GenieAgent(
 
     runnable = RunnableLambda(partial_genie_agent)
     runnable.name = genie_agent_name
-    runnable.description = genie.description
+    runnable.description = description or genie.description
     return runnable

--- a/integrations/langchain/tests/unit_tests/test_genie.py
+++ b/integrations/langchain/tests/unit_tests/test_genie.py
@@ -92,7 +92,7 @@ def test_create_genie_agent_with_description(MockRunnableLambda, MockWorkspaceCl
     MockWorkspaceClient.genie.get_space.return_value = mock_space
 
     agent = GenieAgent("space-id", "Genie", "this is a description", MockWorkspaceClient)
-    assert agent.description == "description"
+    assert agent.description == "this is a description"
 
     MockWorkspaceClient.genie.get_space.assert_called_once()
     assert agent == MockRunnableLambda.return_value

--- a/integrations/langchain/tests/unit_tests/test_genie.py
+++ b/integrations/langchain/tests/unit_tests/test_genie.py
@@ -82,6 +82,23 @@ def test_create_genie_agent(MockRunnableLambda, MockWorkspaceClient):
 
 
 @patch("databricks.sdk.WorkspaceClient")
+@patch("langchain_core.runnables.RunnableLambda")
+def test_create_genie_agent_with_description(MockRunnableLambda, MockWorkspaceClient):
+    mock_space = GenieSpace(
+        space_id="space-id",
+        title="Sales Space",
+        description=None,
+    )
+    MockWorkspaceClient.genie.get_space.return_value = mock_space
+
+    agent = GenieAgent("space-id", "Genie", "this is a description", MockWorkspaceClient)
+    assert agent.description == "description"
+
+    MockWorkspaceClient.genie.get_space.assert_called_once()
+    assert agent == MockRunnableLambda.return_value
+
+
+@patch("databricks.sdk.WorkspaceClient")
 def test_query_genie_with_client(mock_workspace_client):
     mock_workspace_client.genie.get_space.return_value = GenieSpace(
         space_id="space-id",

--- a/integrations/langchain/tests/unit_tests/test_genie.py
+++ b/integrations/langchain/tests/unit_tests/test_genie.py
@@ -72,12 +72,13 @@ def test_create_genie_agent(MockRunnableLambda, MockWorkspaceClient):
         title="Sales Space",
         description="description",
     )
-    MockWorkspaceClient.genie.get_space.return_value = mock_space
+    mock_client = MockWorkspaceClient.return_value
+    mock_client.genie.get_space.return_value = mock_space
 
-    agent = GenieAgent("space-id", "Genie", MockWorkspaceClient)
+    agent = GenieAgent("space-id", "Genie", client=mock_client)
     assert agent.description == "description"
 
-    MockWorkspaceClient.genie.get_space.assert_called_once()
+    mock_client.genie.get_space.assert_called_once()
     assert agent == MockRunnableLambda.return_value
 
 
@@ -89,12 +90,13 @@ def test_create_genie_agent_with_description(MockRunnableLambda, MockWorkspaceCl
         title="Sales Space",
         description=None,
     )
-    MockWorkspaceClient.genie.get_space.return_value = mock_space
+    mock_client = MockWorkspaceClient.return_value
+    mock_client.genie.get_space.return_value = mock_space
 
-    agent = GenieAgent("space-id", "Genie", "this is a description", MockWorkspaceClient)
+    agent = GenieAgent("space-id", "Genie", "this is a description", client=mock_client)
     assert agent.description == "this is a description"
 
-    MockWorkspaceClient.genie.get_space.assert_called_once()
+    mock_client.genie.get_space.assert_called_once()
     assert agent == MockRunnableLambda.return_value
 
 


### PR DESCRIPTION
default to the genie space description if one is not provided for the genieagent

addresses https://github.com/databricks/databricks-ai-bridge/issues/118 and https://databricks.slack.com/archives/C065NC65Q9F/p1747614537652739