### PR TITLE
Updated retriever tool kwargs so that parameters passed in will take precedence over instance values. 

### DIFF
--- a/integrations/langchain/src/databricks_langchain/vector_search_retriever_tool.py
+++ b/integrations/langchain/src/databricks_langchain/vector_search_retriever_tool.py
@@ -80,13 +80,18 @@ class VectorSearchRetrieverTool(BaseTool, VectorSearchRetrieverToolMixin):
         # Since LLM can generate either a dict or FilterItem, convert to dict always
         filters_dict = {dict(item)["key"]: dict(item)["value"] for item in (filters or [])}
         combined_filters = {**filters_dict, **(self.filters or {})}
+
+        # Allow kwargs to override the default values upon invocation
+        num_results = kwargs.pop("k", self.num_results)
+        query_type = kwargs.pop("query_type", self.query_type)
+
         # Ensure that we don't have duplicate keys
         kwargs.update(
             {
                 "query": query,
-                "k": self.num_results,
+                "k": num_results,
                 "filter": combined_filters,
-                "query_type": self.query_type,
+                "query_type": query_type,
             }
         )
         return self._vector_store.similarity_search(**kwargs)


### PR DESCRIPTION

## Allow runtime override of `num_results` and `query_type` in VectorSearchRetrieverTool

### Summary

Updates the `VectorSearchRetrieverTool._run()` method in the LangChain integration to allow runtime parameters to override instance-level defaults for `k` (num_results) and `query_type`.

### Problem

Previously, the `VectorSearchRetrieverTool` would always use the instance-level values for `num_results` and `query_type`, even if these parameters were explicitly passed in the `kwargs` during tool invocation. This prevented users from dynamically adjusting these parameters at runtime without modifying the tool instance.

```python
# Before: These kwargs would be ignored
tool._run("search query", k=10, query_type="ANN")  # k and query_type ignored
```

### Solution

Modified the parameter handling logic to:

1. **Extract runtime overrides**: Use `kwargs.pop()` to extract `k` and `query_type` from kwargs if provided
2. **Preserve defaults**: Fall back to instance values (`self.num_results`, `self.query_type`) when not provided
3. **Prevent conflicts**: Eliminate duplicate keys before passing to the underlying vector search

```python
# After: Runtime parameters take precedence
num_results = kwargs.pop("k", self.num_results)
query_type = kwargs.pop("query_type", self.query_type)
```

### Changes Made

**File**: `integrations/langchain/src/databricks_langchain/vector_search_retriever_tool.py`

- **Lines 84-86**: Added logic to extract `k` and `query_type` from kwargs with instance defaults as fallbacks
- **Lines 92-94**: Use extracted values instead of direct instance properties
- **Improved comments**: Clarified the precedence behavior

### Benefits

1. **Enhanced Flexibility**: Users can now override `num_results` and `query_type` on a per-call basis
2. **Standard Behavior**: Follows expected precedence where runtime arguments override defaults
3. **Backward Compatibility**: Existing code continues to work unchanged
4. **No Breaking Changes**: Instance-level configuration still works as default values

### Usage Example

```python
# Tool configured with defaults
tool = VectorSearchRetrieverTool(
    index_name="my_index",
    num_results=5,          # Default
    query_type="HYBRID"     # Default
)

# Can now override at runtime
results1 = tool._run("query", k=10)                    # Uses k=10, query_type="HYBRID"
results2 = tool._run("query", query_type="ANN")        # Uses k=5, query_type="ANN"  
results3 = tool._run("query", k=3, query_type="ANN")   # Uses k=3, query_type="ANN"
```

### Testing

- [x] Verified backward compatibility with existing usage patterns
- [x] Confirmed runtime overrides work correctly
- [x] Ensured default values are preserved when not overridden
- [x] No linting errors introduced

---

This PR improves the flexibility and usability of the `VectorSearchRetrieverTool` while maintaining full backward compatibility.