### PR TITLE
chore: use uv for running tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,26 +12,30 @@ on:
       - ready_for_review
   workflow_dispatch:
 
+env:
+  UV_VERSION: "0.9.11"
+
 jobs:
   lint:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
-      - name: Set up Python
-        uses: actions/setup-python@v5
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
         with:
-          python-version: "3.10"
+          version: ${{ env.UV_VERSION }}
       - name: Install dependencies
         run: |
-          pip install . --group lint
+          uv sync --group lint
       - name: Lint Python code with ruff
         run: |
-          ruff check .
-          ruff format --check .
+          uv run ruff check .
+          uv run ruff format --check .
 
   core_test:
     runs-on: ubuntu-latest
+    name: core_test python-${{ matrix.python-version }}
     strategy:
       matrix:
         python-version: ["3.10", "3.11", "3.12"]
@@ -39,16 +43,14 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-      - name: Set up Python
-        uses: actions/setup-python@v5
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
         with:
+          version: ${{ env.UV_VERSION }}
           python-version: ${{ matrix.python-version }}
-      - name: Install dependencies
-        run: |
-          pip install ".[memory]" --group dev
       - name: Run tests
         run: |
-          pytest tests/
+          uv run --exact --group tests --extra memory pytest tests/
 
   langchain_test:
     runs-on: ubuntu-latest
@@ -59,17 +61,15 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-      - name: Set up Python
-        uses: actions/setup-python@v5
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
         with:
+          version: ${{ env.UV_VERSION }}
           python-version: ${{ matrix.python-version }}
-      - name: Install dependencies
-        run: |
-          pip install .
-          pip install integrations/langchain --group dev
       - name: Run tests
+        working-directory: integrations/langchain
         run: |
-          pytest integrations/langchain/tests/unit_tests
+          uv run --exact --group tests pytest tests/unit_tests
 
   lakebase_memory_test:
     runs-on: ubuntu-latest
@@ -80,19 +80,18 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-      - name: Set up Python
-        uses: actions/setup-python@v5
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
         with:
+          version: ${{ env.UV_VERSION }}
           python-version: ${{ matrix.python-version }}
-      - name: Install dependencies
+      - name: Run databricks-ai-bridge Tests
         run: |
-          pip install .[memory]
-          pip install "integrations/langchain[memory]" --group dev
-      - name: Run tests
+          uv run --exact --group tests --extra memory pytest tests/databricks_ai_bridge/test_lakebase.py
+      - name: Run databricks-langchain Tests
+        working-directory: integrations/langchain
         run: |
-          pytest tests/databricks_ai_bridge/test_lakebase.py
-          pytest integrations/langchain/tests/unit_tests/test_checkpoint.py
-          pytest integrations/langchain/tests/unit_tests/test_store.py
+          uv run --exact --group tests --extra memory pytest tests/unit_tests/test_checkpoint.py tests/unit_tests/test_store.py
 
   langchain_cross_version_test:
     runs-on: ubuntu-latest
@@ -150,17 +149,15 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-      - name: Set up Python
-        uses: actions/setup-python@v5
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
         with:
+          version: ${{ env.UV_VERSION }}
           python-version: ${{ matrix.python-version }}
-      - name: Install dependencies
-        run: |
-          pip install .
-          pip install integrations/openai --group dev
       - name: Run tests
+        working-directory: integrations/openai
         run: |
-          pytest integrations/openai/tests/unit_tests
+          uv run --exact --group tests pytest tests/unit_tests
 
   openai_cross_version_test:
     runs-on: ubuntu-latest
@@ -215,17 +212,15 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-      - name: Set up Python
-        uses: actions/setup-python@v5
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
         with:
+          version: ${{ env.UV_VERSION }}
           python-version: ${{ matrix.python-version }}
-      - name: Install dependencies
-        run: |
-          pip install .
-          pip install integrations/llamaindex --group dev
       - name: Run tests
+        working-directory: integrations/llamaindex
         run: |
-          pytest integrations/llamaindex/tests/unit_tests
+          uv run --exact --group tests pytest tests/unit_tests
 
   mcp_test:
     runs-on: ubuntu-latest
