### PR TITLE
Release databricks-ai-bridge 0.7.0 and other packages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 # CHANGELOG
 
+## databricks-ai-bridge 0.7.0, databricks-langchain 0.7.0, databricks-mcp 0.3.0 (TBD)
+
+### Highlights
+- Improved ChatDatabricks with OpenAI client compatibility
+- Enhanced Genie functionality with reasoning and SQL steps
+- Add DSPy integration support with DatabricksLM
+
+### Improvements
+- Use OpenAI client to make LLM inference requests in ChatDatabricks (#153)
+- Make ChatDatabricks compatible with ChatAgent and ResponsesAgent (#141)
+- Send Genie reasoning + SQL steps on query (#138)
+- Add Genie deprecation warning (#157)
+- Add integration test for databricks-dspy (#158)
+- Include MTPT endpoint creation in DatabricksLM (#151)
+- Add DSPy integration in databricks-ai-bridge (#148)
+- Update VectorSearchRetrieverTool docs to document additional parameters (#156)
+
+### Bug Fixes
+- Fix CI issues (#159)
+
 ## databricks-ai-bridge 0.6.0, databricks-langchain 0.6.0, databricks-openai 0.5.0, databricks-mcp 0.2.0 (2025-06-02)
 
 ### Improvements

--- a/databricks_mcp/pyproject.toml
+++ b/databricks_mcp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "databricks-mcp"
-version = "0.3.0.dev0"
+version = "0.3.0"
 description = "MCP helpers for Databricks"
 authors = [
     { name="Databricks", email="agent-feedback@databricks.com" },
@@ -11,7 +11,7 @@ requires-python = ">=3.10"
 dependencies = [
     "mcp>=1.9.1",
     "databricks-sdk>=0.49.0",
-    "databricks-ai-bridge>=0.4.2",
+    "databricks-ai-bridge>=0.7.0",
     "mlflow>=3.1"
 ]
 

--- a/integrations/langchain/pyproject.toml
+++ b/integrations/langchain/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "databricks-langchain"
-version = "0.5.2.dev0"
+version = "0.7.0"
 description = "Support for Databricks AI support in LangChain"
 authors = [
     { name="Databricks", email="agent-feedback@databricks.com" },
@@ -11,7 +11,7 @@ requires-python = ">=3.10"
 dependencies = [
     "langchain>=0.3.0",
     "databricks-vectorsearch>=0.50",
-    "databricks-ai-bridge>=0.4.2",
+    "databricks-ai-bridge>=0.7.0",
     "mlflow>=2.20.1",
     "pydantic>2.10.0",
     "unitycatalog-langchain[databricks]>=0.2.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "databricks-ai-bridge"
-version = "0.5.2.dev0"
+version = "0.7.0"
 description = "Official Python library for Databricks AI support"
 authors = [
     { name="Databricks", email="agent-feedback@databricks.com" },


### PR DESCRIPTION
Updated versions based on current PyPI releases:
- databricks-ai-bridge: 0.5.2.dev0 → 0.7.0 (was 0.6.0 on PyPI)
- databricks-langchain: 0.5.2.dev0 → 0.7.0 (was 0.6.0 on PyPI)
- databricks-mcp: 0.3.0.dev0 → 0.3.0 (was 0.2.1 on PyPI)

Key improvements:
- OpenAI client compatibility in ChatDatabricks
- Enhanced Genie functionality with reasoning and SQL steps
- DSPy integration support
- Improved VectorSearchRetrieverTool

All packages tested and validated for release.
