### PR TITLE
Delegate fetch_token implementation to model serving

### DIFF
--- a/src/databricks_ai_bridge/model_serving_obo_credential_strategy.py
+++ b/src/databricks_ai_bridge/model_serving_obo_credential_strategy.py
@@ -27,13 +27,24 @@ def should_fetch_model_serving_environment_oauth() -> bool:
     return is_in_model_serving_env == "true"
 
 
-def _get_invokers_token():
+def _get_invokers_token_fallback():
     main_thread = threading.main_thread()
     thread_data = main_thread.__dict__
     invokers_token = None
     if "invokers_token" in thread_data:
         invokers_token = thread_data["invokers_token"]
+    return invokers_token
 
+
+def _get_invokers_token_from_mlflowserving():
+    try:
+        from mlflowserving.scoring_server.agent_utils import fetch_obo_token
+        return fetch_obo_token()
+    except ImportError:
+        return _get_invokers_token_fallback()
+
+def _get_invokers_token():
+    invokers_token = _get_invokers_token_from_mlflowserving()
     if invokers_token is None:
         raise RuntimeError(
             "Unable to read end user token in Databricks Model Serving. "
@@ -41,9 +52,7 @@ def _get_invokers_token():
             "and On Behalf of User Authorization for Agents is enabled in your workspace. "
             "If the issue persists, contact Databricks Support"
         )
-
     return invokers_token
-
 
 def get_databricks_host_token() -> Optional[Tuple[str, str]]:
     if not should_fetch_model_serving_environment_oauth():

--- a/src/databricks_ai_bridge/model_serving_obo_credential_strategy.py
+++ b/src/databricks_ai_bridge/model_serving_obo_credential_strategy.py
@@ -39,9 +39,11 @@ def _get_invokers_token_fallback():
 def _get_invokers_token_from_mlflowserving():
     try:
         from mlflowserving.scoring_server.agent_utils import fetch_obo_token
+
         return fetch_obo_token()
     except ImportError:
         return _get_invokers_token_fallback()
+
 
 def _get_invokers_token():
     invokers_token = _get_invokers_token_from_mlflowserving()
@@ -53,6 +55,7 @@ def _get_invokers_token():
             "If the issue persists, contact Databricks Support"
         )
     return invokers_token
+
 
 def get_databricks_host_token() -> Optional[Tuple[str, str]]:
     if not should_fetch_model_serving_environment_oauth():

--- a/tests/databricks_ai_bridge/test_model_serving_obo_credential_strategy.py
+++ b/tests/databricks_ai_bridge/test_model_serving_obo_credential_strategy.py
@@ -77,7 +77,7 @@ def test_agent_user_credentials_in_non_model_serving_environments(monkeypatch):
 
 def test_agent_user_credentials_with_mlflowserving_mock(monkeypatch):
     """Test authentication using mocked mlflowserving.scoring_server.agent_utils.fetch_obo_token"""
-    
+
     # Guarantee that the tests defaults to env variables rather than config file.
     monkeypatch.setenv("DATABRICKS_CONFIG_FILE", "x")
     monkeypatch.setenv("IS_IN_DB_MODEL_SERVING_ENV", "true")
@@ -87,15 +87,15 @@ def test_agent_user_credentials_with_mlflowserving_mock(monkeypatch):
     mock_mlflowserving = MagicMock()
     mock_agent_utils = MagicMock()
     mock_scoring_server = MagicMock()
-    
+
     # Create the nested module structure
     mock_mlflowserving.scoring_server = mock_scoring_server
     mock_scoring_server.agent_utils = mock_agent_utils
-    
+
     # Set up the mock function to return a token
     initial_token = "mlflow_obo_token_123"
     mock_agent_utils.fetch_obo_token.return_value = initial_token
-    
+
     # Add the mock module to sys.modules
     monkeypatch.setitem(sys.modules, "mlflowserving", mock_mlflowserving)
     monkeypatch.setitem(sys.modules, "mlflowserving.scoring_server", mock_scoring_server)
@@ -108,17 +108,17 @@ def test_agent_user_credentials_with_mlflowserving_mock(monkeypatch):
     headers = cfg.authenticate()
     assert cfg.host == "https://test-host.databricks.com"
     assert headers.get("Authorization") == f"Bearer {initial_token}"
