### PR TITLE
chore: move optional dependencies to dependency groups

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,7 +3,7 @@ name: tests
 on:
   push:
     branches:
-      - master
+      - main
   pull_request:
     types:
       - opened
@@ -24,7 +24,7 @@ jobs:
           python-version: "3.10"
       - name: Install dependencies
         run: |
-          pip install .[lint]
+          pip install . --group lint
       - name: Lint Python code with ruff
         run: |
           ruff check .
@@ -45,7 +45,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
         run: |
-          pip install ".[dev, memory]"
+          pip install ".[memory]" --group dev
       - name: Run tests
         run: |
           pytest tests/
@@ -66,7 +66,7 @@ jobs:
       - name: Install dependencies
         run: |
           pip install .
-          pip install integrations/langchain[dev]
+          pip install integrations/langchain --group dev
       - name: Run tests
         run: |
           pytest integrations/langchain/tests/unit_tests
@@ -87,7 +87,7 @@ jobs:
       - name: Install dependencies
         run: |
           pip install .[memory]
-          pip install "integrations/langchain[dev, memory]"
+          pip install "integrations/langchain[memory]" --group dev
       - name: Run tests
         run: |
           pytest tests/databricks_ai_bridge/test_lakebase.py
@@ -132,7 +132,7 @@ jobs:
           cp -r older-version/integrations/langchain integrations/
       - name: Install langchain dependency
         run: |
-          pip install integrations/langchain[dev]
+          pip install integrations/langchain --group dev
       - name: Run tests
         run: |
           # Only testing initialization since functionality can change
@@ -157,7 +157,7 @@ jobs:
       - name: Install dependencies
         run: |
           pip install .
-          pip install integrations/openai[dev]
+          pip install integrations/openai --group dev
       - name: Run tests
         run: |
           pytest integrations/openai/tests/unit_tests
@@ -199,7 +199,8 @@ jobs:
           cp -r older-version/integrations/openai integrations/
       - name: Install openai dependency
         run: |
-          pip install integrations/openai[dev]
+          pip install .
+          pip install integrations/openai --group dev
       - name: Run tests
         run: |
           # Only testing initialization since functionality can change
@@ -221,7 +222,7 @@ jobs:
       - name: Install dependencies
         run: |
           pip install .
-          pip install integrations/llamaindex[dev]
+          pip install integrations/llamaindex --group dev
       - name: Run tests
         run: |
           pytest integrations/llamaindex/tests/unit_tests
@@ -242,7 +243,7 @@ jobs:
       - name: Install dependencies
         run: |
           pip install .
-          pip install -e databricks_mcp[dev]
+          pip install -e databricks_mcp --group dev
       - name: Run tests
         run: |
           pytest databricks_mcp/tests/unit_tests
@@ -263,7 +264,7 @@ jobs:
       - name: Install dependencies
         run: |
           pip install .
-          pip install integrations/dspy[dev]
+          pip install integrations/dspy --group dev
       - name: Run tests
         run: |
           pytest integrations/dspy/tests/unit_tests

--- a/databricks_mcp/pyproject.toml
+++ b/databricks_mcp/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = [
     "mlflow>=3.1"
 ]
 
-[project.optional-dependencies]
+[dependency-groups]
 dev = [
   "pytest",
   "pytest-asyncio",

--- a/integrations/dspy/pyproject.toml
+++ b/integrations/dspy/pyproject.toml
@@ -14,7 +14,7 @@ dependencies = [
     "mlflow>=3.0.0",
 ]
 
-[project.optional-dependencies]
+[dependency-groups]
 dev = [
   "pytest",
   "ruff",

--- a/integrations/langchain/pyproject.toml
+++ b/integrations/langchain/pyproject.toml
@@ -23,6 +23,12 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
+memory = [
+  "langgraph-checkpoint-postgres>=2.0.0",
+  "databricks-ai-bridge[memory]>=0.10.0",
+]
+
+[dependency-groups]
 dev = [
   "pytest",
   "pytest-asyncio",
@@ -37,10 +43,6 @@ integration = [
   "anyio",
 ]
 
-memory = [
-  "langgraph-checkpoint-postgres>=2.0.0",
-  "databricks-ai-bridge[memory]>=0.10.0",
-]
 
 [build-system]
 requires = ["hatchling"]

--- a/integrations/llamaindex/pyproject.toml
+++ b/integrations/llamaindex/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = [
     "unitycatalog-llamaindex[databricks]>=0.2.0",
 ]
 
-[project.optional-dependencies]
+[dependency-groups]
 dev = [
     "pytest",
     "typing_extensions",

--- a/integrations/openai/pyproject.toml
+++ b/integrations/openai/pyproject.toml
@@ -20,7 +20,7 @@ dependencies = [
     "openai-agents>=0.5.0"
 ]
 
-[project.optional-dependencies]
+[dependency-groups]
 dev = [
     "pytest",
     "pytest-asyncio",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,19 +21,12 @@ dependencies = [
 [project.license]
 file = "LICENSE.txt"
 
-[build-system]
-requires = ["hatchling"]
-build-backend = "hatchling.build"
-
-[tool.hatch.build]
-include = [
-  "src/*"
+[project.optional-dependencies]
+memory = [
+  "psycopg[binary,pool]>=3.1",
 ]
 
-[tool.hatch.build.targets.wheel]
-packages = ["src/databricks_ai_bridge"]
-
-[project.optional-dependencies]
+[dependency-groups]
 dev = [
   "hatch",
   "pytest",
@@ -56,9 +49,17 @@ lint = [
   "ruff==0.12.10",
 ]
 
-memory = [
-  "psycopg[binary,pool]>=3.1",
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build]
+include = [
+  "src/*"
 ]
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/databricks_ai_bridge"]
 
 [tool.ruff]
 line-length = 100


### PR DESCRIPTION
[PEP 735](https://packaging.python.org/en/latest/specifications/dependency-groups/#dependency-groups) defines dependency groups, which is different from optional dependencies -- notably the dependency information is not exported to the published package metadata.

For dependencies we need for testing purposes, we can use dependency groups and only use optional features when we want to allow users to customize their dependencies based on their needs.

## Test Plan

GitHub Action
