### PR TITLE
vector search: add reranker parameter

### DIFF
--- a/integrations/langchain/src/databricks_langchain/vector_search_retriever_tool.py
+++ b/integrations/langchain/src/databricks_langchain/vector_search_retriever_tool.py
@@ -60,6 +60,7 @@ class VectorSearchRetrieverTool(BaseTool, VectorSearchRetrieverToolMixin):
             "columns": self.columns,
             "workspace_client": self.workspace_client,
             "include_score": self.include_score,
+            "reranker": self.reranker,
         }
         dbvs = DatabricksVectorSearch(**kwargs)
         self._vector_store = dbvs

--- a/integrations/llamaindex/src/databricks_llamaindex/vector_search_retriever_tool.py
+++ b/integrations/llamaindex/src/databricks_llamaindex/vector_search_retriever_tool.py
@@ -120,6 +120,7 @@ class VectorSearchRetrieverTool(FunctionTool, VectorSearchRetrieverToolMixin):
             # Allow kwargs to override the default values upon invocation
             num_results = kwargs.pop("num_results", self.num_results)
             query_type = kwargs.pop("query_type", self.query_type)
+            reranker = kwargs.pop("reranker", self.reranker)
 
             # Ensure that we don't have duplicate keys
             kwargs.update(
@@ -130,6 +131,7 @@ class VectorSearchRetrieverTool(FunctionTool, VectorSearchRetrieverToolMixin):
                     "filters": combined_filters,
                     "num_results": num_results,
                     "query_type": query_type,
+                    "reranker": reranker,
                 }
             )
             search_resp = self._index.similarity_search(**kwargs)

--- a/integrations/openai/src/databricks_openai/vector_search_retriever_tool.py
+++ b/integrations/openai/src/databricks_openai/vector_search_retriever_tool.py
@@ -250,6 +250,7 @@ class VectorSearchRetrieverTool(VectorSearchRetrieverToolMixin):
         # Allow kwargs to override the default values upon invocation
         num_results = kwargs.pop("num_results", self.num_results)
         query_type = kwargs.pop("query_type", self.query_type)
+        reranker = kwargs.pop("reranker", self.reranker)
 
         kwargs.update(
             {
@@ -259,6 +260,7 @@ class VectorSearchRetrieverTool(VectorSearchRetrieverToolMixin):
                 "filters": combined_filters,
                 "num_results": num_results,
                 "query_type": query_type,
+                "reranker": reranker,
             }
         )
         search_resp = self._index.similarity_search(**kwargs)

--- a/integrations/openai/tests/unit_tests/test_vector_search_retriever_tool.py
+++ b/integrations/openai/tests/unit_tests/test_vector_search_retriever_tool.py
@@ -9,6 +9,7 @@ import pytest
 from databricks.sdk import WorkspaceClient
 from databricks.sdk.credentials_provider import ModelServingUserCredentials
 from databricks.vector_search.client import VectorSearchIndex
+from databricks.vector_search.reranker import DatabricksReranker, Reranker
 from databricks.vector_search.utils import CredentialStrategy
 from databricks_ai_bridge.test_utils.vector_search import (  # noqa: F401
     ALL_INDEX_NAMES,
@@ -92,6 +93,7 @@ def init_vector_search_tool(
     text_column: Optional[str] = None,
     embedding_model_name: Optional[str] = None,
     filters: Optional[Dict[str, Any]] = None,
+    reranker: Optional[Reranker] = None,
     **kwargs: Any,
 ) -> VectorSearchRetrieverTool:
     kwargs.update(
@@ -103,6 +105,7 @@ def init_vector_search_tool(
             "text_column": text_column,
             "embedding_model_name": embedding_model_name,
             "filters": filters,
+            "reranker": reranker,
         }
     )
     if index_name != DELTA_SYNC_INDEX:
@@ -356,6 +359,7 @@ def test_kwargs_are_passed_through() -> None:
         filters={},
         score_threshold=0.5,
         debug_level=2,
+        reranker=None,
     )
 
 
@@ -374,6 +378,7 @@ def test_filters_are_passed_through() -> None:
         num_results=vector_search_tool.num_results,
         query_type=vector_search_tool.query_type,
         query_vector=None,
+        reranker=None,
     )
 
 
@@ -391,6 +396,7 @@ def test_filters_are_combined() -> None:
         num_results=vector_search_tool.num_results,
         query_type=vector_search_tool.query_type,
         query_vector=None,
+        reranker=None,
     )
 
 
@@ -408,6 +414,7 @@ def test_kwargs_override_both_num_results_and_query_type() -> None:
         num_results=3,  # Should use overridden value
         query_type="HYBRID",  # Should use overridden value
         query_vector=None,
+        reranker=None,
     )
 
 
