### PR TITLE
Add ModelServingUserCredentials CredentialStrategy

### DIFF
--- a/src/databricks_ai_bridge/__init__.py
+++ b/src/databricks_ai_bridge/__init__.py
@@ -1,5 +1,3 @@
 from .model_serving_obo_credential_strategy import ModelServingUserCredentials
 
-__all__ = [
-    "ModelServingUserCredentials"
-]
+__all__ = ["ModelServingUserCredentials"]

--- a/src/databricks_ai_bridge/__init__.py
+++ b/src/databricks_ai_bridge/__init__.py
@@ -1,0 +1,5 @@
+from .model_serving_obo_credential_strategy import ModelServingUserCredentials
+
+__all__ = [
+    "ModelServingUserCredentials"
+]

--- a/src/databricks_ai_bridge/model_serving_obo_credential_strategy.py
+++ b/src/databricks_ai_bridge/model_serving_obo_credential_strategy.py
@@ -1,0 +1,111 @@
+import os
+import threading
+from typing import Dict, Optional, Tuple
+
+from databricks.sdk.core import Config
+from databricks.sdk.credentials_provider import (
+    CredentialsProvider,
+    CredentialsStrategy,
+    DefaultCredentials,
+)
+import logging
+
+logger = logging.getLogger(__name__)
+
+_MODEL_DEPENDENCY_OAUTH_TOKEN_FILE_PATH = "/var/credentials-secret/model-dependencies-oauth-token"
+
+def should_fetch_model_serving_environment_oauth() -> bool:
+        """
+        Check whether this is the model serving environment
+        Additionally check if the oauth token file path exists
+        """
+
+        is_in_model_serving_env = (
+            os.environ.get("IS_IN_DB_MODEL_SERVING_ENV")
+            or os.environ.get("IS_IN_DATABRICKS_MODEL_SERVING_ENV")
+            or "false"
+        )
+        return is_in_model_serving_env == "true" and os.path.isfile(
+            _MODEL_DEPENDENCY_OAUTH_TOKEN_FILE_PATH
+        )
+
+def _get_invokers_token():
+    main_thread = threading.main_thread()
+    thread_data = main_thread.__dict__
+    invokers_token = None
+    if "invokers_token" in thread_data:
+        invokers_token = thread_data["invokers_token"]
+
+    if invokers_token is None:
+        raise RuntimeError("Unable to read Invokers Token in Databricks Model Serving")
+
+    return invokers_token
+
+def get_databricks_host_token() -> Optional[Tuple[str, str]]:
+    if not should_fetch_model_serving_environment_oauth():
+        return None
+
+    # read from DB_MODEL_SERVING_HOST_ENV_VAR if available otherwise MODEL_SERVING_HOST_ENV_VAR
+    host = os.environ.get("DATABRICKS_MODEL_SERVING_HOST_URL") or os.environ.get("DB_MODEL_SERVING_HOST_URL")
+
+    return (host, _get_invokers_token())
+
+def model_serving_auth_visitor(cfg: Config) -> Optional[CredentialsProvider]:
+        try:
+            host, token = get_databricks_host_token()
+            if token is None:
+                raise ValueError(
+                    "Got malformed auth (empty token) when fetching auth implicitly available in Model Serving Environment. Please contact Databricks support"
+                )
+            if cfg.host is None:
+                cfg.host = host
+        except Exception as e:
+            logger.warning(
+                "Unable to get auth from Databricks Model Serving Environment",
+                exc_info=e,
+            )
+            return None
+        logger.info("Using Databricks Model Serving Authentication")
+
+        def inner() -> Dict[str, str]:
+            # Call here again to get the refreshed token
+            _, token = get_databricks_host_token()
+            return {"Authorization": f"Bearer {token}"}
+
+        return inner
+
+
+class ModelServingUserCredentials(CredentialsStrategy):
+    """
+    This credential strategy is designed for authenticating the Databricks SDK in the model serving environment using user-specific rights.
+    In the model serving environment, the strategy retrieves a downscoped user token from the thread-local variable.
+    In any other environments, the class defaults to the DefaultCredentialStrategy.
+    To use this credential strategy, instantiate the WorkspaceClient with the ModelServingUserCredentials strategy as follows:
+
+    invokers_client = WorkspaceClient(credential_strategy = ModelServingUserCredentials())
+    """
+
+
+    def __init__(self):
+        self.default_credentials = DefaultCredentials()
+    
+
+    # Override
+    def auth_type(self):
+        if should_fetch_model_serving_environment_oauth():
+            return "model_serving_user_credentials"
+        else:
+            return self.default_credentials.auth_type()
+   
+
+    # Override
+    def __call__(self, cfg: Config) -> CredentialsProvider:
+        if should_fetch_model_serving_environment_oauth():
+            header_factory = model_serving_auth_visitor(cfg)
+            if not header_factory:
+                raise ValueError(
+                    f"Unable to authenticate using model_serving_user_credentials in Databricks Model Serving Environment"
+                )
+            return header_factory
+        else:
+            return self.default_credentials(cfg)

