### PR TITLE
Rename dspy integration test to be generic

### DIFF
--- a/integrations/dspy/tests/integration_tests/test_databricks_integration.py
+++ b/integrations/dspy/tests/integration_tests/test_databricks_integration.py
@@ -7,18 +7,18 @@ from databricks.sdk.service.jobs import RunLifecycleStateV2State, TerminationTyp
 
 
 @pytest.mark.timeout(3600)
-def test_databricks_lm():
+def test_databricks_integration():
     """
     This test simply triggers a predefined Databricks job to verify the functionality
-    of the DatabricksLM class.
+    of public APIs in databricks-dspy.
     """
-    test_job_id = os.getenv("DATABRICKS_LM_TEST_JOB_ID")
+    test_job_id = os.getenv("DATABRICKS_DSPY_TEST_JOB_ID")
     branch_name = os.getenv("BRANCH_NAME")
     fork_name = os.getenv("FORK_NAME")
 
     if not test_job_id:
         raise RuntimeError(
-            "Please set the environment variable DATABRICKS_LM_TEST_JOB_ID",
+            "Please set the environment variable DATABRICKS_DSPY_TEST_JOB_ID",
         )
 
     w = WorkspaceClient()


### PR DESCRIPTION
We are going to use the same job for integration testing for all public APIs inside databricks-dspy, so I am opening this PR to make the name more generic.

A sample run can be [found here](https://ai-oss-ecosystem-integration-testing.cloud.databricks.com/jobs/704146759464961/runs/989906352536076?o=3272836215725701), requires access to the corresponding workspace.

Screenshot:

<img width="1004" height="650" alt="image" src="https://github.com/user-attachments/assets/8d618d29-9d62-4122-82c9-d90a921db5e6" />