-    
+
     # Verify that fetch_obo_token was called
     mock_agent_utils.fetch_obo_token.assert_called()
 
     # Test token refresh - update the mock to return a new token
     updated_token = "mlflow_obo_token_456"
     mock_agent_utils.fetch_obo_token.return_value = updated_token
-    
+
     # Authenticate again to test token refresh
     headers = cfg.authenticate()
     assert headers.get("Authorization") == f"Bearer {updated_token}"
-    
+
     # Verify fetch_obo_token was called again
     assert mock_agent_utils.fetch_obo_token.call_count >= 2

--- a/tests/databricks_ai_bridge/test_model_serving_obo_credential_strategy.py
+++ b/tests/databricks_ai_bridge/test_model_serving_obo_credential_strategy.py
@@ -1,5 +1,5 @@
-import threading
 import sys
+import threading
 from unittest.mock import MagicMock
 
 from databricks.sdk.core import Config

--- a/tests/databricks_ai_bridge/test_model_serving_obo_credential_strategy.py
+++ b/tests/databricks_ai_bridge/test_model_serving_obo_credential_strategy.py
@@ -1,4 +1,6 @@
 import threading
+import sys
+from unittest.mock import MagicMock
 
 from databricks.sdk.core import Config
 
@@ -71,3 +73,52 @@ def test_agent_user_credentials_in_non_model_serving_environments(monkeypatch):
 
     assert cfg.host == "https://x"
     assert headers.get("Authorization") == "Bearer token"
+
+
+def test_agent_user_credentials_with_mlflowserving_mock(monkeypatch):
+    """Test authentication using mocked mlflowserving.scoring_server.agent_utils.fetch_obo_token"""
+    
+    # Guarantee that the tests defaults to env variables rather than config file.
+    monkeypatch.setenv("DATABRICKS_CONFIG_FILE", "x")
+    monkeypatch.setenv("IS_IN_DB_MODEL_SERVING_ENV", "true")
+    monkeypatch.setenv("DB_MODEL_SERVING_HOST_URL", "https://test-host.databricks.com")
+
+    # Mock the mlflowserving module and fetch_obo_token function
+    mock_mlflowserving = MagicMock()
+    mock_agent_utils = MagicMock()
+    mock_scoring_server = MagicMock()
+    
+    # Create the nested module structure
+    mock_mlflowserving.scoring_server = mock_scoring_server
+    mock_scoring_server.agent_utils = mock_agent_utils
+    
+    # Set up the mock function to return a token
+    initial_token = "mlflow_obo_token_123"
+    mock_agent_utils.fetch_obo_token.return_value = initial_token
+    
+    # Add the mock module to sys.modules
+    monkeypatch.setitem(sys.modules, "mlflowserving", mock_mlflowserving)
+    monkeypatch.setitem(sys.modules, "mlflowserving.scoring_server", mock_scoring_server)
+    monkeypatch.setitem(sys.modules, "mlflowserving.scoring_server.agent_utils", mock_agent_utils)
+
+    # Test authentication with the mocked mlflowserving
+    cfg = Config(credentials_strategy=ModelServingUserCredentials())
+    assert cfg.auth_type == "model_serving_user_credentials"
+
+    headers = cfg.authenticate()
+    assert cfg.host == "https://test-host.databricks.com"
+    assert headers.get("Authorization") == f"Bearer {initial_token}"
+    
+    # Verify that fetch_obo_token was called
+    mock_agent_utils.fetch_obo_token.assert_called()
+
+    # Test token refresh - update the mock to return a new token
+    updated_token = "mlflow_obo_token_456"
+    mock_agent_utils.fetch_obo_token.return_value = updated_token
+    
+    # Authenticate again to test token refresh
+    headers = cfg.authenticate()
+    assert headers.get("Authorization") == f"Bearer {updated_token}"
+    
+    # Verify fetch_obo_token was called again
+    assert mock_agent_utils.fetch_obo_token.call_count >= 2


### PR DESCRIPTION
Delegate fetch_token implementation to model serving
This will help us change the model serving code for auth
changes without the need to change agent sdk

Testing via UTs.