### PR TITLE
Add integration test for databricks-dspy

### DIFF
--- a/integrations/dspy/tests/integration_tests/test_databricks_lm.py
+++ b/integrations/dspy/tests/integration_tests/test_databricks_lm.py
@@ -1,0 +1,45 @@
+import os
+from datetime import timedelta
+
+import pytest
+from databricks.sdk import WorkspaceClient
+from databricks.sdk.service.jobs import RunLifecycleStateV2State, TerminationTypeType
+
+
+@pytest.mark.timeout(3600)
+def test_databricks_lm():
+    """
+    This test simply triggers a predefined Databricks job to verify the functionality
+    of the DatabricksLM class.
+    """
+    test_job_id = os.getenv("DATABRICKS_LM_TEST_JOB_ID")
+    branch_name = os.getenv("BRANCH_NAME")
+    fork_name = os.getenv("FORK_NAME")
+
+    if not test_job_id:
+        raise RuntimeError(
+            "Please set the environment variable DATABRICKS_LM_TEST_JOB_ID",
+        )
+
+    w = WorkspaceClient()
+
+    # Check if there is any ongoing job run
+    run_list = list(w.jobs.list_runs(job_id=test_job_id, active_only=True))
+    no_active_run = len(run_list) == 0
+    assert no_active_run, "There is an ongoing job run. Please wait for it to complete."
+
+    # Trigger the workflow
+    response = w.jobs.run_now(
+        job_id=test_job_id,
+        job_parameters={
+            "branch_name": branch_name or "main",
+            "fork_name": fork_name or "databricks",
+        },
+    )
+    job_url = f"{w.config.host}/jobs/{test_job_id}/runs/{response.run_id}"
+    print(f"Started the job at {job_url}")  # noqa: T201
+
+    # Wait for the job to complete
+    result = response.result(timeout=timedelta(seconds=3600))
+    assert result.status.state == RunLifecycleStateV2State.TERMINATED
+    assert result.status.termination_details.type == TerminationTypeType.SUCCESS


### PR DESCRIPTION
The setup is a bit strange, basically:

1. We create a job in workspace https://ai-oss-ecosystem-integration-testing.cloud.databricks.com/, the notebook under which contains the actual testing code.
2. We add an integration test .py file in databricks-ai-bridge, which just triggers the job and check the job status. On any sort of failure in the job, the test will fail.
3. In another internal repo: https://github.com/databricks-eng/ai-oss-integration-tests-runner, we create github action that executes .py file created in step 2. This is necessary because storing the credentials in internal repos is much safer than this public repo.
4. On PRs, we may need to run the test manually though, which is fine IMO. 

This PR handles step 2 specifically. 