### PR TITLE
Higher visibility of Genie API's execution steps in MLflow traces

### DIFF
--- a/src/databricks_ai_bridge/genie.py
+++ b/src/databricks_ai_bridge/genie.py
@@ -10,7 +10,8 @@ import pandas as pd
 from databricks.sdk import WorkspaceClient
 
 MAX_TOKENS_OF_DATA = 20000
-MAX_ITERATIONS = 50
+MAX_ITERATIONS = 500
+ITERATION_FREQUENCY = 0.1  # seconds
 
 
 # Define a function to count tokens
@@ -195,7 +196,7 @@ class Genie:
                     return GenieResponse(result, query_str, description, returned_conversation_id)
                 elif state in ["RUNNING", "PENDING"]:
                     logging.debug("Waiting for query result...")
-                    time.sleep(5)
+                    time.sleep(ITERATION_FREQUENCY)
                 else:
                     return GenieResponse(
                         f"No query result: {resp['state']}",
@@ -213,45 +214,136 @@ class Genie:
         @mlflow.trace()
         def poll_result():
             iteration_count = 0
-            while iteration_count < MAX_ITERATIONS:
-                iteration_count += 1
-                resp = self.genie._api.do(
-                    "GET",
-                    f"/api/2.0/genie/spaces/{self.space_id}/conversations/{conversation_id}/messages/{message_id}",
-                    headers=self.headers,
-                )
-                returned_conversation_id = resp.get("conversation_id", None)
-                if resp["status"] == "COMPLETED":
-                    attachment = next((r for r in resp["attachments"] if "query" in r), None)
-                    if attachment:
-                        query_obj = attachment["query"]
-                        description = query_obj.get("description", "")
-                        query_str = query_obj.get("query", "")
-                        attachment_id = attachment["attachment_id"]
-                        return poll_query_results(
-                            attachment_id, query_str, description, returned_conversation_id
-                        )
-                    if resp["status"] == "COMPLETED":
-                        text_content = next(r for r in resp["attachments"] if "text" in r)["text"][
-                            "content"
-                        ]
-                        return GenieResponse(
-                            result=text_content, conversation_id=returned_conversation_id
-                        )
-                elif resp["status"] in {"CANCELLED", "QUERY_RESULT_EXPIRED"}:
-                    return GenieResponse(result=f"Genie query {resp['status'].lower()}.")
-                elif resp["status"] == "FAILED":
-                    return GenieResponse(
-                        result=f"Genie query failed with error: {resp.get('error', 'Unknown error')}"
+
+            # use MLflow client to get parent of any new spans we create from the current active span
+            # (parenting keeps spans in the same trace)
+            client = mlflow.tracking.MlflowClient()
+            with mlflow.start_span(name="genie_timeline", span_type="CHAIN") as parent:
+                parent_trace_id = parent.trace_id if parent else None
+                parent_span_id = parent.span_id if parent else None
+
+                # Track last status from API and the current child span
+                last_status = None
+                current_span = None
+
+                while iteration_count < MAX_ITERATIONS:
+                    iteration_count += 1
+                    resp = self.genie._api.do(
+                        "GET",
+                        f"/api/2.0/genie/spaces/{self.space_id}/conversations/{conversation_id}/messages/{message_id}",
+                        headers=self.headers,
                     )
-                # includes EXECUTING_QUERY, Genie can retry after this status
-                else:
-                    logging.debug(f"Waiting...: {resp['status']}")
-                    time.sleep(5)
-            return GenieResponse(
-                f"Genie query timed out after {MAX_ITERATIONS} iterations of 5 seconds",
-                conversation_id=conversation_id,
-            )
+                    returned_conversation_id = resp.get("conversation_id", None)
+
+                    # get current status from API response
+                    current_status = resp["status"]
+
+                    # On status change: end previous span, start a new one (excluding terminal states)
+                    if current_status != last_status:
+                        # END previous span
+                        if current_span is not None:
+                            client.end_span(
+                                trace_id=parent_trace_id,
+                                span_id=current_span.span_id,
+                                attributes={"final_state": last_status},
+                            )
+                            current_span = None
+
+                        # START new span for non-terminal states
+                        if current_status not in {
+                            "COMPLETED",
+                            "FAILED",
+                            "CANCELLED",
+                            "QUERY_RESULT_EXPIRED",
+                        }:
+                            current_span = client.start_span(
+                                name=current_status.lower(),
+                                trace_id=parent_trace_id,
+                                parent_id=parent_span_id,
+                                span_type="CHAIN",
+                                attributes={
+                                    "state": current_status,
+                                    "conversation_id": conversation_id,
+                                    "message_id": message_id,
+                                },
+                            )
+
+                        logging.debug(f"Status: {last_status} → {current_status}")
+                        last_status = current_status
+
+                    if current_status == "COMPLETED":
+                        # close any open child timeline span before ending
+                        if current_span is not None:
+                            client.end_span(
+                                trace_id=parent_trace_id,
+                                span_id=current_span.span_id,
+                                attributes={"final_state": current_status},
+                            )
+                            current_span = None
+
+                        attachment = next((r for r in resp["attachments"] if "query" in r), None)
+                        if attachment:
+                            query_obj = attachment["query"]
+                            description = query_obj.get("description", "")
+                            query_str = query_obj.get("query", "")
+                            attachment_id = attachment["attachment_id"]
+                            return poll_query_results(
+                                attachment_id,
+                                query_str,
+                                description,
+                                returned_conversation_id,
+                            )
+                        if current_status == "COMPLETED":
+                            text_content = next(r for r in resp["attachments"] if "text" in r)[
+                                "text"
+                            ]["content"]
+                            return GenieResponse(
+                                result=text_content,
+                                conversation_id=returned_conversation_id,
+                            )
+
+                    elif current_status in {"CANCELLED", "QUERY_RESULT_EXPIRED"}:
+                        # close any open child timeline span before ending
+                        if current_span is not None:
+                            client.end_span(
+                                trace_id=parent_trace_id,
+                                span_id=current_span.span_id,
+                                attributes={"final_state": current_status},
+                            )
+                            current_span = None
+                        return GenieResponse(result=f"Genie query {current_status.lower()}.")
+
+                    elif current_status == "FAILED":
+                        # close any open child timeline span before ending
+                        if current_span is not None:
+                            client.end_span(
+                                trace_id=parent_trace_id,
+                                span_id=current_span.span_id,
+                                attributes={
+                                    "final_state": current_status,
+                                    "error": resp.get("error", "Unknown error"),
+                                },
+                            )
+                            current_span = None
+                        return GenieResponse(
+                            result=f"Genie query failed with error: {resp.get('error', 'Unknown error')}"
+                        )
+                    # includes EXECUTING_QUERY, Genie can retry after this status
+                    else:
+                        logging.debug(f"Status: {current_status}")
+                        time.sleep(ITERATION_FREQUENCY)  # faster poll rate
+
+                # timeout path / end of while loop — close any open spans
+                if current_span is not None:
+                    client.end_span(
+                        trace_id=parent_trace_id,
+                        span_id=current_span.span_id,
+                        attributes={"final_state": "TIMEOUT"},
+                    )
+                return GenieResponse(
+                    f"Genie query timed out after {MAX_ITERATIONS} iterations of {ITERATION_FREQUENCY} seconds",
+                    conversation_id=conversation_id,
+                )
 
         return poll_result()
 

--- a/src/databricks_ai_bridge/genie.py
+++ b/src/databricks_ai_bridge/genie.py
@@ -10,8 +10,8 @@ import pandas as pd
 from databricks.sdk import WorkspaceClient
 
 MAX_TOKENS_OF_DATA = 20000
-MAX_ITERATIONS = 2500  # for 250 s total
-ITERATION_FREQUENCY = 0.1  # seconds
+MAX_ITERATIONS = 500  # for 250 s total
+ITERATION_FREQUENCY = 0.5  # seconds
 
 TERMINAL_STATES = {
     "COMPLETED",

--- a/tests/databricks_ai_bridge/test_genie.py
+++ b/tests/databricks_ai_bridge/test_genie.py
@@ -539,7 +539,7 @@ def test_poll_for_result_span_close_on_status_change(genie, mock_workspace_clien
         end_kwargs = mock_client.end_span.call_args[1]
         assert end_kwargs["trace_id"] == "trace_123"
         assert end_kwargs["span_id"] == "child_789"
-        assert end_kwargs["attributes"]["final_state"] == "COMPLETED"
+        assert end_kwargs["attributes"]["final_state"] == "EXECUTING_QUERY"
 
 
 def test_poll_for_result_no_duplicate_span_on_same_status(genie, mock_workspace_client):
@@ -597,7 +597,7 @@ def test_poll_for_result_cancelled_terminal_state(genie, mock_workspace_client):
         assert result.result == "Genie query cancelled."
         mock_client.end_span.assert_called_once()
         end_kwargs = mock_client.end_span.call_args[1]
-        assert end_kwargs["attributes"]["final_state"] == "CANCELLED"
+        assert end_kwargs["attributes"]["final_state"] == "EXECUTING_QUERY"
 
 
 def test_poll_for_result_failed_terminal_state(genie, mock_workspace_client):
@@ -626,7 +626,7 @@ def test_poll_for_result_failed_terminal_state(genie, mock_workspace_client):
         assert result.result == "Genie query failed with error: some error"
         mock_client.end_span.assert_called_once()
         end_kwargs = mock_client.end_span.call_args[1]
-        assert end_kwargs["attributes"]["final_state"] == "FAILED"
+        assert end_kwargs["attributes"]["final_state"] == "EXECUTING_QUERY"
 
 
 def test_poll_for_result_query_result_expired_terminal_state(genie, mock_workspace_client):
@@ -655,7 +655,7 @@ def test_poll_for_result_query_result_expired_terminal_state(genie, mock_workspa
         assert result.result == "Genie query query_result_expired."
         mock_client.end_span.assert_called_once()
         end_kwargs = mock_client.end_span.call_args[1]
-        assert end_kwargs["attributes"]["final_state"] == "QUERY_RESULT_EXPIRED"
+        assert end_kwargs["attributes"]["final_state"] == "EXECUTING_QUERY"
 
 
 def test_poll_for_result_timeout_includes_timeout_attribute(genie, mock_workspace_client):
@@ -686,7 +686,7 @@ def test_poll_for_result_timeout_includes_timeout_attribute(genie, mock_workspac
         assert "timed out" in result.result
         mock_client.end_span.assert_called_once()
         end_kwargs = mock_client.end_span.call_args[1]
-        assert end_kwargs["attributes"]["final_state"] == "TIMEOUT"
+        assert end_kwargs["attributes"]["final_state"] == "EXECUTING_QUERY"
 
 
 def test_poll_for_result_continues_on_mlflow_tracing_exceptions(genie, mock_workspace_client):

--- a/tests/databricks_ai_bridge/test_genie.py
+++ b/tests/databricks_ai_bridge/test_genie.py
@@ -1,7 +1,7 @@
 import random
 from datetime import datetime, timedelta
 from io import StringIO
-from unittest.mock import patch, MagicMock
+from unittest.mock import MagicMock, patch
 
 import pandas as pd
 import mlflow

--- a/tests/databricks_ai_bridge/test_genie.py
+++ b/tests/databricks_ai_bridge/test_genie.py
@@ -3,8 +3,8 @@ from datetime import datetime, timedelta
 from io import StringIO
 from unittest.mock import MagicMock, patch
 
-import pandas as pd
 import mlflow
+import pandas as pd
 import pytest
 
 from databricks_ai_bridge.genie import Genie, _count_tokens, _parse_query_result


### PR DESCRIPTION
Polls more frequently (from every 5 to every 0.5 seconds) to get [statuses](https://docs.databricks.com/api/workspace/genie/getmessage) of requests to Genie API as they change, and creates new spans for each. The goal is to provide increased traceability into Genie's actual thinking steps as they execute, rather than a generic "poll_result" trace. Added new unit tests to verify this functionality works, and tested locally.

New timeline looks like this:
<img width="732" height="336" alt="Screenshot 2025-09-30 at 3 31 15 PM" src="https://github.com/user-attachments/assets/7ddc1225-e1f3-47a9-92a7-9d953f9abd60" />