@@ -236,17 +231,15 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-      - name: Set up Python
-        uses: actions/setup-python@v5
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
         with:
+          version: ${{ env.UV_VERSION }}
           python-version: ${{ matrix.python-version }}
-      - name: Install dependencies
-        run: |
-          pip install .
-          pip install -e databricks_mcp --group dev
       - name: Run tests
+        working-directory: databricks_mcp
         run: |
-          pytest databricks_mcp/tests/unit_tests
+          uv run --exact --group tests pytest tests/unit_tests
 
   dspy_test:
     runs-on: ubuntu-latest
@@ -257,14 +250,12 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-      - name: Set up Python
-        uses: actions/setup-python@v5
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
         with:
+          version: ${{ env.UV_VERSION }}
           python-version: ${{ matrix.python-version }}
-      - name: Install dependencies
-        run: |
-          pip install .
-          pip install integrations/dspy --group dev
       - name: Run tests
+        working-directory: integrations/dspy
         run: |
-          pytest integrations/dspy/tests/unit_tests
+          uv run --exact --group tests pytest tests/unit_tests

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,19 +2,16 @@
 
 ## Setting up dev environment
 
-Create a conda environment and install dev requirements
+We have individual uv environments for each package. To start, sync dependencies with the following command:
 
 ```sh
-conda create --name databricks-ai-dev-env python=3.10
-conda activate databricks-ai-dev-env
-pip install -e ".[dev]"
-pip install -e ".[doc]"
+uv sync
 ```
 
-If you are working with integration packages install them as well
+## Run tests
 
