### PR TITLE
[s] Send Genie Reasoning + SQL Steps on Query

### DIFF
--- a/integrations/langchain/src/databricks_langchain/genie.py
+++ b/integrations/langchain/src/databricks_langchain/genie.py
@@ -19,10 +19,7 @@ def _concat_messages_array(messages):
 
 
 @mlflow.trace()
-def _query_genie_as_agent(input,
-                          genie: Genie,
-                          genie_agent_name,
-                          include_context: bool = False):
+def _query_genie_as_agent(input, genie: Genie, genie_agent_name, include_context: bool = False):
     from langchain_core.messages import AIMessage
 
     message = f"I will provide you a chat history, where your name is {genie_agent_name}. Please help with the described information in the chat history.\n"

--- a/integrations/langchain/src/databricks_langchain/genie.py
+++ b/integrations/langchain/src/databricks_langchain/genie.py
@@ -19,7 +19,10 @@ def _concat_messages_array(messages):
 
 
 @mlflow.trace()
-def _query_genie_as_agent(input, genie: Genie, genie_agent_name):
+def _query_genie_as_agent(input,
+                          genie: Genie,
+                          genie_agent_name,
+                          include_context: bool = False):
     from langchain_core.messages import AIMessage
 
     message = f"I will provide you a chat history, where your name is {genie_agent_name}. Please help with the described information in the chat history.\n"
@@ -30,23 +33,19 @@ def _query_genie_as_agent(input, genie: Genie, genie_agent_name):
     # Send the message and wait for a response
     genie_response = genie.ask_question(message)
 
-    query_sql = genie_response.query
-    query_reasoning = genie_response.description
-    query_result = genie_response.result
-    
+    query_reasoning = genie_response.description or ""
+    query_sql = genie_response.query or ""
+    query_result = genie_response.result or ""
+
     # Create a list of AIMessage to return
     messages = []
 
-    if query_sql:
-        messages.append(AIMessage(content=query_sql, name="query_sql"))
-    if query_reasoning:
+    if include_context:
         messages.append(AIMessage(content=query_reasoning, name="query_reasoning"))
-    if query_result:
-        messages.append(AIMessage(content=query_result, name="query_result"))
-    if messages:
-        return {"messages": messages}
-    else:
-        return {"messages": [AIMessage(content="")]}
+        messages.append(AIMessage(content=query_sql, name="query_sql"))
+    messages.append(AIMessage(content=query_result, name="query_result"))
+
+    return {"messages": messages}
 
 
 @mlflow.trace(span_type="AGENT")
@@ -54,6 +53,7 @@ def GenieAgent(
     genie_space_id,
     genie_agent_name: str = "Genie",
     description: str = "",
+    include_context: bool = False,
     client: Optional["WorkspaceClient"] = None,
 ):
     """Create a genie agent that can be used to query the API. If a description is not provided, the description of the genie space will be used."""
@@ -71,6 +71,7 @@ def GenieAgent(
         _query_genie_as_agent,
         genie=genie,
         genie_agent_name=genie_agent_name,
+        include_context=include_context,
     )
 
     runnable = RunnableLambda(partial_genie_agent)

--- a/integrations/langchain/src/databricks_langchain/genie.py
+++ b/integrations/langchain/src/databricks_langchain/genie.py
@@ -30,8 +30,21 @@ def _query_genie_as_agent(input, genie: Genie, genie_agent_name):
     # Send the message and wait for a response
     genie_response = genie.ask_question(message)
 
-    if query_result := genie_response.result:
-        return {"messages": [AIMessage(content=query_result)]}
+    query_sql = genie_response.query
+    query_reasoning = genie_response.description
+    query_result = genie_response.result
+    
+    # Create a list of AIMessage to return
+    messages = []
+
+    if query_sql:
+        messages.append(AIMessage(content=query_sql, name="query_sql"))
+    if query_reasoning:
+        messages.append(AIMessage(content=query_reasoning, name="query_reasoning"))
+    if query_result:
+        messages.append(AIMessage(content=query_result, name="query_result"))
+    if messages:
+        return {"messages": messages}
     else:
         return {"messages": [AIMessage(content="")]}
 

--- a/integrations/langchain/tests/unit_tests/test_genie.py
+++ b/integrations/langchain/tests/unit_tests/test_genie.py
@@ -181,45 +181,6 @@ def test_create_genie_agent_with_include_context(MockWorkspaceClient):
     mock_client.genie.get_space.assert_called_once()
 
 
-@patch("databricks.sdk.WorkspaceClient")
-def test_create_genie_agent_with_include_context_false(MockWorkspaceClient):
-    """Test creating a GenieAgent with include_context=False and verify it only returns result"""
-    mock_space = GenieSpace(
-        space_id="space-id",
-        title="Sales Space", 
-        description="description",
-    )
-    mock_client = MockWorkspaceClient.return_value
-    mock_client.genie.get_space.return_value = mock_space
-
-    # Create a proper GenieResponse instance
-    mock_genie_response = GenieResponse(
-        result="It is sunny.",
-        query="SELECT * FROM weather",
-        description="This is the reasoning for the query",
-    )
-
-    # Test with include_context=False (default)
-    agent = GenieAgent("space-id", "Genie", include_context=False, client=mock_client)
-    assert agent.description == "description"
-
-    # Create test input
-    input_data = {"messages": [{"role": "user", "content": "What is the weather?"}]}
-    
-    # Mock the ask_question method on the Genie instance
-    with patch("databricks_ai_bridge.genie.Genie.ask_question", return_value=mock_genie_response):
-        # Invoke the agent and verify include_context=False behavior
-        result = agent.invoke(input_data)
-        
-        # Should only include result when include_context=False
-        expected_messages = [
-            AIMessage(content="It is sunny.", name="query_result"),
-        ]
-        assert result["messages"] == expected_messages
-
-    mock_client.genie.get_space.assert_called_once()
-
-
 def test_create_genie_agent_no_space_id():
     with pytest.raises(ValueError):
         GenieAgent("", "Genie")

--- a/integrations/langchain/tests/unit_tests/test_genie.py
+++ b/integrations/langchain/tests/unit_tests/test_genie.py
@@ -51,31 +51,31 @@ def test_query_genie_as_agent(MockWorkspaceClient):
         description="description",
     )
     MockWorkspaceClient.genie.get_space.return_value = mock_space
-    
+
     # Create a proper GenieResponse instance
     mock_genie_response = GenieResponse(
-        result='It is sunny.',
-        query='SELECT * FROM weather',
-        description='This is the reasoning for the query'
+        result="It is sunny.",
+        query="SELECT * FROM weather",
+        description="This is the reasoning for the query",
     )
-    
+
     input_data = {"messages": [{"role": "user", "content": "What is the weather?"}]}
     genie = Genie("space-id", MockWorkspaceClient)
-    
+
     # Mock the ask_question method to return our mock response
-    with patch.object(genie, 'ask_question', return_value=mock_genie_response):
+    with patch.object(genie, "ask_question", return_value=mock_genie_response):
         # Test with include_context=False (default)
         result = _query_genie_as_agent(input_data, genie, "Genie")
         expected_message = {"messages": [AIMessage(content="It is sunny.", name="query_result")]}
         assert result == expected_message
