### PR TITLE
Add DatabricksRM to databricks-dspy

### DIFF
--- a/integrations/dspy/pyproject.toml
+++ b/integrations/dspy/pyproject.toml
@@ -59,4 +59,4 @@ select = [
 
 [tool.ruff.format]
 docstring-code-format = true
-docstring-code-line-length = 88
+docstring-code-line-length = 100

--- a/integrations/dspy/src/databricks_dspy/__init__.py
+++ b/integrations/dspy/src/databricks_dspy/__init__.py
@@ -1,3 +1,4 @@
 from databricks_dspy.clients import DatabricksLM
+from databricks_dspy.retrievers import DatabricksRM
 
-__all__ = ["DatabricksLM"]
+__all__ = ["DatabricksLM", "DatabricksRM"]

--- a/integrations/dspy/src/databricks_dspy/retrievers/__init__.py
+++ b/integrations/dspy/src/databricks_dspy/retrievers/__init__.py
@@ -1,0 +1,3 @@
+from databricks_dspy.retrievers.databricks_rm import DatabricksRM
+
+__all__ = ["DatabricksRM"]

--- a/integrations/dspy/src/databricks_dspy/retrievers/databricks_rm.py
+++ b/integrations/dspy/src/databricks_dspy/retrievers/databricks_rm.py
@@ -1,0 +1,380 @@
+import json
+import os
+from dataclasses import dataclass
+from importlib.util import find_spec
+from typing import Any
+
+import requests
+
+import dspy
+from dspy.primitives.prediction import Prediction
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class Document:
+    page_content: str
+    metadata: dict[str, Any]
+    type: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "page_content": self.page_content,
+            "metadata": self.metadata,
+            "type": self.type,
+        }
+
+
+class DatabricksRM(dspy.Retrieve):
+    """
+    A retriever module that uses a Databricks Mosaic AI Vector Search Index to return the top-k
+    embeddings for a given query.
+
+    Examples:
+        Below is a code snippet that shows how to set up a Databricks Vector Search Index
+        and configure a DatabricksRM DSPy retriever module to query the index.
+
+        (example adapted from "Databricks: How to create and query a Vector Search Index:
+        https://docs.databricks.com/en/generative-ai/create-query-vector-search.html#create-a-vector-search-index)
+
+        ```python
+        from databricks.vector_search.client import VectorSearchClient
+
+        # Create a Databricks Vector Search Endpoint
+        client = VectorSearchClient()
+        client.create_endpoint(name="your_vector_search_endpoint_name", endpoint_type="STANDARD")
+
+        # Create a Databricks Direct Access Vector Search Index
+        index = client.create_direct_access_index(
+            endpoint_name="your_vector_search_endpoint_name",
+            index_name="your_index_name",
+            primary_key="id",
+            embedding_dimension=1024,
+            embedding_vector_column="text_vector",
+            schema={
+                "id": "int",
+                "field2": "str",
+                "field3": "float",
+                "text_vector": "array<float>",
+            },
+        )
+
+        # Create a DatabricksRM retriever module to query the Databricks Direct Access Vector
+        # Search Index
+        retriever = DatabricksRM(
+            databricks_index_name="your_index_name",
+            docs_id_column_name="id",
+            text_column_name="field2",
+            k=3,
+        )
+        ```
+
+        Below is a code snippet that shows how to query the Databricks Direct Access Vector
+        Search Index using the DatabricksRM retriever module:
+
+        ```python
+        retrieved_results = DatabricksRM(query="Example query text"))
+        ```
+    """
+
+    def __init__(
+        self,
+        databricks_index_name: str,
+        databricks_endpoint: str | None = None,
+        databricks_token: str | None = None,
+        databricks_client_id: str | None = None,
+        databricks_client_secret: str | None = None,
+        columns: list[str] | None = None,
+        filters_json: str | None = None,
+        k: int = 3,
+        docs_id_column_name: str = "id",
+        docs_uri_column_name: str | None = None,
+        text_column_name: str = "text",
+        use_with_databricks_agent_framework: bool = False,
+    ):
+        """
+        Args:
+            databricks_index_name (str): The name of the Databricks Vector Search Index to query.
+            databricks_endpoint (Optional[str]): The URL of the Databricks Workspace containing
+                the Vector Search Index. Defaults to the value of the ``DATABRICKS_HOST``
+                environment variable. If unspecified, the Databricks SDK is used to identify the
+                endpoint based on the current environment.
+            databricks_token (Optional[str]): The Databricks Workspace authentication token to use
+                when querying the Vector Search Index. Defaults to the value of the
+                ``DATABRICKS_TOKEN`` environment variable. If unspecified, the Databricks SDK is
+                used to identify the token based on the current environment.
+            databricks_client_id (str): Databricks service principal id. If not specified,
+                the token is resolved from the current environment (DATABRICKS_CLIENT_ID).
+            databricks_client_secret (str): Databricks service principal secret. If not specified,
+                the endpoint is resolved from the current environment (DATABRICKS_CLIENT_SECRET).
+            columns (Optional[list[str]]): Extra column names to include in response,
+                in addition to the document id and text columns specified by
+                ``docs_id_column_name`` and ``text_column_name``.
+            filters_json (Optional[str]): A JSON string specifying additional query filters.
+                Example filters: ``{"id <": 5}`` selects records that have an ``id`` column value
+                less than 5, and ``{"id >=": 5, "id <": 10}`` selects records that have an ``id``
+                column value greater than or equal to 5 and less than 10.
+            k (int): The number of documents to retrieve.
+            docs_id_column_name (str): The name of the column in the Databricks Vector Search Index
+                containing document IDs.
+            docs_uri_column_name (Optional[str]): The name of the column in the Databricks Vector
+                Search Index containing document URI.
+            text_column_name (str): The name of the column in the Databricks Vector Search Index
+                containing document text to retrieve.
+            use_with_databricks_agent_framework (bool): Whether to use the `DatabricksRM` in a way
+                that is compatible with the Databricks Mosaic Agent Framework.
+        """
+        super().__init__(k=k)
+        self.databricks_token = databricks_token or os.environ.get("DATABRICKS_TOKEN")
+        self.databricks_endpoint = databricks_endpoint or os.environ.get("DATABRICKS_HOST")
+        self.databricks_client_id = databricks_client_id or os.environ.get("DATABRICKS_CLIENT_ID")
+        self.databricks_client_secret = databricks_client_secret or os.environ.get(
+            "DATABRICKS_CLIENT_SECRET"
+        )
+        self.databricks_index_name = databricks_index_name
+        self.columns = list({docs_id_column_name, text_column_name, *(columns or [])})
+        self.filters_json = filters_json
+        self.k = k
+        self.docs_id_column_name = docs_id_column_name
+        self.docs_uri_column_name = docs_uri_column_name
+        self.text_column_name = text_column_name
+        self.use_with_databricks_agent_framework = use_with_databricks_agent_framework
+        if self.use_with_databricks_agent_framework:
+            try:
+                import mlflow
+
+                mlflow.models.set_retriever_schema(
+                    primary_key="doc_id",
+                    text_column="page_content",
+                    doc_uri="doc_uri",
+                )
+            except ImportError:
+                raise ImportError(
+                    "To use the `DatabricksRM` retriever module with the Databricks "
+                    "Mosaic Agent Framework, you must install the mlflow Python "
+                    "library. Please install mlflow via `pip install mlflow`."
+                ) from None
+
+    def _extract_doc_ids(self, item: dict[str, Any]) -> str:
+        """Extracts the document id from a search result
+
+        Args:
+            item: dict[str, Any]: a record from the search results.
+        Returns:
+            str: document id.
+        """
+        if self.docs_id_column_name == "metadata":
+            docs_dict = json.loads(item["metadata"])
+            return docs_dict["document_id"]
+        return item[self.docs_id_column_name]
+
+    def _get_extra_columns(self, item: dict[str, Any]) -> dict[str, Any]:
+        """Extracts search result column values, excluding the "text" and not "id" columns
+
+        Args:
+            item: dict[str, Any]: a record from the search results.
+        Returns:
+            dict[str, Any]: Search result column values, excluding the "text", "id" and "uri" columns.
+        """
+        extra_columns = {
+            k: v
+            for k, v in item.items()
+            if k not in [self.docs_id_column_name, self.text_column_name, self.docs_uri_column_name]
+        }
+        if self.docs_id_column_name == "metadata":
+            extra_columns = {
+                **extra_columns,
+                **{
+                    "metadata": {
+                        k: v for k, v in json.loads(item["metadata"]).items() if k != "document_id"
+                    }
+                },
+            }
+        return extra_columns
+
+    def forward(
+        self,
+        query: str | list[float],
+        query_type: str = "ANN",
+        filters_json: str | None = None,
+    ) -> dspy.Prediction | list[dict[str, Any]]:
+        """
+        Retrieve documents from a Databricks Mosaic AI Vector Search Index that are relevant to the
+        specified query.
+
+        Args:
+            query (Union[str, list[float]]): The query text or numeric query vector for which to
+                retrieve relevant documents.
+            query_type (str): The type of search query to perform against the Databricks Vector
+                Search Index. Must be either 'ANN' (approximate nearest neighbor) or 'HYBRID'
+                (hybrid search).
+            filters_json (Optional[str]): A JSON string specifying additional query filters.
+                Example filters: ``{"id <": 5}`` selects records that have an ``id`` column value
+                less than 5, and ``{"id >=": 5, "id <": 10}`` selects records that have an ``id``
+                column value greater than or equal to 5 and less than 10. If specified, this
+                parameter overrides the `filters_json` parameter passed to the constructor.
+
+        Returns:
+            A list of dictionaries when ``use_with_databricks_agent_framework`` is ``True``,
+            or a ``dspy.Prediction`` object when ``use_with_databricks_agent_framework`` is
+            ``False``.
+        """
+        if query_type not in ["ANN", "HYBRID"]:
+            raise ValueError(f"Invalid query_type: {query_type}. Must be one of 'ANN' or 'HYBRID'.")
+
+        if isinstance(query, str):
+            query_text = query
+            query_vector = None
+        elif isinstance(query, list):
+            query_text = None
+            query_vector = query
+        else:
+            raise ValueError("Query must be a string or a list of floats.")
+
+        results = self._query_vector_search_index(
+            index_name=self.databricks_index_name,
+            k=self.k,
+            columns=self.columns,
+            query_type=query_type,
+            query_text=query_text,
+            query_vector=query_vector,
+            databricks_token=self.databricks_token,
+            databricks_endpoint=self.databricks_endpoint,
+            databricks_client_id=self.databricks_client_id,
+            databricks_client_secret=self.databricks_client_secret,
+            filters_json=filters_json or self.filters_json,
+        )
+
+        # Checking if defined columns are present in the index columns
+        col_names = [column["name"] for column in results["manifest"]["columns"]]
+
+        if self.docs_id_column_name not in col_names:
+            raise ValueError(
+                f"docs_id_column_name: '{self.docs_id_column_name}' is not in the index "
+                f"columns: \n {col_names}"
+            )
+
+        if self.text_column_name not in col_names:
+            raise ValueError(
+                f"text_column_name: '{self.text_column_name}' is not in the index "
+                "columns: \n {col_names}"
+            )
+
+        # Extracting the results
+        items = []
+        if "data_array" in results["result"]:
+            for _, data_row in enumerate(results["result"]["data_array"]):
+                item = {}
+                for col_name, val in zip(col_names, data_row, strict=False):
+                    item[col_name] = val
+                items.append(item)
+
+        # Sorting results by score in descending order
+        sorted_docs = sorted(items, key=lambda x: x["score"], reverse=True)[: self.k]
+
+        if self.use_with_databricks_agent_framework:
+            return [
+                Document(
+                    page_content=doc[self.text_column_name],
+                    metadata={
+                        "doc_id": self._extract_doc_ids(doc),
+                        "doc_uri": doc[self.docs_uri_column_name]
+                        if self.docs_uri_column_name
+                        else None,
+                    }
+                    | self._get_extra_columns(doc),
+                    type="Document",
+                ).to_dict()
+                for doc in sorted_docs
+            ]
+        else:
+            # Returning the prediction
+            return Prediction(
+                docs=[doc[self.text_column_name] for doc in sorted_docs],
+                doc_ids=[self._extract_doc_ids(doc) for doc in sorted_docs],
+                doc_uris=[doc[self.docs_uri_column_name] for doc in sorted_docs]
+                if self.docs_uri_column_name
+                else None,
+                extra_columns=[self._get_extra_columns(item) for item in sorted_docs],
+            )
+
+    def _query_vector_search_index(
+        self,
+        index_name: str,
+        k: int,
+        columns: list[str],
+        query_type: str,
+        query_text: str | None,
+        query_vector: list[float] | None,
+        databricks_token: str | None,
+        databricks_endpoint: str | None,
+        databricks_client_id: str | None,
+        databricks_client_secret: str | None,
+        filters_json: str | None,
+    ) -> dict[str, Any]:
+        """
+        Query a Databricks Vector Search Index via the Databricks SDK.
+        Assumes that the databricks-sdk Python library is installed.
+
+        Args:
+            index_name (str): Name of the Databricks vector search index to query
+            k (int): Number of relevant documents to retrieve.
+            columns (list[str]): Column names to include in response.
+            query_text (Optional[str]): Text query for which to find relevant documents. Exactly
+                one of query_text or query_vector must be specified.
+            query_vector (Optional[list[float]]): Numeric query vector for which to find relevant
+                documents. Exactly one of query_text or query_vector must be specified.
+            filters_json (Optional[str]): JSON string representing additional query filters.
+            databricks_token (str): Databricks authentication token. If not specified,
+                the token is resolved from the current environment.
+            databricks_endpoint (str): Databricks index endpoint url. If not specified,
+                the endpoint is resolved from the current environment.
+            databricks_client_id (str): Databricks service principal id. If not specified,
+                the token is resolved from the current environment (DATABRICKS_CLIENT_ID).
+            databricks_client_secret (str): Databricks service principal secret. If not specified,
+                the endpoint is resolved from the current environment (DATABRICKS_CLIENT_SECRET).
+
+        Returns:
+            dict[str, Any]: Parsed JSON response from the Databricks Vector Search Index query.
+        """
+
+        from databricks.sdk import WorkspaceClient
+
+        if (query_text, query_vector).count(None) != 1:
+            raise ValueError("Exactly one of query_text or query_vector must be specified.")
+
+        if databricks_client_secret and databricks_client_id:
+            # Use client ID and secret for authentication if they are provided
+            databricks_client = WorkspaceClient(
+                client_id=databricks_client_id,
+                client_secret=databricks_client_secret,
+            )
+            logger.info(
+                "Creating Databricks workspace client using service principal authentication."
+            )
+
+        elif databricks_token and databricks_endpoint:
+            # token-based authentication
+            databricks_client = WorkspaceClient(
+                host=databricks_endpoint,
+                token=databricks_token,
+            )
+            logger.info("Creating Databricks workspace client using token authentication.")
+        else:
+            # fallback to default authentication, i.e., using `~/.databrickscfg` file.
+            databricks_client = WorkspaceClient()
+            logger.info(
+                "Creating Databricks workspace client using credentials from `~/.databrickscfg` file."
+            )
+
+        return databricks_client.vector_search_indexes.query_index(
+            index_name=index_name,
+            query_type=query_type,
+            query_text=query_text,
+            query_vector=query_vector,
+            columns=columns,
+            filters_json=filters_json,
+            num_results=k,
+        ).as_dict()