-```sh
-pip install -e "integrations/langchain[dev]"
+```
+uv run --group tests pytest tests/
 ```
 
 ### Build API docs

--- a/databricks_mcp/pyproject.toml
+++ b/databricks_mcp/pyproject.toml
@@ -17,20 +17,24 @@ dependencies = [
 
 [dependency-groups]
 dev = [
-  "pytest",
-  "pytest-asyncio",
   "typing_extensions",
   "databricks-sdk>=0.49.0",
   "ruff==0.6.4",
+  { include-group = "tests" }
 ]
 
-integration = [
+tests = [
+  "pytest",
+  "pytest-asyncio",
   "pytest-timeout>=2.3.1",
 ]
 
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"
+
+[tool.uv.sources]
+databricks-ai-bridge = { path = "../", editable = true }
 
 [tool.hatch.build]
 include = [
@@ -71,3 +75,10 @@ docstring-code-line-length = 88
 
 [tool.ruff.lint.pydocstyle]
 convention = "google"
+
+[tool.pytest.ini_options]
+filterwarnings = [
+    "ignore::Warning",
+    "default::Warning:databricks_mcp",
+    "default::Warning:tests",
+]

--- a/integrations/dspy/pyproject.toml
+++ b/integrations/dspy/pyproject.toml
@@ -16,13 +16,19 @@ dependencies = [
 
 [dependency-groups]
 dev = [
-  "pytest",
   "ruff",
+  { include-group = "tests" }
+]
+tests = [
+  "pytest",
 ]
 
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"
+
+[tool.uv.sources]
+databricks-ai-bridge = { path = "../../", editable = true }
 
 [tool.hatch.build]
 include = [
@@ -60,3 +66,10 @@ select = [
 [tool.ruff.format]
 docstring-code-format = true
 docstring-code-line-length = 100
+
+[tool.pytest.ini_options]
+filterwarnings = [
+    "ignore::Warning",
+    "default::Warning:databricks_dspy",
+    "default::Warning:tests",
+]

--- a/integrations/langchain/pyproject.toml
+++ b/integrations/langchain/pyproject.toml
@@ -30,13 +30,13 @@ memory = [
 
 [dependency-groups]
 dev = [
-  "pytest",
-  "pytest-asyncio",
   "typing_extensions",
   "ruff==0.6.4",
+  { include-group = "tests" }
 ]
 
-integration = [
+tests = [
+  "pytest",
   "langgraph>=0.2.27",
   "pytest-timeout>=2.3.1",
   "pytest-asyncio",
@@ -47,6 +47,9 @@ integration = [
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"
+
+[tool.uv.sources]
+databricks-ai-bridge = { path = "../../", editable = true }
 
 [tool.hatch.build]
 include = [
@@ -87,3 +90,10 @@ docstring-code-line-length = 88
 
 [tool.ruff.lint.pydocstyle]
 convention = "google"
+
+[tool.pytest.ini_options]
+filterwarnings = [
+    "ignore::Warning",
+    "default::Warning:databricks_langchain",
+    "default::Warning:tests",
+]

--- a/integrations/llamaindex/pyproject.toml
+++ b/integrations/llamaindex/pyproject.toml
@@ -17,19 +17,23 @@ dependencies = [
 
 [dependency-groups]
 dev = [
-    "pytest",
     "typing_extensions",
     "databricks-sdk>=0.34.0",
     "ruff==0.6.4",
+    { include-group = "tests" }
 ]
 
-integration = [
+tests = [
+    "pytest",
     "pytest-timeout>=2.3.1",
 ]
 
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"
+
+[tool.uv.sources]
+databricks-ai-bridge = { path = "../../", editable = true }
 
 [tool.hatch.build]
 include = [
@@ -70,3 +74,10 @@ docstring-code-line-length = 88
 
 [tool.ruff.lint.pydocstyle]
 convention = "google"
+
+[tool.pytest.ini_options]
+filterwarnings = [
+    "ignore::Warning",
+    "default::Warning:databricks_llamaindex",
+    "default::Warning:tests",
+]

--- a/integrations/openai/pyproject.toml
+++ b/integrations/openai/pyproject.toml
@@ -22,20 +22,24 @@ dependencies = [
 
 [dependency-groups]
 dev = [
-    "pytest",
-    "pytest-asyncio",
     "typing_extensions",
     "databricks-sdk>=0.34.0",
     "ruff==0.6.4",
+    { include-group = "tests" }
 ]
 
-integration = [
+tests = [
+    "pytest",
+    "pytest-asyncio",
     "pytest-timeout>=2.3.1",
 ]
 
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"
+
+[tool.uv.sources]
+databricks-ai-bridge = { path = "../../", editable = true }
 
 [tool.hatch.build]
 include = [
@@ -76,3 +80,10 @@ docstring-code-line-length = 88
 
 [tool.ruff.lint.pydocstyle]
 convention = "google"
+
+[tool.pytest.ini_options]
+filterwarnings = [
+    "ignore::Warning",
+    "default::Warning:databricks_openai",
+    "default::Warning:tests",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,9 +29,12 @@ memory = [
 [dependency-groups]
 dev = [
   "hatch",
-  "pytest",
+  { include-group = "tests" },
+  { include-group = "lint" },
+]
+tests = [
   "mlflow",
-  "ruff==0.12.10",
+  "pytest",
   "pytest-asyncio",
 ]
 doc = [
@@ -95,3 +98,8 @@ convention = "google"
 
 [tool.pytest.ini_options]
 pythonpath = ["src"]
+filterwarnings = [
+    "ignore::Warning",
+    "default::Warning:databricks_ai_bridge",
+    "default::Warning:tests",
+]


### PR DESCRIPTION
Summary of what changed:

- Uses uv for environment isolation in GitHub tests
- Restructured `pyproject.toml` so that:
  - Every package now has a `dev` and `integration` dependency group. `integration` group for dependencies in integration tests, and `dev` for all the dependencies required for local development
  - All the subpackages will use `databricks-ai-bridge` at `<PROJECT_ROOT>` in tests instead of pulling from PyPI.
  - Warnings from dependent packages are suppressed. This means all the reported warnings are valid and probably worth looking into.
- I left the cross-version tests alone as it clones the older source which do not include uv configurations. It could be tricky to support these.

This should provide better environment isolation for our testing environments, and fail quickly if we fail to declare some dependencies.

### Test Plan

GitHub Action signals should be green.