-        
+
         # Test with include_context=True
         result = _query_genie_as_agent(input_data, genie, "Genie", include_context=True)
         expected_messages = {
             "messages": [
                 AIMessage(content="This is the reasoning for the query", name="query_reasoning"),
                 AIMessage(content="SELECT * FROM weather", name="query_sql"),
-                AIMessage(content="It is sunny.", name="query_result")
+                AIMessage(content="It is sunny.", name="query_result"),
             ]
         }
         assert result == expected_messages
@@ -124,19 +124,17 @@ def test_query_genie_with_client(mock_workspace_client):
         title="Sales Space",
         description="description",
     )
-    
+
     # Create a proper GenieResponse instance
     mock_genie_response = GenieResponse(
-        result='It is sunny.',
-        query='SELECT weather FROM data',
-        description='Query reasoning'
+        result="It is sunny.", query="SELECT weather FROM data", description="Query reasoning"
     )
 
     input_data = {"messages": [{"role": "user", "content": "What is the weather?"}]}
     genie = Genie("space-id", mock_workspace_client)
-    
+
     # Mock the ask_question method to return our mock response
-    with patch.object(genie, 'ask_question', return_value=mock_genie_response):
+    with patch.object(genie, "ask_question", return_value=mock_genie_response):
         result = _query_genie_as_agent(input_data, genie, "Genie")
         expected_message = {"messages": [AIMessage(content="It is sunny.", name="query_result")]}
         assert result == expected_message

--- a/integrations/langchain/tests/unit_tests/test_genie.py
+++ b/integrations/langchain/tests/unit_tests/test_genie.py
@@ -2,7 +2,7 @@ from unittest.mock import patch
 
 import pytest
 from databricks.sdk.service.dashboards import GenieSpace
-from databricks_ai_bridge.genie import Genie
+from databricks_ai_bridge.genie import Genie, GenieResponse
 from langchain_core.messages import AIMessage
 
 from databricks_langchain.genie import (
@@ -51,17 +51,34 @@ def test_query_genie_as_agent(MockWorkspaceClient):
         description="description",
     )
     MockWorkspaceClient.genie.get_space.return_value = mock_space
-    MockWorkspaceClient.genie._api.do.side_effect = [
-        {"conversation_id": "123", "message_id": "abc"},
-        {"status": "COMPLETED", "attachments": [{"text": {"content": "It is sunny."}}]},
-    ]
-
+    
+    # Create a proper GenieResponse instance
+    mock_genie_response = GenieResponse(
+        result='It is sunny.',
+        query='SELECT * FROM weather',
+        description='This is the reasoning for the query'
+    )
+    
     input_data = {"messages": [{"role": "user", "content": "What is the weather?"}]}
     genie = Genie("space-id", MockWorkspaceClient)
-    result = _query_genie_as_agent(input_data, genie, "Genie")
-
-    expected_message = {"messages": [AIMessage(content="It is sunny.")]}
-    assert result == expected_message
+    
+    # Mock the ask_question method to return our mock response
+    with patch.object(genie, 'ask_question', return_value=mock_genie_response):
+        # Test with include_context=False (default)
+        result = _query_genie_as_agent(input_data, genie, "Genie")
+        expected_message = {"messages": [AIMessage(content="It is sunny.", name="query_result")]}
+        assert result == expected_message
+        
+        # Test with include_context=True
+        result = _query_genie_as_agent(input_data, genie, "Genie", include_context=True)
+        expected_messages = {
+            "messages": [
+                AIMessage(content="This is the reasoning for the query", name="query_reasoning"),
+                AIMessage(content="SELECT * FROM weather", name="query_sql"),
+                AIMessage(content="It is sunny.", name="query_result")
+            ]
+        }
+        assert result == expected_messages
 
 
 @patch("databricks.sdk.WorkspaceClient")
@@ -107,17 +124,42 @@ def test_query_genie_with_client(mock_workspace_client):
         title="Sales Space",
         description="description",
     )
-    mock_workspace_client.genie._api.do.side_effect = [
-        {"conversation_id": "123", "message_id": "abc"},
-        {"status": "COMPLETED", "attachments": [{"text": {"content": "It is sunny."}}]},
-    ]
+    
+    # Create a proper GenieResponse instance
+    mock_genie_response = GenieResponse(
+        result='It is sunny.',
+        query='SELECT weather FROM data',
+        description='Query reasoning'
+    )
 
     input_data = {"messages": [{"role": "user", "content": "What is the weather?"}]}
     genie = Genie("space-id", mock_workspace_client)
-    result = _query_genie_as_agent(input_data, genie, "Genie")
+    
+    # Mock the ask_question method to return our mock response
+    with patch.object(genie, 'ask_question', return_value=mock_genie_response):
+        result = _query_genie_as_agent(input_data, genie, "Genie")
+        expected_message = {"messages": [AIMessage(content="It is sunny.", name="query_result")]}
+        assert result == expected_message
 
-    expected_message = {"messages": [AIMessage(content="It is sunny.")]}
-    assert result == expected_message
+
+@patch("databricks.sdk.WorkspaceClient")
+@patch("langchain_core.runnables.RunnableLambda")
+def test_create_genie_agent_with_include_context(MockRunnableLambda, MockWorkspaceClient):
+    """Test creating a GenieAgent with include_context parameter"""
+    mock_space = GenieSpace(
+        space_id="space-id",
+        title="Sales Space",
+        description="description",
+    )
+    mock_client = MockWorkspaceClient.return_value
+    mock_client.genie.get_space.return_value = mock_space
+
+    # Test with include_context=True
+    agent = GenieAgent("space-id", "Genie", include_context=True, client=mock_client)
+    assert agent.description == "description"
+
+    mock_client.genie.get_space.assert_called_once()
+    assert agent == MockRunnableLambda.return_value
 
 
 def test_create_genie_agent_no_space_id():

--- a/integrations/langchain/tests/unit_tests/test_genie.py
+++ b/integrations/langchain/tests/unit_tests/test_genie.py
@@ -164,12 +164,12 @@ def test_create_genie_agent_with_include_context(MockWorkspaceClient):
 
     # Create test input
     input_data = {"messages": [{"role": "user", "content": "What is the weather?"}]}
-    
+
     # Mock the ask_question method on the Genie instance
     with patch("databricks_ai_bridge.genie.Genie.ask_question", return_value=mock_genie_response):
         # Invoke the agent and verify include_context=True behavior
         result = agent.invoke(input_data)
