### PR TITLE
LangChain: pass client_args through VectorSearchRetrieverTool to enable service-principal (M2M) auth

### DIFF
--- a/integrations/langchain/tests/unit_tests/test_vs_retriever_tool_client_args.py
+++ b/integrations/langchain/tests/unit_tests/test_vs_retriever_tool_client_args.py
@@ -1,0 +1,56 @@
+# integrations/langchain/tests/unit_tests/test_vs_retriever_tool_client_args.py
+
+from typing import List
+from langchain_core.embeddings import Embeddings
+
+def test_client_args_pass_through(monkeypatch):
+    captured = {}
+
+    class FakeVSClient:
+        def __init__(self, **client_kwargs):
+            captured["kwargs"] = client_kwargs
+
+        def get_index(self, **_):
+            # Return a fake index object with a minimal describe() the tool expects
+            class _Idx:
+                def describe(self):
+                    return {
+                        "name": "catalog.schema.index",
+                        "endpoint_name": "vs_endpoint",
+                        "index_type": "DELTA_SYNC",  # validator sees delta-sync
+                        "primary_key": "id",
+                        "status": {"status": "ONLINE"},
+                        # (No need to declare managed vs self-managed if we supply embedding+text_column)
+                    }
+            return _Idx()
+
+    # Patch the canonical SDK client path
+    monkeypatch.setattr(
+        "databricks.vector_search.client.VectorSearchClient",
+        FakeVSClient,
+        raising=True,
+    )
+
+    # Minimal embeddings stub to satisfy self-managed requirement
+    class DummyEmbeddings(Embeddings):
+        def embed_documents(self, texts: List[str]) -> List[List[float]]:
+            return [[0.0] * 3 for _ in texts]
+        def embed_query(self, text: str) -> List[float]:
+            return [0.0, 0.0, 0.0]
+
+    from databricks_langchain.vector_search_retriever_tool import VectorSearchRetrieverTool
+
+    tool = VectorSearchRetrieverTool(
+        index_name="catalog.schema.index",
+        text_column="body",               # required with self-managed/delta-sync
+        embedding=DummyEmbeddings(),      # satisfy validator
+        client_args={
+            "service_principal_client_id": "abc",
+            "service_principal_client_secret": "xyz",
+            "disable_notice": True,
+        },
+    )
+
+    assert captured["kwargs"]["service_principal_client_id"] == "abc"
+    assert captured["kwargs"]["service_principal_client_secret"] == "xyz"
+    assert captured["kwargs"]["disable_notice"] is True


### PR DESCRIPTION
**Problem**
VectorSearchRetrieverTool wasn’t forwarding client_args to DatabricksVectorSearch, so VectorSearchClient(**client_args) couldn’t be configured for service principals or flags like disable_notice.

**Change**
Add optional client_args: Dict[str, Any] | None to the tool and include it in DatabricksVectorSearch(**kwargs). No behavior change for PAT users.

**Tests**
New unit test patches the SDK’s databricks.vector_search.client.VectorSearchClient and asserts client_args (SP creds + disable_notice) reach the client. Local run: 191 passed, 2 skipped.

**Backwards compatibility**
Optional field; existing flows unchanged.

**Closes:** #178