### PR TITLE
bug: fix minimal requirement for databricks-vectorsearch package

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ dependencies = [
   "typing_extensions",
   "pydantic",
   "databricks-sdk>=0.49.0",
-  "databricks-vectorsearch>=0.50",
+  "databricks-vectorsearch>=0.57",
   "pandas",
   "tiktoken>=0.8.0",
   "tabulate>=0.9.0",
@@ -39,6 +39,7 @@ dev = [
   "pytest",
   "mlflow",
   "ruff==0.12.10",
+  "pytest-asyncio",
 ]
 doc = [
   "docutils>=0.21.2",


### PR DESCRIPTION
Fix #222 

`0.57` is the earliest `databricks-vectorsearch` version when we introduced the `Reranker` classes.

### Test Plan

Before:

Change `pyproject.toml`:

```
  "databricks-vectorsearch==0.57",
```

Then run tests:

```
$ uv run pytest integrations/openai/tests/unit_tests/
...
_______________________________________ ERROR collecting integrations/openai/tests/unit_tests/test_imports.py _______________________________________
ImportError while importing test module '/Users/zeyi.f/databricks-ai-bridge/integrations/openai/tests/unit_tests/test_imports.py'.
Hint: make sure your test modules/packages have valid Python names.
Traceback:
../.local/share/uv/python/cpython-3.14.0-macos-aarch64-none/lib/python3.14/importlib/__init__.py:88: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
integrations/openai/tests/unit_tests/test_imports.py:1: in <module>
    from databricks_openai import (
integrations/openai/src/databricks_openai/__init__.py:21: in <module>
    from databricks_openai.vector_search_retriever_tool import VectorSearchRetrieverTool
integrations/openai/src/databricks_openai/vector_search_retriever_tool.py:13: in <module>
    from databricks_ai_bridge.vector_search_retriever_tool import (
src/databricks_ai_bridge/vector_search_retriever_tool.py:8: in <module>
    from databricks.vector_search.reranker import Reranker
E   ModuleNotFoundError: No module named 'databricks.vector_search.reranker'
```

After:

```
$ uv run pytest integrations/openai/tests/unit_tests/
...
integrations/openai/tests/unit_tests/test_clients.py ....                                                                                     [  4%]
integrations/openai/tests/unit_tests/test_mcp_server.py ...........                                                                           [ 17%]
integrations/openai/tests/unit_tests/test_mcp_server_toolkit.py .................                                                             [ 37%]
integrations/openai/tests/unit_tests/test_vector_search_retriever_tool.py .....................................................               [100%]
...
========================================================= 85 passed, 971 warnings in 2.39s ==========================================================
```