--- a/src/databricks_ai_bridge/model_serving_obo_credential_strategy.py
+++ b/src/databricks_ai_bridge/model_serving_obo_credential_strategy.py
@@ -111,7 +111,10 @@ class ModelServingUserCredentials(CredentialsStrategy):
             header_factory = model_serving_auth_visitor(cfg)
             if not header_factory:
                 raise ValueError(
-                    f"Unable to authenticate using model_serving_user_credentials in Databricks Model Serving Environment"
+                    "Unable to authenticate using model_serving_user_credentials in Databricks Model Serving Environment. "
+                    "Please ensure you have specified UserAuthPolicy when logging the agent model and On Behalf of User Authorization for Agents is enabled in your workspace. "
+                    "Refer to the documentation here for more information: https://docs.databricks.com/aws/en/generative-ai/agent-framework/authenticate-on-behalf-of-user. "
+                    "If the issue persists, contact Databricks Support"
                 )
             return header_factory
         else:

--- a/src/databricks_ai_bridge/model_serving_obo_credential_strategy.py
+++ b/src/databricks_ai_bridge/model_serving_obo_credential_strategy.py
@@ -5,25 +5,27 @@ from typing import Dict, Optional, Tuple
 
 from databricks.sdk.core import Config
 from databricks.sdk.credentials_provider import (
-        CredentialsProvider,
-        CredentialsStrategy,
-        DefaultCredentials,
+    CredentialsProvider,
+    CredentialsStrategy,
+    DefaultCredentials,
 )
 
 logger = logging.getLogger(__name__)
 
-def should_fetch_model_serving_environment_oauth() -> bool:
-        """
-        Check whether this is the model serving environment
-        Additionally check if the oauth token file path exists
-        """
 
-        is_in_model_serving_env = (
-            os.environ.get("IS_IN_DB_MODEL_SERVING_ENV")
-            or os.environ.get("IS_IN_DATABRICKS_MODEL_SERVING_ENV")
-            or "false"
-        )
-        return is_in_model_serving_env == "true"
+def should_fetch_model_serving_environment_oauth() -> bool:
+    """
+    Check whether this is the model serving environment
+    Additionally check if the oauth token file path exists
+    """
+
+    is_in_model_serving_env = (
+        os.environ.get("IS_IN_DB_MODEL_SERVING_ENV")
+        or os.environ.get("IS_IN_DATABRICKS_MODEL_SERVING_ENV")
+        or "false"
+    )
+    return is_in_model_serving_env == "true"
+
 
 def _get_invokers_token():
     main_thread = threading.main_thread()
@@ -33,52 +35,58 @@ def _get_invokers_token():
         invokers_token = thread_data["invokers_token"]
 
     if invokers_token is None:
-        raise RuntimeError("Unable to read end user token in Databricks Model Serving. " \
-        "Please ensure you have specified UserAuthPolicy when logging the agent model "
-        "and On Behalf of User Authorization for Agents is enabled in your workspace. " \
-        "If the issue persists, contact Databricks Support")
+        raise RuntimeError(
+            "Unable to read end user token in Databricks Model Serving. "
+            "Please ensure you have specified UserAuthPolicy when logging the agent model "
+            "and On Behalf of User Authorization for Agents is enabled in your workspace. "
+            "If the issue persists, contact Databricks Support"
+        )
 
     return invokers_token
+
 
 def get_databricks_host_token() -> Optional[Tuple[str, str]]:
     if not should_fetch_model_serving_environment_oauth():
         return None
 
     # read from DB_MODEL_SERVING_HOST_ENV_VAR if available otherwise MODEL_SERVING_HOST_ENV_VAR
-    host = os.environ.get("DATABRICKS_MODEL_SERVING_HOST_URL") or os.environ.get("DB_MODEL_SERVING_HOST_URL")
+    host = os.environ.get("DATABRICKS_MODEL_SERVING_HOST_URL") or os.environ.get(
+        "DB_MODEL_SERVING_HOST_URL"
+    )
 
     return (host, _get_invokers_token())
 
+
 def model_serving_auth_visitor(cfg: Config) -> Optional[CredentialsProvider]:
