### PR TITLE
Extend the databricks_ai_bridge.genie.ask_question method to allow conversation ids

### DIFF
--- a/src/databricks_ai_bridge/genie.py
+++ b/src/databricks_ai_bridge/genie.py
@@ -126,7 +126,7 @@ class Genie:
     @mlflow.trace()
     def poll_for_result(self, conversation_id, message_id):
         @mlflow.trace()
-        def poll_query_results(attachment_id, query_str, description):
+        def poll_query_results(attachment_id, query_str, description, conversation_id=conversation_id):
             iteration_count = 0
             while iteration_count < MAX_ITERATIONS:
                 iteration_count += 1
@@ -136,20 +136,22 @@ class Genie:
                     headers=self.headers,
                 )["statement_response"]
                 state = resp["status"]["state"]
+                returned_conversation_id = resp.get("conversation_id", None)
                 if state == "SUCCEEDED":
                     result = _parse_query_result(resp)
-                    return GenieResponse(result, query_str, description)
+                    return GenieResponse(result, query_str, description, returned_conversation_id)
                 elif state in ["RUNNING", "PENDING"]:
                     logging.debug("Waiting for query result...")
                     time.sleep(5)
                 else:
                     return GenieResponse(
-                        f"No query result: {resp['state']}", query_str, description
+                        f"No query result: {resp['state']}", query_str, description, returned_conversation_id
                     )
             return GenieResponse(
                 f"Genie query for result timed out after {MAX_ITERATIONS} iterations of 5 seconds",
                 query_str,
                 description,
+                conversation_id
             )
 
         @mlflow.trace()
@@ -162,6 +164,7 @@ class Genie:
                     f"/api/2.0/genie/spaces/{self.space_id}/conversations/{conversation_id}/messages/{message_id}",
                     headers=self.headers,
                 )
+                returned_conversation_id = resp.get("conversation_id", None)
                 if resp["status"] == "COMPLETED":
                     attachment = next((r for r in resp["attachments"] if "query" in r), None)
                     if attachment:
@@ -169,12 +172,12 @@ class Genie:
                         description = query_obj.get("description", "")
                         query_str = query_obj.get("query", "")
                         attachment_id = attachment["attachment_id"]
-                        return poll_query_results(attachment_id, query_str, description)
+                        return poll_query_results(attachment_id, query_str, description, returned_conversation_id)
                     if resp["status"] == "COMPLETED":
                         text_content = next(r for r in resp["attachments"] if "text" in r)["text"][
                             "content"
                         ]
-                        return GenieResponse(result=text_content)
+                        return GenieResponse(result=text_content, conversation_id=returned_conversation_id)
                 elif resp["status"] in {"CANCELLED", "QUERY_RESULT_EXPIRED"}:
                     return GenieResponse(result=f"Genie query {resp['status'].lower()}.")
                 elif resp["status"] == "FAILED":
@@ -186,7 +189,8 @@ class Genie:
                     logging.debug(f"Waiting...: {resp['status']}")
                     time.sleep(5)
             return GenieResponse(
-                f"Genie query timed out after {MAX_ITERATIONS} iterations of 5 seconds"
+                f"Genie query timed out after {MAX_ITERATIONS} iterations of 5 seconds",
+                conversation_id=conversation_id
             )
 
         return poll_result()

--- a/tests/databricks_ai_bridge/test_genie.py
+++ b/tests/databricks_ai_bridge/test_genie.py
@@ -122,6 +122,45 @@ def test_ask_question(genie, mock_workspace_client):
     ]
     genie_result = genie.ask_question("What is the meaning of life?")
     assert genie_result.result == "Answer"
+    assert genie_result.conversation_id == "123"
+
+
+def test_ask_question_continued_conversation(genie, mock_workspace_client):
+    mock_workspace_client.genie._api.do.side_effect = [
+        {"conversation_id": "123", "message_id": "456"},
+        {"status": "COMPLETED", "attachments": [{"text": {"content": "42"}}]},
+    ]
+    genie_result = genie.ask_question("What is the meaning of life?", "123")
+    assert genie_result.result == "42"
+    assert genie_result.conversation_id == "123"
+
+
+def test_ask_question_calls_start_once_and_not_create_on_new(genie, mock_workspace_client):
+    # arrange
+    with patch.object(genie, "create_message") as mock_create_message, \
+            patch.object(genie, "start_conversation") as mock_start_conversation, \
+            patch.object(genie, "poll_for_result") as mock_poll_for_result:
+
+        # act
+        genie.ask_question("What is the meaning of life?")
+
+        # assert
+        mock_create_message.assert_not_called()
+        mock_start_conversation.assert_called_once()
+
+
+def test_ask_question_calls_create_once_and_not_start_on_continue(genie, mock_workspace_client):
+    # arrange
+    with patch.object(genie, "create_message") as mock_create_message, \
+            patch.object(genie, "start_conversation") as mock_start_conversation, \
+            patch.object(genie, "poll_for_result") as mock_poll_for_result:
+
+        # act
+        genie.ask_question("What is the meaning of life?", "123")
+
+        # assert
+        mock_create_message.assert_called_once()
+        mock_start_conversation.assert_not_called()
 
 
 def test_parse_query_result_empty():


### PR DESCRIPTION
This extends the base Genie and GenieResponse class to include the conversation_id returned by the genie sdk. Often a genie space will ask clarifying questions and so the existing conversation needs to be continued. Example:

<img width="613" height="163" alt="image" src="https://github.com/user-attachments/assets/1d6c4660-422b-4d21-a823-5e8b34367960" />

In the above case the genie space asked for my employee number. By providing it along with the conversation id returned from the previous response, the conversation was maintained and the genie could answer correctly.