### PR TITLE
Fix MCP Test

### DIFF
--- a/mcp/tests/unit_tests/test_oauth_provider.py
+++ b/mcp/tests/unit_tests/test_oauth_provider.py
@@ -10,7 +10,7 @@ from databricks_mcp import DatabricksOAuthClientProvider
 async def test_oauth_provider():
     workspace_client = WorkspaceClient(host="https://test-databricks.com", token="test-token")
     provider = DatabricksOAuthClientProvider(workspace_client=workspace_client)
-    oauth_token = await provider.storage.get_tokens()
+    oauth_token = await provider.context.storage.get_tokens()
     assert oauth_token.access_token == "test-token"
     assert oauth_token.expires_in == 60
     assert oauth_token.token_type.lower() == "bearer"
@@ -27,7 +27,8 @@ async def test_authenticate_raises_exception():
             ValueError, match="Invalid authentication token format. Expected Bearer token."
         ):
             provider = DatabricksOAuthClientProvider(workspace_client=workspace_client)
-            oauth_token = await provider.storage.get_tokens()
+
+            oauth_token = await provider.context.storage.get_tokens()
             assert oauth_token.access_token == "test-token"
             assert oauth_token.expires_in == 60
             assert oauth_token.token_type.lower() == "bearer"


### PR DESCRIPTION
With the new MCP Release the storage object is abstracted inside of context. So fixed the tests