### PR TITLE
Add DSPy integration in databricks-ai-bridge

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -224,3 +224,24 @@ jobs:
       - name: Run tests
         run: |
           pytest databricks_mcp/tests/unit_tests
+
+  dspy_test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.10"]
+    timeout-minutes: 20
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          pip install .
+          pip install integrations/dspy[dev]
+      - name: Run tests
+        run: |
+          pytest integrations/dspy/tests/unit_tests

--- a/integrations/dspy/README.md
+++ b/integrations/dspy/README.md
@@ -1,0 +1,37 @@
+# Databricks DSPy Integration
+
+The `databricks-dspy` package provides Databricks extensions for DSPy, with a purpose of facilitating the usage
+of DSPy on Databricks platform.
+
+## Installation
+
+### From PyPI
+```sh
+pip install databricks-dspy
+```
+
+### From Source
+```sh
+pip install git+https://git@github.com/databricks/databricks-ai-bridge.git#subdirectory=integrations/dspy
+```
+
+## Key Features
+
+- **LLMs Integration:** Use Databricks-hosted LLM endpoints.
+
+## Getting Started
+
+### Use LLMs on Databricks
+
+```python
+import databricks_dspy
+import dspy
+
+dspy.configure(lm=databricks_dspy.DatabricksLM(model="databricks/databricks-llama-4-maverick"))
+
+predict = dspy.Predict("question->answer")
+
+print(predict(question="why did a chicken cross the kitchen?"))
+```
+
+

--- a/integrations/dspy/pyproject.toml
+++ b/integrations/dspy/pyproject.toml
@@ -1,0 +1,61 @@
+[project]
+name = "databricks-dspy"
+version = "0.0.1"
+description = "Databricks integration for DSPy"
+authors = [
+    { name="Databricks", email="agent-feedback@databricks.com" },
+]
+readme = "README.md"
+license = { text="Apache-2.0" }
+requires-python = ">=3.10"
+dependencies = [
+    "dspy>=2.6.27",
+    "databricks-sdk>=0.58.0",
+]
+
+[project.optional-dependencies]
+dev = [
+  "pytest",
+  "ruff",
+]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build]
+include = [
+  "src/databricks_dspy/*"
+]
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/databricks_dspy"]
+
+[tool.ruff]
+line-length = 100
+target-version = "py310"
+
+[tool.ruff.lint]
+select = [
+  # isort
+  "I",
+  # bugbear rules
+  "B",
+  # remove unused imports
+  "F401",
+  # bare except statements
+  "E722",
+  # print statements
+  "T201",
+  "T203",
+  # misuse of typing.TYPE_CHECKING
+  "TCH004",
+  # import rules
+  "TID251",
+  # undefined-local-with-import-star
+  "F403",
+]
+
+[tool.ruff.format]
+docstring-code-format = true
+docstring-code-line-length = 88

--- a/integrations/dspy/src/databricks_dspy/__init__.py
+++ b/integrations/dspy/src/databricks_dspy/__init__.py
@@ -1,0 +1,3 @@
+from databricks_dspy.clients import DatabricksLM
+
+__all__ = ["DatabricksLM"]

--- a/integrations/dspy/src/databricks_dspy/clients/__init__.py
+++ b/integrations/dspy/src/databricks_dspy/clients/__init__.py
@@ -1,0 +1,3 @@
+from databricks_dspy.clients.databricks_lm import DatabricksLM
+
+__all__ = ["DatabricksLM"]

--- a/integrations/dspy/src/databricks_dspy/clients/databricks_lm.py
+++ b/integrations/dspy/src/databricks_dspy/clients/databricks_lm.py
@@ -1,0 +1,36 @@
+from typing import Optional
+
+import dspy
+from databricks.sdk import WorkspaceClient
+
+
+class DatabricksLM(dspy.LM):
+    def __init__(
+        self,
+        model: str,
+        workspace_client: Optional[WorkspaceClient] = None,
+        **kwargs,
+    ):
+        super().__init__(model=model, **kwargs)
+
+        if workspace_client:
+            self.workspace_client = workspace_client
+        else:
+            self.workspace_client = WorkspaceClient()
+
+        try:
+            # If credentials are invalid, `w.current_user.me()` will throw an error.
+            self.workspace_client.current_user.me()
+        except Exception as e:
+            raise RuntimeError(
+                "Failed to validate databricks credentials, please refer to "
+                "https://docs.databricks.com/aws/en/dev-tools/auth/unified-auth#default-methods-for-client-unified-authentication "  # noqa: E501
+                "for how to set up the authentication."
+            ) from e
+
+    def forward(self, **kwargs):
+        return super().forward(
+            headers=self.workspace_client.config.authenticate(),
+            api_base=f"{self.workspace_client.config.host}/serving-endpoints",
+            **kwargs,
+        )

--- a/integrations/dspy/tests/unit_tests/clients/test_databricks_lm.py
+++ b/integrations/dspy/tests/unit_tests/clients/test_databricks_lm.py
@@ -1,0 +1,52 @@
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from databricks_dspy.clients.databricks_lm import DatabricksLM
+
+
+def test_forward_invokes_authenticate():
+    mock_ws_client = MagicMock()
+    mock_ws_client.config.authenticate.return_value = {"Authorization": "Bearer token"}
+    mock_ws_client.config.host = "https://test-host"
+    mock_ws_client.current_user.me.return_value = "some valid value"
+    lm = DatabricksLM(model="test-model", workspace_client=mock_ws_client)
+
+    with patch("databricks_dspy.clients.databricks_lm.dspy.LM.forward") as mock_super_forward:
+        # Call the LM (`DatabricksLM.__call__` will call `forward`)
+        lm("test input")
+        # `authenticate` should be called
+        assert mock_ws_client.config.authenticate.called
+        mock_super_forward.assert_called_once()
+
+        _, kwargs = mock_super_forward.call_args
+        assert kwargs["headers"] == {"Authorization": "Bearer token"}
+        assert kwargs["api_base"] == "https://test-host/serving-endpoints"
+        assert kwargs["prompt"] == "test input"
+
+
+def test_valid_credentials():
+    with patch("databricks_dspy.clients.databricks_lm.WorkspaceClient") as MockWSClient:
+        mock_ws = MagicMock()
+        mock_current_user = MagicMock()
+        # Simulate valid credentials
+        mock_current_user.me.return_value = "some valid value"
+        mock_ws.current_user = mock_current_user
+        MockWSClient.return_value = mock_ws
+
+        DatabricksLM(model="test-model")
+        mock_current_user.me.assert_called_once()
+
+
+def test_invalid_credentials_raise_error():
+    with patch("databricks_dspy.clients.databricks_lm.WorkspaceClient") as MockWSClient:
+        mock_ws = MagicMock()
+        mock_current_user = MagicMock()
+        # Simulate invalid credentials (raise on me())
+        mock_current_user.me.side_effect = Exception("auth failed")
+        mock_ws.current_user = mock_current_user
+        MockWSClient.return_value = mock_ws
+
+        with pytest.raises(RuntimeError, match="Failed to validate databricks credentials"):
+            DatabricksLM(model="test-model")
+        mock_current_user.me.assert_called_once()


### PR DESCRIPTION
This PR includes:

- Project setup, e.g., pyproject.toml, README, ...
- Add `DatabricksLM` which bypasses the issue that litellm creates a workspaceclient at every LM call, which causes authentication service to throttle.