### PR TITLE
Adding databricks-ai-bridge package to databricks_mcp since its missi…

### DIFF
--- a/databricks_mcp/pyproject.toml
+++ b/databricks_mcp/pyproject.toml
@@ -11,6 +11,7 @@ requires-python = ">=3.10"
 dependencies = [
     "mcp>=1.9.1",
     "databricks-sdk>=0.49.0",
+    "databricks-ai-bridge>=0.4.2",
     "mlflow>=3.1"
 ]
 


### PR DESCRIPTION
Adding databricks-ai-bridge package to databricks_mcp since its missing the dep

Its used here: https://github.com/databricks/databricks-ai-bridge/blob/main/databricks_mcp/src/databricks_mcp/mcp.py#L8
But its not installed as a dep.
So fixing that. 

