### PR TITLE
Update VectorSearchRetrieverTool docs for langchain/openai to document additional parameters and kwargs passthrough during tool execution

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ __pycache__
 dist/
 *.egg-info/
 Pipfile
+docs/build

--- a/integrations/langchain/src/databricks_langchain/vector_search_retriever_tool.py
+++ b/integrations/langchain/src/databricks_langchain/vector_search_retriever_tool.py
@@ -20,6 +20,14 @@ class VectorSearchRetrieverTool(BaseTool, VectorSearchRetrieverToolMixin):
     A utility class to create a vector search-based retrieval tool for querying indexed embeddings.
     This class integrates with Databricks Vector Search and provides a convenient interface
     for building a retriever tool for agents.
+
+    Note: Any additional keyword arguments passed to the constructor will be passed along to
+    :meth:`~databricks_langchain.vectorstores.DatabricksVectorSearch.similarity_search`. See
+    documentation for :meth:`~databricks_langchain.vectorstores.DatabricksVectorSearch.similarity_search`
+    to see the full set of supported keyword arguments, e.g. `score_threshold`.
+
+    Additionally, see documentation for :class:`~databricks_ai_bridge.vector_search_retriever_tool.VectorSearchRetrieverToolMixin` for details on additional supported parameters, including
+    `query_type` and `num_results`.
     """
 
     text_column: Optional[str] = Field(

--- a/integrations/langchain/src/databricks_langchain/vector_search_retriever_tool.py
+++ b/integrations/langchain/src/databricks_langchain/vector_search_retriever_tool.py
@@ -21,7 +21,7 @@ class VectorSearchRetrieverTool(BaseTool, VectorSearchRetrieverToolMixin):
     This class integrates with Databricks Vector Search and provides a convenient interface
     for building a retriever tool for agents.
 
-    Note: Any additional keyword arguments passed to the constructor will be passed along to
+    **Note**: Any additional keyword arguments passed to the constructor will be passed along to
     :meth:`~databricks_langchain.vectorstores.DatabricksVectorSearch.similarity_search`. See
     documentation for :meth:`~databricks_langchain.vectorstores.DatabricksVectorSearch.similarity_search`
     to see the full set of supported keyword arguments, e.g. `score_threshold`.

--- a/integrations/langchain/src/databricks_langchain/vector_search_retriever_tool.py
+++ b/integrations/langchain/src/databricks_langchain/vector_search_retriever_tool.py
@@ -22,11 +22,11 @@ class VectorSearchRetrieverTool(BaseTool, VectorSearchRetrieverToolMixin):
     for building a retriever tool for agents.
 
     **Note**: Any additional keyword arguments passed to the constructor will be passed along to
-    :meth:`~databricks_langchain.vectorstores.DatabricksVectorSearch.similarity_search`. See
-    documentation for :meth:`~databricks_langchain.vectorstores.DatabricksVectorSearch.similarity_search`
-    to see the full set of supported keyword arguments, e.g. `score_threshold`.
-
-    Additionally, see documentation for :class:`~databricks_ai_bridge.vector_search_retriever_tool.VectorSearchRetrieverToolMixin` for details on additional supported parameters, including
+    `databricks.vector_search.client.VectorSearchIndex.similarity_search` when executing the tool. `See
+    documentation <https://api-docs.databricks.com/python/vector-search/databricks.vector_search.html#databricks.vector_search.index.VectorSearchIndex.similarity_search>`_
+    to see the full set of supported keyword arguments,
+    e.g. `score_threshold`. Additionally, see documentation for
+    :class:`~databricks_ai_bridge.vector_search_retriever_tool.VectorSearchRetrieverToolMixin` for details on additional supported parameters, including
     `query_type` and `num_results`.
     """
 

--- a/integrations/langchain/src/databricks_langchain/vector_search_retriever_tool.py
+++ b/integrations/langchain/src/databricks_langchain/vector_search_retriever_tool.py
@@ -25,9 +25,9 @@ class VectorSearchRetrieverTool(BaseTool, VectorSearchRetrieverToolMixin):
     `databricks.vector_search.client.VectorSearchIndex.similarity_search` when executing the tool. `See
     documentation <https://api-docs.databricks.com/python/vector-search/databricks.vector_search.html#databricks.vector_search.index.VectorSearchIndex.similarity_search>`_
     to see the full set of supported keyword arguments,
