### PR TITLE
Remove Databricks Connect Dependency

### DIFF
--- a/integrations/langchain/pyproject.toml
+++ b/integrations/langchain/pyproject.toml
@@ -15,7 +15,6 @@ dependencies = [
     "mlflow>=2.20.1",
     "pydantic>2.10.0",
     "unitycatalog-langchain[databricks]>=0.2.0",
-    "databricks-connect>=16.1.1,<16.4",
     "openai>=1.99.9",
 ]
 

--- a/integrations/openai/pyproject.toml
+++ b/integrations/openai/pyproject.toml
@@ -16,7 +16,6 @@ dependencies = [
     "pydantic>2.10.0",
     "mlflow>=2.20.1",
     "unitycatalog-openai[databricks]>=0.2.0",
-    "databricks-connect>=16.1.1,<16.4",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
UC AI already restricts the databricks-connect package between the min and max version. We do not need to restrict it again here.