-        
+
         # Should include reasoning, SQL, and result when include_context=True
         expected_messages = [
             AIMessage(content="This is the reasoning for the query", name="query_reasoning"),

--- a/integrations/langchain/tests/unit_tests/test_genie.py
+++ b/integrations/langchain/tests/unit_tests/test_genie.py
@@ -141,9 +141,8 @@ def test_query_genie_with_client(mock_workspace_client):
 
 
 @patch("databricks.sdk.WorkspaceClient")
-@patch("langchain_core.runnables.RunnableLambda")
-def test_create_genie_agent_with_include_context(MockRunnableLambda, MockWorkspaceClient):
-    """Test creating a GenieAgent with include_context parameter"""
+def test_create_genie_agent_with_include_context(MockWorkspaceClient):
+    """Test creating a GenieAgent with include_context parameter and verify it propagates correctly"""
     mock_space = GenieSpace(
         space_id="space-id",
         title="Sales Space",
@@ -152,12 +151,73 @@ def test_create_genie_agent_with_include_context(MockRunnableLambda, MockWorkspa
     mock_client = MockWorkspaceClient.return_value
     mock_client.genie.get_space.return_value = mock_space
 
+    # Create a proper GenieResponse instance
+    mock_genie_response = GenieResponse(
+        result="It is sunny.",
+        query="SELECT * FROM weather",
+        description="This is the reasoning for the query",
+    )
+
     # Test with include_context=True
     agent = GenieAgent("space-id", "Genie", include_context=True, client=mock_client)
     assert agent.description == "description"
 
+    # Create test input
+    input_data = {"messages": [{"role": "user", "content": "What is the weather?"}]}
+    
+    # Mock the ask_question method on the Genie instance
+    with patch("databricks_ai_bridge.genie.Genie.ask_question", return_value=mock_genie_response):
+        # Invoke the agent and verify include_context=True behavior
+        result = agent.invoke(input_data)
+        
+        # Should include reasoning, SQL, and result when include_context=True
+        expected_messages = [
+            AIMessage(content="This is the reasoning for the query", name="query_reasoning"),
+            AIMessage(content="SELECT * FROM weather", name="query_sql"),
+            AIMessage(content="It is sunny.", name="query_result"),
+        ]
+        assert result["messages"] == expected_messages
+
     mock_client.genie.get_space.assert_called_once()
-    assert agent == MockRunnableLambda.return_value
+
+
+@patch("databricks.sdk.WorkspaceClient")
+def test_create_genie_agent_with_include_context_false(MockWorkspaceClient):
+    """Test creating a GenieAgent with include_context=False and verify it only returns result"""
+    mock_space = GenieSpace(
+        space_id="space-id",
+        title="Sales Space", 
+        description="description",
+    )
+    mock_client = MockWorkspaceClient.return_value
+    mock_client.genie.get_space.return_value = mock_space
+
+    # Create a proper GenieResponse instance
+    mock_genie_response = GenieResponse(
+        result="It is sunny.",
+        query="SELECT * FROM weather",
+        description="This is the reasoning for the query",
+    )
+
+    # Test with include_context=False (default)
+    agent = GenieAgent("space-id", "Genie", include_context=False, client=mock_client)
+    assert agent.description == "description"
+
+    # Create test input
+    input_data = {"messages": [{"role": "user", "content": "What is the weather?"}]}
+    
+    # Mock the ask_question method on the Genie instance
+    with patch("databricks_ai_bridge.genie.Genie.ask_question", return_value=mock_genie_response):
+        # Invoke the agent and verify include_context=False behavior
+        result = agent.invoke(input_data)
+        
+        # Should only include result when include_context=False
+        expected_messages = [
+            AIMessage(content="It is sunny.", name="query_result"),
+        ]
+        assert result["messages"] == expected_messages
+
+    mock_client.genie.get_space.assert_called_once()
 
 
 def test_create_genie_agent_no_space_id():

--- a/tests/databricks_ai_bridge/test_genie.py
+++ b/tests/databricks_ai_bridge/test_genie.py
@@ -1,167 +1,333 @@
+import random
+from datetime import datetime, timedelta
+from io import StringIO
 from unittest.mock import patch
 
+import pandas as pd
 import pytest
-from databricks.sdk.service.dashboards import GenieSpace
-from databricks_ai_bridge.genie import Genie, GenieResponse
-from langchain_core.messages import AIMessage
 
-from databricks_langchain.genie import (
-    GenieAgent,
-    _concat_messages_array,
-    _query_genie_as_agent,
-)
+from databricks_ai_bridge.genie import Genie, _count_tokens, _parse_query_result
 
 
-def test_concat_messages_array():
-    # Test a simple case with multiple messages
-    messages = [
-        {"role": "user", "content": "What is the weather?"},
-        {"role": "assistant", "content": "It is sunny."},
-    ]
-    result = _concat_messages_array(messages)
-    expected = "user: What is the weather?\nassistant: It is sunny."
-    assert result == expected
-
-    # Test case with missing content
-    messages = [{"role": "user"}, {"role": "assistant", "content": "I don't know."}]
-    result = _concat_messages_array(messages)
-    expected = "user: \nassistant: I don't know."
-    assert result == expected
-
-    # Test case with non-dict message objects
-    class Message:
-        def __init__(self, role, content):
-            self.role = role
-            self.content = content
-
-    messages = [
-        Message("user", "Tell me a joke."),
-        Message("assistant", "Why did the chicken cross the road?"),
-    ]
-    result = _concat_messages_array(messages)
-    expected = "user: Tell me a joke.\nassistant: Why did the chicken cross the road?"
-    assert result == expected
+@pytest.fixture
+def mock_workspace_client():
+    with patch("databricks_ai_bridge.genie.WorkspaceClient") as MockWorkspaceClient:
+        mock_client = MockWorkspaceClient.return_value
+        yield mock_client
 
 
-@patch("databricks.sdk.WorkspaceClient")
-def test_query_genie_as_agent(MockWorkspaceClient):
-    mock_space = GenieSpace(
-        space_id="space-id",
-        title="Sales Space",
-        description="description",
+@pytest.fixture
+def genie(mock_workspace_client):
+    return Genie(space_id="test_space_id")
+
+
+def test_start_conversation(genie, mock_workspace_client):
+    mock_workspace_client.genie._api.do.return_value = {"conversation_id": "123"}
+    response = genie.start_conversation("Hello")
+    assert response == {"conversation_id": "123"}
+    mock_workspace_client.genie._api.do.assert_called_once_with(
+        "POST",
+        "/api/2.0/genie/spaces/test_space_id/start-conversation",
+        body={"content": "Hello"},
+        headers=genie.headers,
     )
-    MockWorkspaceClient.genie.get_space.return_value = mock_space
-    
-    # Create a proper GenieResponse instance
-    mock_genie_response = GenieResponse(
-        result='It is sunny.',
-        query='SELECT * FROM weather',
-        description='This is the reasoning for the query'
+
+
+def test_create_message(genie, mock_workspace_client):
+    mock_workspace_client.genie._api.do.return_value = {"message_id": "456"}
+    response = genie.create_message("123", "Hello again")
+    assert response == {"message_id": "456"}
+    mock_workspace_client.genie._api.do.assert_called_once_with(
+        "POST",
+        "/api/2.0/genie/spaces/test_space_id/conversations/123/messages",
+        body={"content": "Hello again"},
+        headers=genie.headers,
     )
-    
-    input_data = {"messages": [{"role": "user", "content": "What is the weather?"}]}
-    genie = Genie("space-id", MockWorkspaceClient)
-    
-    # Mock the ask_question method to return our mock response
-    with patch.object(genie, 'ask_question', return_value=mock_genie_response):
-        # Test with include_context=False (default)
-        result = _query_genie_as_agent(input_data, genie, "Genie")
-        expected_message = {"messages": [AIMessage(content="It is sunny.", name="query_result")]}
-        assert result == expected_message
-        
-        # Test with include_context=True
-        result = _query_genie_as_agent(input_data, genie, "Genie", include_context=True)
-        expected_messages = {
-            "messages": [
-                AIMessage(content="This is the reasoning for the query", name="query_reasoning"),
-                AIMessage(content="SELECT * FROM weather", name="query_sql"),
-                AIMessage(content="It is sunny.", name="query_result")
+
+
+def test_poll_for_result_completed_with_text(genie, mock_workspace_client):
+    mock_workspace_client.genie._api.do.side_effect = [
+        {
+            "status": "COMPLETED",
+            "attachments": [{"attachment_id": "123", "text": {"content": "Result"}}],
+        },
+    ]
+    genie_result = genie.poll_for_result("123", "456")
+    assert genie_result.result == "Result"
+
+
+def test_poll_for_result_completed_with_query(genie, mock_workspace_client):
+    mock_workspace_client.genie._api.do.side_effect = [
+        {
+            "status": "COMPLETED",
+            "attachments": [{"attachment_id": "123", "query": {"query": "SELECT *"}}],
+        },
+        {
+            "statement_response": {
+                "status": {"state": "SUCCEEDED"},
+                "manifest": {"schema": {"columns": []}},
+                "result": {
+                    "data_array": [],
+                },
+            }
+        },
+    ]
+    genie_result = genie.poll_for_result("123", "456")
+    assert genie_result.result == pd.DataFrame().to_markdown()
+
+
+def test_poll_for_result_failed(genie, mock_workspace_client):
+    mock_workspace_client.genie._api.do.side_effect = [
+        {"status": "FAILED", "error": "Test error"},
+    ]
+    genie_result = genie.poll_for_result("123", "456")
+    assert genie_result.result == "Genie query failed with error: Test error"
+
+
+def test_poll_for_result_cancelled(genie, mock_workspace_client):
+    mock_workspace_client.genie._api.do.side_effect = [
+        {"status": "CANCELLED"},
+    ]
+    genie_result = genie.poll_for_result("123", "456")
+    assert genie_result.result == "Genie query cancelled."
+
+
+def test_poll_for_result_expired(genie, mock_workspace_client):
+    mock_workspace_client.genie._api.do.side_effect = [
+        {"status": "QUERY_RESULT_EXPIRED"},
+    ]
+    genie_result = genie.poll_for_result("123", "456")
+    assert genie_result.result == "Genie query query_result_expired."
+
+
+def test_poll_for_result_max_iterations(genie, mock_workspace_client):
+    # patch MAX_ITERATIONS to 2 for this test and sleep to avoid delays
+    with (
+        patch("databricks_ai_bridge.genie.MAX_ITERATIONS", 2),
+        patch("time.sleep", return_value=None),
+    ):
+        mock_workspace_client.genie._api.do.side_effect = [
+            {"status": "EXECUTING_QUERY"},
+            {"status": "EXECUTING_QUERY"},
+            {"status": "EXECUTING_QUERY"},
+        ]
+        result = genie.poll_for_result("123", "456")
+        assert result.result == "Genie query timed out after 2 iterations of 5 seconds"
+
+
+def test_ask_question(genie, mock_workspace_client):
+    mock_workspace_client.genie._api.do.side_effect = [
+        {"conversation_id": "123", "message_id": "456"},
+        {"status": "COMPLETED", "attachments": [{"text": {"content": "Answer"}}]},
+    ]
+    genie_result = genie.ask_question("What is the meaning of life?")
+    assert genie_result.result == "Answer"
+
+
+def test_parse_query_result_empty():
+    resp = {"manifest": {"schema": {"columns": []}}, "result": None}
+    result = _parse_query_result(resp)
+    assert result == "EMPTY"
+
+
+def test_parse_query_result_with_data():
+    resp = {
+        "manifest": {
+            "schema": {
+                "columns": [
+                    {"name": "id", "type_name": "INT"},
+                    {"name": "name", "type_name": "STRING"},
+                    {"name": "created_at", "type_name": "TIMESTAMP"},
+                ]
+            }
+        },
+        "result": {
+            "data_array": [
+                ["1", "Alice", "2023-10-01T00:00:00Z"],
+                ["2", "Bob", "2023-10-02T00:00:00Z"],
             ]
+        },
+    }
+    result = _parse_query_result(resp)
+    expected_df = pd.DataFrame(
+        {
+            "id": [1, 2],
+            "name": ["Alice", "Bob"],
+            "created_at": [datetime(2023, 10, 1).date(), datetime(2023, 10, 2).date()],
         }
-        assert result == expected_messages
-
-
-@patch("databricks.sdk.WorkspaceClient")
-@patch("langchain_core.runnables.RunnableLambda")
-def test_create_genie_agent(MockRunnableLambda, MockWorkspaceClient):
-    mock_space = GenieSpace(
-        space_id="space-id",
-        title="Sales Space",
-        description="description",
     )
-    mock_client = MockWorkspaceClient.return_value
-    mock_client.genie.get_space.return_value = mock_space
-
-    agent = GenieAgent("space-id", "Genie", client=mock_client)
-    assert agent.description == "description"
-
-    mock_client.genie.get_space.assert_called_once()
-    assert agent == MockRunnableLambda.return_value
+    assert result == expected_df.to_markdown()
 
 
-@patch("databricks.sdk.WorkspaceClient")
-@patch("langchain_core.runnables.RunnableLambda")
-def test_create_genie_agent_with_description(MockRunnableLambda, MockWorkspaceClient):
-    mock_space = GenieSpace(
-        space_id="space-id",
-        title="Sales Space",
-        description=None,
+def test_parse_query_result_with_null_values():
+    resp = {
+        "manifest": {
+            "schema": {
+                "columns": [
+                    {"name": "id", "type_name": "INT"},
+                    {"name": "name", "type_name": "STRING"},
+                    {"name": "created_at", "type_name": "TIMESTAMP"},
+                ]
+            }
+        },
+        "result": {
+            "data_array": [
+                ["1", None, "2023-10-01T00:00:00Z"],
+                ["2", "Bob", None],
+            ]
+        },
+    }
+    result = _parse_query_result(resp)
+    expected_df = pd.DataFrame(
+        {
+            "id": [1, 2],
+            "name": [None, "Bob"],
+            "created_at": [datetime(2023, 10, 1).date(), None],
+        }
     )
-    mock_client = MockWorkspaceClient.return_value
-    mock_client.genie.get_space.return_value = mock_space
-
-    agent = GenieAgent("space-id", "Genie", "this is a description", client=mock_client)
-    assert agent.description == "this is a description"
-
-    mock_client.genie.get_space.assert_called_once()
-    assert agent == MockRunnableLambda.return_value
+    assert result == expected_df.to_markdown()
 
 
-@patch("databricks.sdk.WorkspaceClient")
-def test_query_genie_with_client(mock_workspace_client):
-    mock_workspace_client.genie.get_space.return_value = GenieSpace(
-        space_id="space-id",
-        title="Sales Space",
-        description="description",
-    )
-    
-    # Create a proper GenieResponse instance
-    mock_genie_response = GenieResponse(
-        result='It is sunny.',
-        query='SELECT weather FROM data',
-        description='Query reasoning'
-    )
+def test_parse_query_result_trims_data():
+    # patch MAX_TOKENS_OF_DATA to 100 for this test
+    with patch("databricks_ai_bridge.genie.MAX_TOKENS_OF_DATA", 100):
+        resp = {
+            "manifest": {
+                "schema": {
+                    "columns": [
+                        {"name": "id", "type_name": "INT"},
+                        {"name": "name", "type_name": "STRING"},
+                        {"name": "created_at", "type_name": "TIMESTAMP"},
+                    ]
+                }
+            },
+            "result": {
+                "data_array": [
+                    ["1", "Alice", "2023-10-01T00:00:00Z"],
+                    ["2", "Bob", "2023-10-02T00:00:00Z"],
+                    ["3", "Charlie", "2023-10-03T00:00:00Z"],
+                    ["4", "David", "2023-10-04T00:00:00Z"],
+                    ["5", "Eve", "2023-10-05T00:00:00Z"],
+                    ["6", "Frank", "2023-10-06T00:00:00Z"],
+                    ["7", "Grace", "2023-10-07T00:00:00Z"],
+                    ["8", "Hank", "2023-10-08T00:00:00Z"],
+                    ["9", "Ivy", "2023-10-09T00:00:00Z"],
+                    ["10", "Jack", "2023-10-10T00:00:00Z"],
+                ]
+            },
+        }
+        result = _parse_query_result(resp)
+        assert (
+            result
+            == pd.DataFrame(
+                {
+                    "id": [1, 2, 3],
+                    "name": ["Alice", "Bob", "Charlie"],
+                    "created_at": [
+                        datetime(2023, 10, 1).date(),
+                        datetime(2023, 10, 2).date(),
+                        datetime(2023, 10, 3).date(),
+                    ],
+                }
+            ).to_markdown()
+        )
+        assert _count_tokens(result) <= 100
 
-    input_data = {"messages": [{"role": "user", "content": "What is the weather?"}]}
-    genie = Genie("space-id", mock_workspace_client)
-    
-    # Mock the ask_question method to return our mock response
-    with patch.object(genie, 'ask_question', return_value=mock_genie_response):
-        result = _query_genie_as_agent(input_data, genie, "Genie")
-        expected_message = {"messages": [AIMessage(content="It is sunny.", name="query_result")]}
-        assert result == expected_message
+
+def markdown_to_dataframe(markdown_str: str) -> pd.DataFrame:
+    if markdown_str == "":
+        return pd.DataFrame()
+
+    lines = markdown_str.strip().splitlines()
+
+    # Remove Markdown separator row (2nd line)
+    lines = [line.strip().strip("|") for i, line in enumerate(lines) if i != 1]
+
+    # Re-join cleaned lines and parse
+    cleaned_markdown = "\n".join(lines)
+    df = pd.read_csv(StringIO(cleaned_markdown), sep="|")
+
+    # Strip whitespace from column names and values
+    df.columns = [col.strip() for col in df.columns]
+    df = df.applymap(lambda x: x.strip() if isinstance(x, str) else x)
+
+    # Drop the first column
+    df = df.drop(columns=[df.columns[0]])
+
+    return df
 
 
-@patch("databricks.sdk.WorkspaceClient")
-@patch("langchain_core.runnables.RunnableLambda")
-def test_create_genie_agent_with_include_context(MockRunnableLambda, MockWorkspaceClient):
-    """Test creating a GenieAgent with include_context parameter"""
-    mock_space = GenieSpace(
-        space_id="space-id",
-        title="Sales Space",
-        description="description",
-    )
-    mock_client = MockWorkspaceClient.return_value
-    mock_client.genie.get_space.return_value = mock_space
+@pytest.mark.parametrize("max_tokens", [1, 100, 1000, 2000, 8000, 10000, 15000, 19000, 100000])
+def test_parse_query_result_trims_large_data(max_tokens):
+    """
+    Ensure _parse_query_result trims output to stay within token limits.
+    """
+    with patch("databricks_ai_bridge.genie.MAX_TOKENS_OF_DATA", max_tokens):
+        base_date = datetime(2023, 1, 1)
+        names = ["Alice", "Bob", "Charlie", "David", "Eve", "Frank", "Grace", "Hank", "Ivy", "Jack"]
 
-    # Test with include_context=True
-    agent = GenieAgent("space-id", "Genie", include_context=True, client=mock_client)
-    assert agent.description == "description"
+        data_array = [
+            [
+                str(i + 1),
+                random.choice(names),
+                (base_date + timedelta(days=random.randint(0, 365))).strftime("%Y-%m-%dT%H:%M:%SZ"),
+            ]
+            for i in range(1000)
+        ]
 
-    mock_client.genie.get_space.assert_called_once()
-    assert agent == MockRunnableLambda.return_value
+        response = {
+            "manifest": {
+                "schema": {
+                    "columns": [
+                        {"name": "id", "type_name": "INT"},
+                        {"name": "name", "type_name": "STRING"},
+                        {"name": "created_at", "type_name": "TIMESTAMP"},
+                    ]
+                }
+            },
+            "result": {"data_array": data_array},
+        }
+
+        markdown_result = _parse_query_result(response)
+        result_df = markdown_to_dataframe(markdown_result)
+
+        expected_df = pd.DataFrame(
+            {
+                "id": [int(row[0]) for row in data_array],
+                "name": [row[1] for row in data_array],
+                "created_at": [
+                    datetime.strptime(row[2], "%Y-%m-%dT%H:%M:%SZ").date() for row in data_array
+                ],
+            }
+        )
+
+        expected_markdown = (
+            "" if len(result_df) == 0 else expected_df[: len(result_df)].to_markdown()
+        )
+        # Ensure result matches expected subset and respects token limit
+        assert markdown_result == expected_markdown
+        assert _count_tokens(markdown_result) <= max_tokens
+        # Ensure adding one more row would exceed token limit or we're at full length
+        next_row_exceeds = (
+            _count_tokens(expected_df.iloc[: len(result_df) + 1].to_markdown()) > max_tokens
+        )
+        assert len(result_df) == len(expected_df) or next_row_exceeds
 
 
-def test_create_genie_agent_no_space_id():
-    with pytest.raises(ValueError):
-        GenieAgent("", "Genie")
+def test_poll_query_results_max_iterations(genie, mock_workspace_client):
+    # patch MAX_ITERATIONS to 2 for this test and sleep to avoid delays
+    with (
+        patch("databricks_ai_bridge.genie.MAX_ITERATIONS", 2),
+        patch("time.sleep", return_value=None),
+    ):
+        mock_workspace_client.genie._api.do.side_effect = [
+            {
+                "status": "COMPLETED",
+                "attachments": [{"attachment_id": "123", "query": {"query": "SELECT *"}}],
+            },
+            {"statement_response": {"status": {"state": "PENDING"}}},
+            {"statement_response": {"status": {"state": "PENDING"}}},
+            {"statement_response": {"status": {"state": "PENDING"}}},
+        ]
+        result = genie.poll_for_result("123", "456")
+        assert result.result == "Genie query for result timed out after 2 iterations of 5 seconds"

--- a/tests/databricks_ai_bridge/test_genie.py
+++ b/tests/databricks_ai_bridge/test_genie.py
@@ -1,333 +1,167 @@
-import random
-from datetime import datetime, timedelta
-from io import StringIO
 from unittest.mock import patch
 
-import pandas as pd
 import pytest
+from databricks.sdk.service.dashboards import GenieSpace
+from databricks_ai_bridge.genie import Genie, GenieResponse
+from langchain_core.messages import AIMessage
 
-from databricks_ai_bridge.genie import Genie, _count_tokens, _parse_query_result
-
-
-@pytest.fixture
-def mock_workspace_client():
-    with patch("databricks_ai_bridge.genie.WorkspaceClient") as MockWorkspaceClient:
-        mock_client = MockWorkspaceClient.return_value
-        yield mock_client
-
-
-@pytest.fixture
-def genie(mock_workspace_client):
-    return Genie(space_id="test_space_id")
+from databricks_langchain.genie import (
+    GenieAgent,
+    _concat_messages_array,
+    _query_genie_as_agent,
+)
 
 
-def test_start_conversation(genie, mock_workspace_client):
-    mock_workspace_client.genie._api.do.return_value = {"conversation_id": "123"}
-    response = genie.start_conversation("Hello")
-    assert response == {"conversation_id": "123"}
-    mock_workspace_client.genie._api.do.assert_called_once_with(
-        "POST",
-        "/api/2.0/genie/spaces/test_space_id/start-conversation",
-        body={"content": "Hello"},
-        headers=genie.headers,
+def test_concat_messages_array():
+    # Test a simple case with multiple messages
+    messages = [
+        {"role": "user", "content": "What is the weather?"},
+        {"role": "assistant", "content": "It is sunny."},
+    ]
+    result = _concat_messages_array(messages)
+    expected = "user: What is the weather?\nassistant: It is sunny."
+    assert result == expected
+
+    # Test case with missing content
+    messages = [{"role": "user"}, {"role": "assistant", "content": "I don't know."}]
+    result = _concat_messages_array(messages)
+    expected = "user: \nassistant: I don't know."
+    assert result == expected
+
+    # Test case with non-dict message objects
+    class Message:
+        def __init__(self, role, content):
+            self.role = role
+            self.content = content
+
+    messages = [
+        Message("user", "Tell me a joke."),
+        Message("assistant", "Why did the chicken cross the road?"),
+    ]
+    result = _concat_messages_array(messages)
+    expected = "user: Tell me a joke.\nassistant: Why did the chicken cross the road?"
+    assert result == expected
+
+
+@patch("databricks.sdk.WorkspaceClient")
+def test_query_genie_as_agent(MockWorkspaceClient):
+    mock_space = GenieSpace(
+        space_id="space-id",
+        title="Sales Space",
+        description="description",
     )
-
-
-def test_create_message(genie, mock_workspace_client):
-    mock_workspace_client.genie._api.do.return_value = {"message_id": "456"}
-    response = genie.create_message("123", "Hello again")
-    assert response == {"message_id": "456"}
-    mock_workspace_client.genie._api.do.assert_called_once_with(
-        "POST",
-        "/api/2.0/genie/spaces/test_space_id/conversations/123/messages",
-        body={"content": "Hello again"},
-        headers=genie.headers,
+    MockWorkspaceClient.genie.get_space.return_value = mock_space
+    
+    # Create a proper GenieResponse instance
+    mock_genie_response = GenieResponse(
+        result='It is sunny.',
+        query='SELECT * FROM weather',
+        description='This is the reasoning for the query'
     )
-
-
-def test_poll_for_result_completed_with_text(genie, mock_workspace_client):
-    mock_workspace_client.genie._api.do.side_effect = [
-        {
-            "status": "COMPLETED",
-            "attachments": [{"attachment_id": "123", "text": {"content": "Result"}}],
-        },
-    ]
-    genie_result = genie.poll_for_result("123", "456")
-    assert genie_result.result == "Result"
-
-
-def test_poll_for_result_completed_with_query(genie, mock_workspace_client):
-    mock_workspace_client.genie._api.do.side_effect = [
-        {
-            "status": "COMPLETED",
-            "attachments": [{"attachment_id": "123", "query": {"query": "SELECT *"}}],
-        },
-        {
-            "statement_response": {
-                "status": {"state": "SUCCEEDED"},
-                "manifest": {"schema": {"columns": []}},
-                "result": {
-                    "data_array": [],
-                },
-            }
-        },
-    ]
-    genie_result = genie.poll_for_result("123", "456")
-    assert genie_result.result == pd.DataFrame().to_markdown()
-
-
-def test_poll_for_result_failed(genie, mock_workspace_client):
-    mock_workspace_client.genie._api.do.side_effect = [
-        {"status": "FAILED", "error": "Test error"},
-    ]
-    genie_result = genie.poll_for_result("123", "456")
-    assert genie_result.result == "Genie query failed with error: Test error"
-
-
-def test_poll_for_result_cancelled(genie, mock_workspace_client):
-    mock_workspace_client.genie._api.do.side_effect = [
-        {"status": "CANCELLED"},
-    ]
-    genie_result = genie.poll_for_result("123", "456")
-    assert genie_result.result == "Genie query cancelled."
-
-
-def test_poll_for_result_expired(genie, mock_workspace_client):
-    mock_workspace_client.genie._api.do.side_effect = [
-        {"status": "QUERY_RESULT_EXPIRED"},
-    ]
-    genie_result = genie.poll_for_result("123", "456")
-    assert genie_result.result == "Genie query query_result_expired."
-
-
-def test_poll_for_result_max_iterations(genie, mock_workspace_client):
-    # patch MAX_ITERATIONS to 2 for this test and sleep to avoid delays
-    with (
-        patch("databricks_ai_bridge.genie.MAX_ITERATIONS", 2),
-        patch("time.sleep", return_value=None),
-    ):
-        mock_workspace_client.genie._api.do.side_effect = [
-            {"status": "EXECUTING_QUERY"},
-            {"status": "EXECUTING_QUERY"},
-            {"status": "EXECUTING_QUERY"},
-        ]
-        result = genie.poll_for_result("123", "456")
-        assert result.result == "Genie query timed out after 2 iterations of 5 seconds"
-
-
-def test_ask_question(genie, mock_workspace_client):
-    mock_workspace_client.genie._api.do.side_effect = [
-        {"conversation_id": "123", "message_id": "456"},
-        {"status": "COMPLETED", "attachments": [{"text": {"content": "Answer"}}]},
-    ]
-    genie_result = genie.ask_question("What is the meaning of life?")
-    assert genie_result.result == "Answer"
-
-
-def test_parse_query_result_empty():
-    resp = {"manifest": {"schema": {"columns": []}}, "result": None}
-    result = _parse_query_result(resp)
-    assert result == "EMPTY"
-
-
-def test_parse_query_result_with_data():
-    resp = {
-        "manifest": {
-            "schema": {
-                "columns": [
-                    {"name": "id", "type_name": "INT"},
-                    {"name": "name", "type_name": "STRING"},
-                    {"name": "created_at", "type_name": "TIMESTAMP"},
-                ]
-            }
-        },
-        "result": {
-            "data_array": [
-                ["1", "Alice", "2023-10-01T00:00:00Z"],
-                ["2", "Bob", "2023-10-02T00:00:00Z"],
+    
+    input_data = {"messages": [{"role": "user", "content": "What is the weather?"}]}
+    genie = Genie("space-id", MockWorkspaceClient)
+    
+    # Mock the ask_question method to return our mock response
+    with patch.object(genie, 'ask_question', return_value=mock_genie_response):
+        # Test with include_context=False (default)
+        result = _query_genie_as_agent(input_data, genie, "Genie")
+        expected_message = {"messages": [AIMessage(content="It is sunny.", name="query_result")]}
+        assert result == expected_message
+        
+        # Test with include_context=True
+        result = _query_genie_as_agent(input_data, genie, "Genie", include_context=True)
+        expected_messages = {
+            "messages": [
+                AIMessage(content="This is the reasoning for the query", name="query_reasoning"),
+                AIMessage(content="SELECT * FROM weather", name="query_sql"),
+                AIMessage(content="It is sunny.", name="query_result")
             ]
-        },
-    }
-    result = _parse_query_result(resp)
-    expected_df = pd.DataFrame(
-        {
-            "id": [1, 2],
-            "name": ["Alice", "Bob"],
-            "created_at": [datetime(2023, 10, 1).date(), datetime(2023, 10, 2).date()],
         }
+        assert result == expected_messages
+
+
+@patch("databricks.sdk.WorkspaceClient")
+@patch("langchain_core.runnables.RunnableLambda")
+def test_create_genie_agent(MockRunnableLambda, MockWorkspaceClient):
+    mock_space = GenieSpace(
+        space_id="space-id",
+        title="Sales Space",
+        description="description",
     )
-    assert result == expected_df.to_markdown()
+    mock_client = MockWorkspaceClient.return_value
+    mock_client.genie.get_space.return_value = mock_space
+
+    agent = GenieAgent("space-id", "Genie", client=mock_client)
+    assert agent.description == "description"
+
+    mock_client.genie.get_space.assert_called_once()
+    assert agent == MockRunnableLambda.return_value
 
 
-def test_parse_query_result_with_null_values():
-    resp = {
-        "manifest": {
-            "schema": {
-                "columns": [
-                    {"name": "id", "type_name": "INT"},
-                    {"name": "name", "type_name": "STRING"},
-                    {"name": "created_at", "type_name": "TIMESTAMP"},
-                ]
-            }
-        },
-        "result": {
-            "data_array": [
-                ["1", None, "2023-10-01T00:00:00Z"],
-                ["2", "Bob", None],
-            ]
-        },
-    }
-    result = _parse_query_result(resp)
-    expected_df = pd.DataFrame(
-        {
-            "id": [1, 2],
-            "name": [None, "Bob"],
-            "created_at": [datetime(2023, 10, 1).date(), None],
-        }
+@patch("databricks.sdk.WorkspaceClient")
+@patch("langchain_core.runnables.RunnableLambda")
+def test_create_genie_agent_with_description(MockRunnableLambda, MockWorkspaceClient):
+    mock_space = GenieSpace(
+        space_id="space-id",
+        title="Sales Space",
+        description=None,
     )
-    assert result == expected_df.to_markdown()
+    mock_client = MockWorkspaceClient.return_value
+    mock_client.genie.get_space.return_value = mock_space
+
+    agent = GenieAgent("space-id", "Genie", "this is a description", client=mock_client)
+    assert agent.description == "this is a description"
+
+    mock_client.genie.get_space.assert_called_once()
+    assert agent == MockRunnableLambda.return_value
 
 
-def test_parse_query_result_trims_data():
-    # patch MAX_TOKENS_OF_DATA to 100 for this test
-    with patch("databricks_ai_bridge.genie.MAX_TOKENS_OF_DATA", 100):
-        resp = {
-            "manifest": {
-                "schema": {
-                    "columns": [
-                        {"name": "id", "type_name": "INT"},
-                        {"name": "name", "type_name": "STRING"},
-                        {"name": "created_at", "type_name": "TIMESTAMP"},
-                    ]
-                }
-            },
-            "result": {
-                "data_array": [
-                    ["1", "Alice", "2023-10-01T00:00:00Z"],
-                    ["2", "Bob", "2023-10-02T00:00:00Z"],
-                    ["3", "Charlie", "2023-10-03T00:00:00Z"],
-                    ["4", "David", "2023-10-04T00:00:00Z"],
-                    ["5", "Eve", "2023-10-05T00:00:00Z"],
-                    ["6", "Frank", "2023-10-06T00:00:00Z"],
-                    ["7", "Grace", "2023-10-07T00:00:00Z"],
-                    ["8", "Hank", "2023-10-08T00:00:00Z"],
-                    ["9", "Ivy", "2023-10-09T00:00:00Z"],
-                    ["10", "Jack", "2023-10-10T00:00:00Z"],
-                ]
-            },
-        }
-        result = _parse_query_result(resp)
-        assert (
-            result
-            == pd.DataFrame(
-                {
-                    "id": [1, 2, 3],
-                    "name": ["Alice", "Bob", "Charlie"],
-                    "created_at": [
-                        datetime(2023, 10, 1).date(),
-                        datetime(2023, 10, 2).date(),
-                        datetime(2023, 10, 3).date(),
-                    ],
-                }
-            ).to_markdown()
-        )
-        assert _count_tokens(result) <= 100
+@patch("databricks.sdk.WorkspaceClient")
+def test_query_genie_with_client(mock_workspace_client):
+    mock_workspace_client.genie.get_space.return_value = GenieSpace(
+        space_id="space-id",
+        title="Sales Space",
+        description="description",
+    )
+    
+    # Create a proper GenieResponse instance
+    mock_genie_response = GenieResponse(
+        result='It is sunny.',
+        query='SELECT weather FROM data',
+        description='Query reasoning'
+    )
+
+    input_data = {"messages": [{"role": "user", "content": "What is the weather?"}]}
+    genie = Genie("space-id", mock_workspace_client)
+    
+    # Mock the ask_question method to return our mock response
+    with patch.object(genie, 'ask_question', return_value=mock_genie_response):
+        result = _query_genie_as_agent(input_data, genie, "Genie")
+        expected_message = {"messages": [AIMessage(content="It is sunny.", name="query_result")]}
+        assert result == expected_message
 
 
-def markdown_to_dataframe(markdown_str: str) -> pd.DataFrame:
-    if markdown_str == "":
-        return pd.DataFrame()
+@patch("databricks.sdk.WorkspaceClient")
+@patch("langchain_core.runnables.RunnableLambda")
+def test_create_genie_agent_with_include_context(MockRunnableLambda, MockWorkspaceClient):
+    """Test creating a GenieAgent with include_context parameter"""
+    mock_space = GenieSpace(
+        space_id="space-id",
+        title="Sales Space",
+        description="description",
+    )
+    mock_client = MockWorkspaceClient.return_value
+    mock_client.genie.get_space.return_value = mock_space
 
-    lines = markdown_str.strip().splitlines()
+    # Test with include_context=True
+    agent = GenieAgent("space-id", "Genie", include_context=True, client=mock_client)
+    assert agent.description == "description"
 
-    # Remove Markdown separator row (2nd line)
-    lines = [line.strip().strip("|") for i, line in enumerate(lines) if i != 1]
-
-    # Re-join cleaned lines and parse
-    cleaned_markdown = "\n".join(lines)
-    df = pd.read_csv(StringIO(cleaned_markdown), sep="|")
-
-    # Strip whitespace from column names and values
-    df.columns = [col.strip() for col in df.columns]
-    df = df.applymap(lambda x: x.strip() if isinstance(x, str) else x)
-
-    # Drop the first column
-    df = df.drop(columns=[df.columns[0]])
-
-    return df
+    mock_client.genie.get_space.assert_called_once()
+    assert agent == MockRunnableLambda.return_value
 
 
-@pytest.mark.parametrize("max_tokens", [1, 100, 1000, 2000, 8000, 10000, 15000, 19000, 100000])
-def test_parse_query_result_trims_large_data(max_tokens):
-    """
-    Ensure _parse_query_result trims output to stay within token limits.
-    """
-    with patch("databricks_ai_bridge.genie.MAX_TOKENS_OF_DATA", max_tokens):
-        base_date = datetime(2023, 1, 1)
-        names = ["Alice", "Bob", "Charlie", "David", "Eve", "Frank", "Grace", "Hank", "Ivy", "Jack"]
-
-        data_array = [
-            [
-                str(i + 1),
-                random.choice(names),
-                (base_date + timedelta(days=random.randint(0, 365))).strftime("%Y-%m-%dT%H:%M:%SZ"),
-            ]
-            for i in range(1000)
-        ]
-
-        response = {
-            "manifest": {
-                "schema": {
-                    "columns": [
-                        {"name": "id", "type_name": "INT"},
-                        {"name": "name", "type_name": "STRING"},
-                        {"name": "created_at", "type_name": "TIMESTAMP"},
-                    ]
-                }
-            },
-            "result": {"data_array": data_array},
-        }
-
-        markdown_result = _parse_query_result(response)
-        result_df = markdown_to_dataframe(markdown_result)
-
-        expected_df = pd.DataFrame(
-            {
-                "id": [int(row[0]) for row in data_array],
-                "name": [row[1] for row in data_array],
-                "created_at": [
-                    datetime.strptime(row[2], "%Y-%m-%dT%H:%M:%SZ").date() for row in data_array
-                ],
-            }
-        )
-
-        expected_markdown = (
-            "" if len(result_df) == 0 else expected_df[: len(result_df)].to_markdown()
-        )
-        # Ensure result matches expected subset and respects token limit
-        assert markdown_result == expected_markdown
-        assert _count_tokens(markdown_result) <= max_tokens
-        # Ensure adding one more row would exceed token limit or we're at full length
-        next_row_exceeds = (
-            _count_tokens(expected_df.iloc[: len(result_df) + 1].to_markdown()) > max_tokens
-        )
-        assert len(result_df) == len(expected_df) or next_row_exceeds
-
-
-def test_poll_query_results_max_iterations(genie, mock_workspace_client):
-    # patch MAX_ITERATIONS to 2 for this test and sleep to avoid delays
-    with (
-        patch("databricks_ai_bridge.genie.MAX_ITERATIONS", 2),
-        patch("time.sleep", return_value=None),
-    ):
-        mock_workspace_client.genie._api.do.side_effect = [
-            {
-                "status": "COMPLETED",
-                "attachments": [{"attachment_id": "123", "query": {"query": "SELECT *"}}],
-            },
-            {"statement_response": {"status": {"state": "PENDING"}}},
-            {"statement_response": {"status": {"state": "PENDING"}}},
-            {"statement_response": {"status": {"state": "PENDING"}}},
-        ]
-        result = genie.poll_for_result("123", "456")
-        assert result.result == "Genie query for result timed out after 2 iterations of 5 seconds"
+def test_create_genie_agent_no_space_id():
+    with pytest.raises(ValueError):
+        GenieAgent("", "Genie")


### PR DESCRIPTION
## Changes
Adds `include_context` parameter to the Genie class. When set to true, the `_query_genie_as_agent` will send back the SQL command + reasoning from the Genie API call (which is already retrieved). It is set to false by default to maintain backwards compatibility!


## How it's tested
- Tested with new unit tests.
- Manual tests on local (query_reasoning, query_sql, and query_result are all there)
<img width="1306" alt="Screenshot 2025-06-30 at 4 14 25 PM" src="https://github.com/user-attachments/assets/a4ba1536-089a-461a-ad4c-1965840c486e" />

Manual test file:
```
#!/usr/bin/env python3
from databricks.sdk import WorkspaceClient
from databricks_langchain.genie import GenieAgent

GENIE_SPACE_ID = "01f03c3c97521c9db676ac39ec6a8166"


def test_genie_agent():
    """Test GenieAgent creation and basic usage"""
    print("=== Testing GenieAgent creation ===")
    
    try:
        client = WorkspaceClient()
        
        # Test creating GenieAgent
        agent = GenieAgent(
            genie_space_id=GENIE_SPACE_ID,
            genie_agent_name="TestAgent",
            description="Test agent for manual testing",
            include_context=True,
            client=client
        )
        
        # Test invoking the agent
        test_input = {
            "messages": [
                {"role": "user", "content": "On average, were customers bills higher in 2024 or 2025?"}
            ]
        }

        print("--------------------------------")
        print(f"Test input: {test_input}")
        print("--------------------------------")
        
        result = agent.invoke(test_input)
        print(f"Agent result type: {type(result)}")
        print(f"Agent result: {result}")
        
    except Exception as e:
        print(f"Error: {e}")
        return False
    
    print("✅ GenieAgent test completed successfully\n")
    return True

def main():
    """Run all tests"""
    print("🚀 Starting manual tests for Genie functionality")
    print(f"Using Genie Space ID: {GENIE_SPACE_ID}")
    print("=" * 50)
    
    if GENIE_SPACE_ID == "YOUR_GENIE_SPACE_ID_HERE":
        print("❌ Please replace GENIE_SPACE_ID with your actual Genie space ID")
        return
    
    tests = [
        test_genie_agent,
    ]
    
    passed = 0
    for test in tests:
        try:
            if test():
                passed += 1
        except Exception as e:
            print(f"Test {test.__name__} failed with exception: {e}\n")
    
    print("=" * 50)
    print(f"Tests completed: {passed}/{len(tests)} passed")

if __name__ == "__main__":
    main()
```