-        try:
-            host, token = get_databricks_host_token()
-            if token is None:
-                raise ValueError(
-                    "Got malformed auth (empty token) when fetching auth implicitly available in Model Serving Environment. " \
-                    "Please ensure you have specified UserAuthPolicy when logging the agent model and On Behalf of " \
-                    "User Authorization for Agents is enabled in your workspace. If the issue persists, contact Databricks Support"
-                )
-            if cfg.host is None:
-                cfg.host = host
-        except Exception as e:
-            logger.warning(
-                "Unable to get auth from Databricks Model Serving Environment",
-                exc_info=e,
+    try:
+        host, token = get_databricks_host_token()
+        if token is None:
+            raise ValueError(
+                "Got malformed auth (empty token) when fetching auth implicitly available in Model Serving Environment. "
+                "Please ensure you have specified UserAuthPolicy when logging the agent model and On Behalf of "
+                "User Authorization for Agents is enabled in your workspace. If the issue persists, contact Databricks Support"
             )
-            return None
-        logger.info("Using Databricks Model Serving Authentication")
+        if cfg.host is None:
+            cfg.host = host
+    except Exception as e:
+        logger.warning(
+            "Unable to get auth from Databricks Model Serving Environment",
+            exc_info=e,
+        )
+        return None
+    logger.info("Using Databricks Model Serving Authentication")
 
-        def inner() -> Dict[str, str]:
-            # Call here again to get the refreshed token
-            _, token = get_databricks_host_token()
-            return {"Authorization": f"Bearer {token}"}
+    def inner() -> Dict[str, str]:
+        # Call here again to get the refreshed token
+        _, token = get_databricks_host_token()
+        return {"Authorization": f"Bearer {token}"}
 
-        return inner
+    return inner
 
 
 class ModelServingUserCredentials(CredentialsStrategy):
     """
-    This credential strategy is designed for authenticating the Databricks SDK in the model serving environment 
+    This credential strategy is designed for authenticating the Databricks SDK in the model serving environment
     using user authorization (acting as the Databricks principal querying the serving endpoint).
     In the model serving environment, the strategy retrieves a downscoped user token or fails if no such token is available
     In any other environments, the class defaults to the DefaultCredentialStrategy.
@@ -87,10 +95,8 @@ class ModelServingUserCredentials(CredentialsStrategy):
     user_client = WorkspaceClient(credential_strategy = ModelServingUserCredentials())
     """
 
-
     def __init__(self):
         self.default_credentials = DefaultCredentials()
-    
 
     # Override
     def auth_type(self):
@@ -98,7 +104,6 @@ class ModelServingUserCredentials(CredentialsStrategy):
             return "model_serving_user_credentials"
         else:
             return self.default_credentials.auth_type()
-   
 
     # Override
     def __call__(self, cfg: Config) -> CredentialsProvider:

--- a/tests/databricks_ai_bridge/test_model_serving_obo_credential_strategy.py
+++ b/tests/databricks_ai_bridge/test_model_serving_obo_credential_strategy.py
@@ -1,0 +1,75 @@
+import threading
+
+from databricks.sdk.core import Config
+from databricks_ai_bridge.model_serving_obo_credential_strategy import ModelServingUserCredentials
+
+
+def test_agent_user_credentials(monkeypatch):
+    # Guarantee that the tests defaults to env variables rather than config file.
+    
+    monkeypatch.setenv("DATABRICKS_CONFIG_FILE", "x")
+
+    monkeypatch.setenv("IS_IN_DB_MODEL_SERVING_ENV", "true")
+    monkeypatch.setenv("DB_MODEL_SERVING_HOST_URL", "x")
+    monkeypatch.setattr(
+        "databricks_ai_bridge.model_serving_obo_credential_strategy._MODEL_DEPENDENCY_OAUTH_TOKEN_FILE_PATH",
+        "tests/testdata/model-serving-test-token",
+    )
+
+    invokers_token_val = "databricks_invokers_token"
+    current_thread = threading.current_thread()
+    thread_data = current_thread.__dict__
+    thread_data["invokers_token"] = invokers_token_val
+
+    cfg = Config(credentials_strategy=ModelServingUserCredentials())
+    assert cfg.auth_type == "model_serving_user_credentials"
+
+    headers = cfg.authenticate()
+
+    assert cfg.host == "x"
+    assert headers.get("Authorization") == f"Bearer {invokers_token_val}"
+
+    # Test updates of invokers token
+    invokers_token_val = "databricks_invokers_token_v2"
+    current_thread = threading.current_thread()
+    thread_data = current_thread.__dict__
+    thread_data["invokers_token"] = invokers_token_val
+
+    headers = cfg.authenticate()
+    assert cfg.host == "x"
+    assert headers.get("Authorization") == f"Bearer {invokers_token_val}"
+
+    # Test invokers token in child thread
+
+    successful_authentication_event = threading.Event()
+
+    def authenticate():
+        try:
+            cfg = Config(credentials_strategy=ModelServingUserCredentials())
+            headers = cfg.authenticate()
+            assert cfg.host == "x"
+            assert headers.get("Authorization") == f"Bearer databricks_invokers_token_v2"
+            successful_authentication_event.set()
+        except Exception:
+            successful_authentication_event.clear()
+
+    thread = threading.Thread(target=authenticate)
+
+    thread.start()
+    thread.join()
+    assert successful_authentication_event.is_set()
+
+
+# If this credential strategy is being used in a non model serving environments then use default credential strategy instead
+def test_agent_user_credentials_in_non_model_serving_environments(monkeypatch):
+
+    monkeypatch.setenv("DATABRICKS_HOST", "x")
+    monkeypatch.setenv("DATABRICKS_TOKEN", "token")
+
+    cfg = Config(credentials_strategy=ModelServingUserCredentials())
+    assert cfg.auth_type == "pat"  # Auth type is PAT as it is no longer in a model serving environment
+
+    headers = cfg.authenticate()
+
+    assert cfg.host == "https://x"
+    assert headers.get("Authorization") == "Bearer token"

--- a/tests/databricks_ai_bridge/test_model_serving_obo_credential_strategy.py
+++ b/tests/databricks_ai_bridge/test_model_serving_obo_credential_strategy.py
@@ -7,7 +7,7 @@ from databricks_ai_bridge.model_serving_obo_credential_strategy import ModelServ
 
 def test_agent_user_credentials(monkeypatch):
     # Guarantee that the tests defaults to env variables rather than config file.
-    
+
     monkeypatch.setenv("DATABRICKS_CONFIG_FILE", "x")
 
     monkeypatch.setenv("IS_IN_DB_MODEL_SERVING_ENV", "true")
@@ -59,12 +59,13 @@ def test_agent_user_credentials(monkeypatch):
 
 # If this credential strategy is being used in a non model serving environments then use default credential strategy instead
 def test_agent_user_credentials_in_non_model_serving_environments(monkeypatch):
-
     monkeypatch.setenv("DATABRICKS_HOST", "x")
     monkeypatch.setenv("DATABRICKS_TOKEN", "token")
 
     cfg = Config(credentials_strategy=ModelServingUserCredentials())
-    assert cfg.auth_type == "pat"  # Auth type is PAT as it is no longer in a model serving environment
+    assert (
+        cfg.auth_type == "pat"
+    )  # Auth type is PAT as it is no longer in a model serving environment
 
     headers = cfg.authenticate()
 

--- a/tests/databricks_ai_bridge/test_model_serving_obo_credential_strategy.py
+++ b/tests/databricks_ai_bridge/test_model_serving_obo_credential_strategy.py
@@ -1,6 +1,7 @@
 import threading
 
 from databricks.sdk.core import Config
+
 from databricks_ai_bridge.model_serving_obo_credential_strategy import ModelServingUserCredentials
 
 
@@ -11,10 +12,6 @@ def test_agent_user_credentials(monkeypatch):
 
     monkeypatch.setenv("IS_IN_DB_MODEL_SERVING_ENV", "true")
     monkeypatch.setenv("DB_MODEL_SERVING_HOST_URL", "x")
-    monkeypatch.setattr(
-        "databricks_ai_bridge.model_serving_obo_credential_strategy._MODEL_DEPENDENCY_OAUTH_TOKEN_FILE_PATH",
-        "tests/testdata/model-serving-test-token",
-    )
 
     invokers_token_val = "databricks_invokers_token"
     current_thread = threading.current_thread()


### PR DESCRIPTION
Adds the `ModelServingUserCredentials` Strategy to `databricks-ai-bridge` so we can move away from databricks-sdk.


Added Unit Tests
Tested E2E on Dogfood:
Notebook:https://e2-spog.staging.cloud.databricks.com/editor/notebooks/1079493036208551?o=6051921418418893#command/6381636434909109
Serving Endpoint:https://e2-spog.staging.cloud.databricks.com/ml/endpoints/agents_main-default-arv_vs_agent_invokers_v5?o=6051921418418893
<img width="1092" alt="image" src="https://github.com/user-attachments/assets/9f263d7a-05ef-423c-958e-a686fa64412e" />