-    e.g. `score_threshold`. Additionally, see documentation for
-    :class:`~databricks_ai_bridge.vector_search_retriever_tool.VectorSearchRetrieverToolMixin` for details on additional supported parameters, including
-    `query_type` and `num_results`.
+    e.g. `score_threshold`. Also, see documentation for
+    :class:`~databricks_ai_bridge.vector_search_retriever_tool.VectorSearchRetrieverToolMixin` for additional supported constructor
+    arguments not listed below, including `query_type` and `num_results`.
     """
 
     text_column: Optional[str] = Field(

--- a/integrations/langchain/src/databricks_langchain/vectorstores.py
+++ b/integrations/langchain/src/databricks_langchain/vectorstores.py
@@ -410,6 +410,9 @@ class DatabricksVectorSearch(VectorStore):
             k: Number of Documents to return. Defaults to 4.
             filter: Filters to apply to the query. Defaults to None.
             query_type: The type of this query. Supported values are "ANN" and "HYBRID".
+            kwargs: Additional keyword arguments to pass to `databricks.vector_search.client.VectorSearchIndex.similarity_search`. `See
+                    documentation <https://api-docs.databricks.com/python/vector-search/databricks.vector_search.html#databricks.vector_search.index.VectorSearchIndex.similarity_search>`_
+                    to see the full set of supported keyword arguments
 
         Returns:
             List of Documents most similar to the embedding.
@@ -446,6 +449,9 @@ class DatabricksVectorSearch(VectorStore):
             k: Number of Documents to return. Defaults to 4.
             filter: Filters to apply to the query. Defaults to None.
             query_type: The type of this query. Supported values are "ANN" and "HYBRID".
+            kwargs: Additional keyword arguments to pass to `databricks.vector_search.client.VectorSearchIndex.similarity_search`. `See
+                    documentation <https://api-docs.databricks.com/python/vector-search/databricks.vector_search.html#databricks.vector_search.index.VectorSearchIndex.similarity_search>`_
+                    to see the full set of supported keyword arguments
 
         Returns:
             List of Documents most similar to the embedding and score for each.
@@ -514,6 +520,9 @@ class DatabricksVectorSearch(VectorStore):
             k: Number of Documents to return. Defaults to 4.
             filter: Filters to apply to the query. Defaults to None.
             query_type: The type of this query. Supported values are "ANN" and "HYBRID".
+            kwargs: Additional keyword arguments to pass to `databricks.vector_search.client.VectorSearchIndex.similarity_search`. `See
+                    documentation <https://api-docs.databricks.com/python/vector-search/databricks.vector_search.html#databricks.vector_search.index.VectorSearchIndex.similarity_search>`_
+                    to see the full set of supported keyword arguments
 
         Returns:
             List of Documents most similar to the embedding.
@@ -561,6 +570,9 @@ class DatabricksVectorSearch(VectorStore):
             k: Number of Documents to return. Defaults to 4.
             filter: Filters to apply to the query. Defaults to None.
             query_type: The type of this query. Supported values are "ANN" and "HYBRID".
+            kwargs: Additional keyword arguments to pass to `databricks.vector_search.client.VectorSearchIndex.similarity_search`. `See
+                    documentation <https://api-docs.databricks.com/python/vector-search/databricks.vector_search.html#databricks.vector_search.index.VectorSearchIndex.similarity_search>`_
+                    to see the full set of supported keyword arguments
 
         Returns:
             List of Documents most similar to the embedding and score for each.

--- a/integrations/openai/src/databricks_openai/vector_search_retriever_tool.py
+++ b/integrations/openai/src/databricks_openai/vector_search_retriever_tool.py
@@ -30,14 +30,6 @@ class VectorSearchRetrieverTool(VectorSearchRetrieverToolMixin):
     This class integrates with Databricks Vector Search and provides a convenient interface
     for tool calling using the OpenAI SDK.
 
-    Note: Any additional keyword arguments passed to the constructor will be passed along to
-    `databricks.vector_search.client.VectorSearchIndex.similarity_search` when executing the tool. `See
-    documentation <https://api-docs.databricks.com/python/vector-search/databricks.vector_search.html#databricks.vector_search.index.VectorSearchIndex.similarity_search>`_
-    to see the full set of supported keyword arguments,
-    e.g. `score_threshold`. Additionally, see documentation for
-    :class:`~databricks_ai_bridge.vector_search_retriever_tool.VectorSearchRetrieverToolMixin` for details on additional supported parameters, including
-    `query_type` and `num_results`.
-
     Example:
         Step 1: Call model with VectorSearchRetrieverTool defined
 
@@ -76,6 +68,14 @@ class VectorSearchRetrieverTool(VectorSearchRetrieverToolMixin):
             second_response = client.chat.completions.create(
                 model="gpt-4o", messages=messages, tools=tools
             )
+
+    **Note**: Any additional keyword arguments passed to the constructor will be passed along to
+    `databricks.vector_search.client.VectorSearchIndex.similarity_search` when executing the tool. `See
+    documentation <https://api-docs.databricks.com/python/vector-search/databricks.vector_search.html#databricks.vector_search.index.VectorSearchIndex.similarity_search>`_
+    to see the full set of supported keyword arguments,
+    e.g. `score_threshold`. Additionally, see documentation for
+    :class:`~databricks_ai_bridge.vector_search_retriever_tool.VectorSearchRetrieverToolMixin` for details on additional supported parameters, including
+    `query_type` and `num_results`.
     """
 
     text_column: Optional[str] = Field(

--- a/integrations/openai/src/databricks_openai/vector_search_retriever_tool.py
+++ b/integrations/openai/src/databricks_openai/vector_search_retriever_tool.py
@@ -73,9 +73,9 @@ class VectorSearchRetrieverTool(VectorSearchRetrieverToolMixin):
     `databricks.vector_search.client.VectorSearchIndex.similarity_search` when executing the tool. `See
     documentation <https://api-docs.databricks.com/python/vector-search/databricks.vector_search.html#databricks.vector_search.index.VectorSearchIndex.similarity_search>`_
     to see the full set of supported keyword arguments,
-    e.g. `score_threshold`. Additionally, see documentation for
-    :class:`~databricks_ai_bridge.vector_search_retriever_tool.VectorSearchRetrieverToolMixin` for details on additional supported parameters, including
-    `query_type` and `num_results`.
+    e.g. `score_threshold`. Also, see documentation for
+    :class:`~databricks_ai_bridge.vector_search_retriever_tool.VectorSearchRetrieverToolMixin` for additional supported constructor
+    arguments not listed below, including `query_type` and `num_results`.
     """
 
     text_column: Optional[str] = Field(

--- a/integrations/openai/src/databricks_openai/vector_search_retriever_tool.py
+++ b/integrations/openai/src/databricks_openai/vector_search_retriever_tool.py
@@ -30,6 +30,14 @@ class VectorSearchRetrieverTool(VectorSearchRetrieverToolMixin):
     This class integrates with Databricks Vector Search and provides a convenient interface
     for tool calling using the OpenAI SDK.
 
+    Note: Any additional keyword arguments passed to the constructor will be passed along to
+    `databricks.vector_search.client.VectorSearchIndex.similarity_search` when executing the tool. `See
+    documentation <https://api-docs.databricks.com/python/vector-search/databricks.vector_search.html#databricks.vector_search.index.VectorSearchIndex.similarity_search>`_
+    to see the full set of supported keyword arguments,
+    e.g. `score_threshold`. Additionally, see documentation for
+    :class:`~databricks_ai_bridge.vector_search_retriever_tool.VectorSearchRetrieverToolMixin` for details on additional supported parameters, including
+    `query_type` and `num_results`.
+
     Example:
         Step 1: Call model with VectorSearchRetrieverTool defined
 


### PR DESCRIPTION
See title. Tested by manually previewing docs:

<img width="780" height="868" alt="image" src="https://github.com/user-attachments/assets/d1fb6897-a76c-4ece-8a8a-239b45c6da5f" />
<img width="730" height="864" alt="image" src="https://github.com/user-attachments/assets/f3bcc3e1-988b-4cba-876c-e6d95704702b" />