--- a/integrations/dspy/src/databricks_dspy/retrievers/databricks_rm.py
+++ b/integrations/dspy/src/databricks_dspy/retrievers/databricks_rm.py
@@ -1,14 +1,11 @@
 import json
+import logging
 import os
 from dataclasses import dataclass
-from importlib.util import find_spec
 from typing import Any
-
-import requests
 
 import dspy
 from dspy.primitives.prediction import Prediction
-import logging
 
 logger = logging.getLogger(__name__)
 

--- a/integrations/dspy/tests/unit_tests/retrievers/test_databricks_rm.py
+++ b/integrations/dspy/tests/unit_tests/retrievers/test_databricks_rm.py
@@ -1,0 +1,238 @@
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from databricks_dspy.retrievers.databricks_rm import DatabricksRM
+
+
+@pytest.fixture
+def mock_vector_search_response():
+    """Mock response from Databricks vector search index query."""
+    return {
+        "result": {
+            "data_array": [
+                ["doc1", "This is document 1", 0.95, {"category": "tech"}],
+                ["doc2", "This is document 2", 0.90, {"category": "science"}],
+                ["doc3", "This is document 3", 0.85, {"category": "tech"}],
+            ]
+        },
+        "manifest": {
+            "columns": [
+                {"name": "id"},
+                {"name": "text"},
+                {"name": "score"},
+                {"name": "metadata"},
+            ]
+        },
+    }
+
+
+@pytest.fixture
+def mock_vector_search_response_with_uri():
+    """Mock response with URI column from Databricks vector search index query."""
+    return {
+        "result": {
+            "data_array": [
+                ["doc1", "This is document 1", 0.95, "http://doc1.com", {"category": "tech"}],
+                ["doc2", "This is document 2", 0.90, "http://doc2.com", {"category": "science"}],
+            ]
+        },
+        "manifest": {
+            "columns": [
+                {"name": "id"},
+                {"name": "text"},
+                {"name": "score"},
+                {"name": "uri"},
+                {"name": "metadata"},
+            ]
+        },
+    }
+
+
+@patch("databricks.sdk.WorkspaceClient")
+def test_databricks_rm_forward_string_query(mock_workspace_client, mock_vector_search_response):
+    """Test forward method with string query and ANN search."""
+    mock_client = MagicMock()
+    mock_workspace_client.return_value = mock_client
+    mock_client.vector_search_indexes.query_index.return_value.as_dict.return_value = (
+        mock_vector_search_response
+    )
+
+    rm = DatabricksRM(
+        databricks_index_name="test_index",
+        databricks_token="test_token",
+        databricks_endpoint="https://test.databricks.com",
+    )
+
+    result = rm("test query", query_type="ANN")
+
+    # Verify API call
+    call_args = mock_client.vector_search_indexes.query_index.call_args[1]
+    assert call_args["index_name"] == "test_index"
+    assert call_args["query_type"] == "ANN"
+    assert call_args["query_text"] == "test query"
+    assert call_args["query_vector"] is None
+    assert set(call_args["columns"]) == {"id", "text"}
+    assert call_args["filters_json"] is None
+    assert call_args["num_results"] == 3
+
+    # Verify result format
+    assert hasattr(result, "docs")
+    assert hasattr(result, "doc_ids")
+    assert len(result.docs) == 3
+    assert result.docs[0] == "This is document 1"
+    assert result.doc_ids[0] == "doc1"
+
+
+@patch("databricks.sdk.WorkspaceClient")
+def test_databricks_rm_forward_vector_query(mock_workspace_client, mock_vector_search_response):
+    """Test forward method with vector query and HYBRID search."""
+    mock_client = MagicMock()
+    mock_workspace_client.return_value = mock_client
+    mock_client.vector_search_indexes.query_index.return_value.as_dict.return_value = (
+        mock_vector_search_response
+    )
+
+    rm = DatabricksRM(databricks_index_name="test_index")
+    query_vector = [0.1, 0.2, 0.3]
+
+    rm(query_vector, query_type="HYBRID")
+
+    # Verify API call
+    call_args = mock_client.vector_search_indexes.query_index.call_args[1]
+    assert call_args["index_name"] == "test_index"
+    assert call_args["query_type"] == "HYBRID"
+    assert call_args["query_text"] is None
+    assert call_args["query_vector"] == query_vector
+    assert set(call_args["columns"]) == {"id", "text"}
+
+
+@patch("databricks.sdk.WorkspaceClient")
+def test_databricks_rm_agent_framework_format(
+    mock_workspace_client, mock_vector_search_response_with_uri
+):
+    """Test forward method returning agent framework format."""
+    mock_client = MagicMock()
+    mock_workspace_client.return_value = mock_client
+    mock_client.vector_search_indexes.query_index.return_value.as_dict.return_value = (
+        mock_vector_search_response_with_uri
+    )
+
+    with patch("mlflow.models.set_retriever_schema"):
+        rm = DatabricksRM(
+            databricks_index_name="test_index",
+            docs_uri_column_name="uri",
+            use_with_databricks_agent_framework=True,
+        )
+
+    result = rm.forward("test query")
+
+    # Should return list of Document dictionaries
+    assert isinstance(result, list)
+    assert len(result) == 2
+
+    doc = result[0]
+    assert doc["page_content"] == "This is document 1"
+    assert doc["metadata"]["doc_id"] == "doc1"
+    assert doc["metadata"]["doc_uri"] == "http://doc1.com"
+    assert doc["type"] == "Document"
+
+
+def test_databricks_rm_initialization():
+    """Test initialization with token authentication."""
+    rm = DatabricksRM(
+        databricks_index_name="test_index",
+        databricks_endpoint="https://test.databricks.com",
+        databricks_token="test_token",
+        k=5,
+    )
+
+    assert rm.databricks_index_name == "test_index"
+    assert rm.databricks_endpoint == "https://test.databricks.com"
+    assert rm.databricks_token == "test_token"
+    assert rm.k == 5
+    assert rm.docs_id_column_name == "id"
+    assert rm.text_column_name == "text"
+    assert not rm.use_with_databricks_agent_framework
+
+
+@patch("databricks.sdk.WorkspaceClient")
+def test_databricks_rm_service_principal_auth(mock_workspace_client, mock_vector_search_response):
+    """Test querying with service principal authentication."""
+    mock_client = MagicMock()
+    mock_workspace_client.return_value = mock_client
+    mock_client.vector_search_indexes.query_index.return_value.as_dict.return_value = (
+        mock_vector_search_response
+    )
+
+    rm = DatabricksRM(
+        databricks_index_name="test_index",
+        databricks_client_id="test_client_id",
+        databricks_client_secret="test_client_secret",
+    )
+
+    rm("test query")
+
+    # Verify WorkspaceClient was created with service principal auth
+    mock_workspace_client.assert_called_once_with(
+        client_id="test_client_id",
+        client_secret="test_client_secret",
+    )
+
+
+def test_databricks_rm_invalid_query_type():
+    """Test forward method with invalid query type."""
+    rm = DatabricksRM(databricks_index_name="test_index")
+
+    with pytest.raises(ValueError, match="Invalid query_type: INVALID"):
+        rm("test query", query_type="INVALID")
+
+
+@patch("databricks.sdk.WorkspaceClient")
+def test_databricks_rm_missing_column_error(mock_workspace_client):
+    """Test error when ID column is missing from index."""
+    mock_client = MagicMock()
+    mock_workspace_client.return_value = mock_client
+
+    # Response missing the ID column
+    mock_response = {
+        "result": {"data_array": []},
+        "manifest": {"columns": [{"name": "text"}, {"name": "score"}]},
+    }
+    mock_client.vector_search_indexes.query_index.return_value.as_dict.return_value = mock_response
+
+    rm = DatabricksRM(
+        databricks_index_name="test_index",
+        docs_id_column_name="id",
+    )
+
+    with pytest.raises(ValueError, match="docs_id_column_name: 'id' is not in the index columns"):
+        rm("test query")
+
+
+@patch("databricks.sdk.WorkspaceClient")
+def test_databricks_rm_result_sorting(mock_workspace_client):
+    """Test that results are sorted by score in descending order."""
+    mock_client = MagicMock()
+    mock_workspace_client.return_value = mock_client
+
+    # Results in random order
+    mock_response = {
+        "result": {
+            "data_array": [
+                ["doc2", "Document 2", 0.75],  # Lower score
+                ["doc1", "Document 1", 0.95],  # Higher score
+                ["doc3", "Document 3", 0.85],  # Middle score
+            ]
+        },
+        "manifest": {"columns": [{"name": "id"}, {"name": "text"}, {"name": "score"}]},
+    }
+    mock_client.vector_search_indexes.query_index.return_value.as_dict.return_value = mock_response
+
+    rm = DatabricksRM(databricks_index_name="test_index", k=3)
+
+    result = rm("test query")
+
+    # Should be sorted by score (highest first)
+    assert result.doc_ids == ["doc1", "doc3", "doc2"]
+    assert result.docs == ["Document 1", "Document 3", "Document 2"]


### PR DESCRIPTION
This is an adapted version from https://github.com/stanfordnlp/dspy/blob/d8b7d1c176eefee9b43302f11cc13b92bcc5e179/dspy/retrievers/databricks_rm.py#L29, and the following changes are made:

- Only keep the path that uses `databricks-sdk` for simplicity, since `databricks-dspy` requires `databricks-sdk` as a hard dependency.
- Support default auth through `.databrickscfg`.
- Some style cleanup.

Tested with unit test internally: 

```
import databricks_dspy

retriever = databricks_dspy.DatabricksRM(
    databricks_index_name="kbqa.moon_fb_managed.index_finance_reports_97g28o",
    text_column_name="chunk_text",
    docs_uri_column_name="doc_uri",
    docs_id_column_name="doc_uri",
    columns=[],
    use_with_databricks_agent_framework=False,
    k=3,
)

retriever(query="financial advice")
```

Produces: 

<img width="1103" height="287" alt="image" src="https://github.com/user-attachments/assets/58838c75-c67c-4c63-b662-5d3b4032e7c8" />


