### PR TITLE
ChatDatabricks: turn on stream usage by default

### DIFF
--- a/integrations/langchain/src/databricks_langchain/chat_models.py
+++ b/integrations/langchain/src/databricks_langchain/chat_models.py
@@ -274,7 +274,7 @@ class ChatDatabricks(BaseChatModel):
     """Whether to include usage metadata in streaming output. If True, additional
     message chunks will be generated during the stream including usage metadata.
     """
-    stream_usage: bool = False
+    stream_usage: bool = True
     """Any extra parameters to pass to the endpoint."""
     use_responses_api: bool = False
     """Whether to use the Responses API to format inputs and outputs."""

--- a/integrations/langchain/tests/integration_tests/test_chat_models.py
+++ b/integrations/langchain/tests/integration_tests/test_chat_models.py
@@ -791,3 +791,34 @@ def test_chat_databricks_custom_outputs_stream():
     )
 
     assert any(chunk.custom_outputs["key"] == "value" for chunk in response)
+
+
+def test_chat_databricks_token_count():
+    import mlflow
+
+    mlflow.set_experiment("4435237072766312")
+    mlflow.langchain.autolog()
+    llm = ChatDatabricks(model="databricks-gpt-oss-120b")
+    # response = llm.invoke("What is the 100th fibonacci number?")
+    # assert response.content is not None
+    # assert response.response_metadata["prompt_tokens"] > 0
+    # assert response.response_metadata["completion_tokens"] > 0
+    # assert response.response_metadata["total_tokens"] > 0
+    # assert (
+    #     response.response_metadata["total_tokens"]
+    #     == response.response_metadata["prompt_tokens"]
+    #     + response.response_metadata["completion_tokens"]
+    # )
+
+    chunks = list(llm.stream("What is the 100th fibonacci number?"))
+    last_chunk = chunks[-1]
+    print(chunks)
+    assert False
+    assert last_chunk.usage_metadata is not None
+    assert last_chunk.usage_metadata["input_tokens"] > 0
+    assert last_chunk.usage_metadata["output_tokens"] > 0
+    assert last_chunk.usage_metadata["total_tokens"] > 0
+    assert (
+        last_chunk.usage_metadata["total_tokens"]
+        == last_chunk.usage_metadata["input_tokens"] + last_chunk.usage_metadata["output_tokens"]
+    )

--- a/integrations/langchain/tests/integration_tests/test_chat_models.py
+++ b/integrations/langchain/tests/integration_tests/test_chat_models.py
@@ -799,21 +799,19 @@ def test_chat_databricks_token_count():
     mlflow.set_experiment("4435237072766312")
     mlflow.langchain.autolog()
     llm = ChatDatabricks(model="databricks-gpt-oss-120b")
-    # response = llm.invoke("What is the 100th fibonacci number?")
-    # assert response.content is not None
-    # assert response.response_metadata["prompt_tokens"] > 0
-    # assert response.response_metadata["completion_tokens"] > 0
-    # assert response.response_metadata["total_tokens"] > 0
-    # assert (
-    #     response.response_metadata["total_tokens"]
-    #     == response.response_metadata["prompt_tokens"]
-    #     + response.response_metadata["completion_tokens"]
-    # )
+    response = llm.invoke("What is the 100th fibonacci number?")
+    assert response.content is not None
+    assert response.response_metadata["prompt_tokens"] > 0
+    assert response.response_metadata["completion_tokens"] > 0
+    assert response.response_metadata["total_tokens"] > 0
+    assert (
+        response.response_metadata["total_tokens"]
+        == response.response_metadata["prompt_tokens"]
+        + response.response_metadata["completion_tokens"]
+    )
 
     chunks = list(llm.stream("What is the 100th fibonacci number?"))
     last_chunk = chunks[-1]
-    print(chunks)
-    assert False
     assert last_chunk.usage_metadata is not None
     assert last_chunk.usage_metadata["input_tokens"] > 0
     assert last_chunk.usage_metadata["output_tokens"] > 0

--- a/integrations/langchain/tests/unit_tests/test_chat_models.py
+++ b/integrations/langchain/tests/unit_tests/test_chat_models.py
@@ -230,7 +230,7 @@ def test_chat_model_stream_with_usage(llm: ChatDatabricks) -> None:
 
 
 def test_chat_model_stream_usage_chunk_emission():
-    """Test that stream_usage=True emits a final usage-only chunk with empty content."""
+    """Test that stream_usage=True emits a final usage-only chunk with empty content by default."""
     from unittest.mock import Mock, patch
 
     mock_usage = Mock()
@@ -262,7 +262,7 @@ def test_chat_model_stream_usage_chunk_emission():
         messages = [HumanMessage(content="Hello")]
 
         # Test with stream_usage=True
-        chunks = list(llm.stream(messages, stream_usage=True))
+        chunks = list(llm.stream(messages))
 
         # Find the usage chunk (empty content with usage_metadata)
         usage_chunks = [


### PR DESCRIPTION
context: https://databricks.slack.com/archives/C065NC65Q9F/p1758832528624079?thread_ts=1758278104.748729&cid=C065NC65Q9F
from integration test:
<img width="1239" height="379" alt="screenshot 2025-09-25-21-26-31-Arc" src="https://github.com/user-attachments/assets/b8ca663a-96d0-4cd2-a303-7e5652be1155" />

by default, we will now emit an empty AIMessageChunk at the very end with usage info