@@ -551,6 +558,7 @@ def test_predefined_filters_work_without_dynamic_filter() -> None:
         num_results=vector_search_tool.num_results,
         query_type=vector_search_tool.query_type,
         query_vector=None,
+        reranker=None,
     )
 
 
@@ -583,4 +591,44 @@ def test_filter_item_serialization() -> None:
         num_results=vector_search_tool.num_results,
         query_type=vector_search_tool.query_type,
         query_vector=None,
+        reranker=None,
+    )
+
+
+def test_reranker_is_passed_through() -> None:
+    vector_search_tool = init_vector_search_tool(
+        DELTA_SYNC_INDEX, reranker=DatabricksReranker(columns_to_rerank=["country"])
+    )
+    vector_search_tool.execute(
+        query="what cities are in Germany", filters=[FilterItem(key="country", value="Germany")]
+    )
+    vector_search_tool._index.similarity_search.assert_called_once_with(
+        columns=vector_search_tool.columns,
+        query_text="what cities are in Germany",
+        filters={"country": "Germany"},
+        num_results=vector_search_tool.num_results,
+        query_type=vector_search_tool.query_type,
+        query_vector=None,
+        reranker=vector_search_tool.reranker,
+    )
+
+
+def test_reranker_is_overriden() -> None:
+    vector_search_tool = init_vector_search_tool(
+        DELTA_SYNC_INDEX, reranker=DatabricksReranker(columns_to_rerank=["country"])
+    )
+    overridden_reranker = DatabricksReranker(columns_to_rerank=["country2"])
+    vector_search_tool.execute(
+        query="what cities are in Germany",
+        filters=[FilterItem(key="country", value="Germany")],
+        reranker=overridden_reranker,
+    )
+    vector_search_tool._index.similarity_search.assert_called_once_with(
+        columns=vector_search_tool.columns,
+        query_text="what cities are in Germany",
+        filters={"country": "Germany"},
+        num_results=vector_search_tool.num_results,
+        query_type=vector_search_tool.query_type,
+        query_vector=None,
+        reranker=overridden_reranker,
     )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ dependencies = [
   "typing_extensions",
   "pydantic",
   "databricks-sdk>=0.49.0",
+  "databricks-vectorsearch>=0.50",
   "pandas",
   "tiktoken>=0.8.0",
   "tabulate>=0.9.0",
@@ -38,7 +39,6 @@ dev = [
   "pytest",
   "mlflow",
   "ruff==0.12.10",
-  "databricks-vectorsearch>=0.50",
 ]
 doc = [
   "docutils>=0.21.2",

--- a/src/databricks_ai_bridge/vector_search_retriever_tool.py
+++ b/src/databricks_ai_bridge/vector_search_retriever_tool.py
@@ -5,6 +5,7 @@ from typing import Any, Dict, List, Optional
 
 import mlflow
 from databricks.sdk import WorkspaceClient
+from databricks.vector_search.reranker import Reranker
 from mlflow.entities import SpanType
 from mlflow.models.resources import (
     DatabricksServingEndpoint,
@@ -109,6 +110,12 @@ class VectorSearchRetrieverToolMixin(BaseModel):
         description="When true, enables LLM-generated filter parameters in the tool schema. "
         "This allows LLMs to dynamically generate filters based on natural language queries. "
         "Cannot be used together with predefined filters (filters parameter).",
+    )
+    reranker: Optional["Reranker"] = Field(
+        None,
+        description="When specified, will reranker the search results to improve relevance. "
+        "\n\nRead more about reranking at: "
+        "https://www.databricks.com/blog/reranking-mosaic-ai-vector-search-faster-smarter-retrieval-rag-agents",
     )
 
     @model_validator(mode="after")


### PR DESCRIPTION
Add reranker parameter to various vector search tools in our integration libraries to make it more obvious this is supported.

**Test Plan:**

```
$ uv run ipython
...
In [1]: from databricks_langchain import VectorSearchRetrieverTool, ChatDatabricks

In [2]: help(VectorSearchRetrieverTool)

class VectorSearchRetrieverTool(langchain_core.tools.base.BaseTool, databricks_ai_bridge.vector_search_retriever_tool.VectorSearchRetrieverToolMixin)
 |  VectorSearchRetrieverTool(
 |      *,
 ...
 |      reranker: databricks.vector_search.reranker.DatabricksReranker | None = None,
 ```

`reranker` now appears in the parameter list.

Tests:

```
$ uv run pytest integrations/langchain/tests/unit_tests
...
=============================================== 4 failed, 194 passed, 2 skipped, 588 warnings in 2.27s ===============================================
# Pre-existing issues

$ uv run pytest integrations/llamaindex/tests/unit_tests
...
========================================================== 112 passed, 88 warnings in 1.60s ==========================================================

$ uv run pytest integrations/openai/tests/unit_tests
...
========================================================== 50 passed, 923 warnings in 1.76s ==========================================================
```