### PR TITLE
chore: start testing both lowest-direct and highest package resolution strategy

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,10 +35,11 @@ jobs:
 
   core_test:
     runs-on: ubuntu-latest
-    name: core_test python-${{ matrix.python-version }}
+    name: "core_test (python: ${{ matrix.python-version }}, uv: ${{ matrix.uv-resolution }})"
     strategy:
       matrix:
         python-version: ["3.10", "3.11", "3.12"]
+        uv-resolution: ["lowest-direct", "highest"]
     timeout-minutes: 20
     steps:
       - name: Checkout code
@@ -50,13 +51,18 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Run tests
         run: |
-          uv run --exact --group tests --extra memory pytest tests/
+          uv run --resolution ${{ matrix.uv-resolution }} \
+            --exact --group tests --extra memory \
+            pytest tests/
 
   langchain_test:
     runs-on: ubuntu-latest
+    name: "langchain_test (python: ${{ matrix.python-version }}, uv: ${{ matrix.uv-resolution }})"
     strategy:
       matrix:
         python-version: ["3.10"]
+        uv-resolution: ["lowest-direct", "highest"]
+
     timeout-minutes: 20
     steps:
       - name: Checkout code
@@ -69,13 +75,16 @@ jobs:
       - name: Run tests
         working-directory: integrations/langchain
         run: |
-          uv run --exact --group tests pytest tests/unit_tests
+          uv run --resolution ${{ matrix.uv-resolution }} \
+            --exact --group tests pytest tests/unit_tests
 
   lakebase_memory_test:
     runs-on: ubuntu-latest
+    name: "lakebase_memory_test (python: ${{ matrix.python-version }}, uv: ${{ matrix.uv-resolution }})"
     strategy:
       matrix:
         python-version: ["3.10"]
+        uv-resolution: ["lowest-direct", "highest"]
     timeout-minutes: 20
     steps:
       - name: Checkout code
@@ -87,11 +96,16 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Run databricks-ai-bridge Tests
         run: |
-          uv run --exact --group tests --extra memory pytest tests/databricks_ai_bridge/test_lakebase.py
+          uv run --resolution ${{ matrix.uv-resolution }} \
+            --exact --group tests --extra memory \
+            pytest tests/databricks_ai_bridge/test_lakebase.py
       - name: Run databricks-langchain Tests
         working-directory: integrations/langchain
         run: |
-          uv run --exact --group tests --extra memory pytest tests/unit_tests/test_checkpoint.py tests/unit_tests/test_store.py
+          uv run --resolution ${{ matrix.uv-resolution }} \
+            --exact --group tests --extra memory \
+            pytest tests/unit_tests/test_checkpoint.py \
+              tests/unit_tests/test_store.py
 
   langchain_cross_version_test:
     runs-on: ubuntu-latest
@@ -142,9 +156,11 @@ jobs:
 
   openai_test:
     runs-on: ubuntu-latest
+    name: "openai_test (python: ${{ matrix.python-version }}, uv: ${{ matrix.uv-resolution }})"
     strategy:
       matrix:
         python-version: ["3.10"]
+        uv-resolution: ["lowest-direct", "highest"]
     timeout-minutes: 20
     steps:
       - name: Checkout code
@@ -157,7 +173,8 @@ jobs:
       - name: Run tests
         working-directory: integrations/openai
         run: |
-          uv run --exact --group tests pytest tests/unit_tests
+          uv run --resolution ${{ matrix.uv-resolution }} \
+            --exact --group tests pytest tests/unit_tests
 
   openai_cross_version_test:
     runs-on: ubuntu-latest
@@ -178,9 +195,6 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
-      - name: Install dependencies
-        run: |
-          pip install . "${{ matrix.version.mlflow }}"
       - name: Checkout openai version
         uses: actions/checkout@v4
         with:
@@ -198,6 +212,7 @@ jobs:
         run: |
           pip install .
           pip install integrations/openai --group dev
+          pip install "${{ matrix.version.mlflow }}"
       - name: Run tests
         run: |
           # Only testing initialization since functionality can change
@@ -205,9 +220,11 @@ jobs:
 
   llamaindex_test:
     runs-on: ubuntu-latest
+    name: "llamaindex_test (python: ${{ matrix.python-version }}, uv: ${{ matrix.uv-resolution }})"
     strategy:
       matrix:
         python-version: ["3.10"]
+        uv-resolution: ["lowest-direct", "highest"]
     timeout-minutes: 20
     steps:
       - name: Checkout code
@@ -220,13 +237,15 @@ jobs:
       - name: Run tests
         working-directory: integrations/llamaindex
         run: |
-          uv run --exact --group tests pytest tests/unit_tests
+          uv run --resolution ${{ matrix.uv-resolution }} --exact --group tests pytest tests/unit_tests
 
   mcp_test:
     runs-on: ubuntu-latest
+    name: "mcp_test (python: ${{ matrix.python-version }}, uv: ${{ matrix.uv-resolution }})"
     strategy:
       matrix:
         python-version: ["3.10"]
+        uv-resolution: ["lowest-direct", "highest"]
     timeout-minutes: 20
     steps:
       - name: Checkout code
@@ -239,13 +258,16 @@ jobs:
       - name: Run tests
         working-directory: databricks_mcp
         run: |
-          uv run --exact --group tests pytest tests/unit_tests
+          uv run --resolution ${{ matrix.uv-resolution }} \
+            --exact --group tests pytest tests/unit_tests
 
   dspy_test:
     runs-on: ubuntu-latest
+    name: "dspy_test (python: ${{ matrix.python-version }}, uv: ${{ matrix.uv-resolution }})"
     strategy:
       matrix:
         python-version: ["3.10"]
+        uv-resolution: ["lowest-direct", "highest"]
     timeout-minutes: 20
     steps:
       - name: Checkout code
@@ -258,4 +280,5 @@ jobs:
       - name: Run tests
         working-directory: integrations/dspy
         run: |
-          uv run --exact --group tests pytest tests/unit_tests
+          uv run --resolution ${{ matrix.uv-resolution }} \
+            --exact --group tests pytest tests/unit_tests

--- a/databricks_mcp/pyproject.toml
+++ b/databricks_mcp/pyproject.toml
@@ -9,7 +9,7 @@ readme = "README.md"
 license = { text="Apache-2.0" }
 requires-python = ">=3.10"
 dependencies = [
-    "mcp>=1.9.1",
+    "mcp>=1.13.0",
     "databricks-sdk>=0.49.0",
     "databricks-ai-bridge>=0.4.2",
     "mlflow>=3.1"
@@ -17,15 +17,15 @@ dependencies = [
 
 [dependency-groups]
 dev = [
-  "typing_extensions",
+  "typing_extensions>=4.15.0",
   "databricks-sdk>=0.49.0",
   "ruff==0.6.4",
   { include-group = "tests" }
 ]
 
 tests = [
-  "pytest",
-  "pytest-asyncio",
+  "pytest>=9.0.0",
+  "pytest-asyncio>=1.3.0",
   "pytest-timeout>=2.3.1",
 ]
 

--- a/integrations/dspy/pyproject.toml
+++ b/integrations/dspy/pyproject.toml
@@ -20,7 +20,7 @@ dev = [
   { include-group = "tests" }
 ]
 tests = [
-  "pytest",
+  "pytest>=9.0.0",
 ]
 
 [build-system]

--- a/integrations/langchain/pyproject.toml
+++ b/integrations/langchain/pyproject.toml
@@ -12,7 +12,7 @@ dependencies = [
     "langchain>=1.0.0",
     "databricks-vectorsearch>=0.50",
     "databricks-ai-bridge>=0.4.2",
-    "mlflow>=2.20.1",
+    "mlflow>=3.0.0",
     "pydantic>2.10.0",
     "unitycatalog-langchain[databricks]>=0.3.0",
     "databricks-sdk>=0.65.0",
@@ -30,17 +30,17 @@ memory = [
 
 [dependency-groups]
 dev = [
-  "typing_extensions",
+  "typing_extensions>=4.15.0",
   "ruff==0.6.4",
   { include-group = "tests" }
 ]
 
 tests = [
-  "pytest",
+  "pytest>=9.0.0",
   "langgraph>=0.2.27",
   "pytest-timeout>=2.3.1",
-  "pytest-asyncio",
-  "anyio",
+  "pytest-asyncio>=1.3.0",
+  "anyio>=4.8.0",
 ]
 
 

--- a/integrations/llamaindex/pyproject.toml
+++ b/integrations/llamaindex/pyproject.toml
@@ -11,20 +11,20 @@ requires-python = ">=3.10"
 dependencies = [
     "databricks-vectorsearch>=0.40",
     "databricks-ai-bridge>=0.1.0",
-    "llama-index>=0.11.0",
+    "llama-index>=0.12.0",
     "unitycatalog-llamaindex[databricks]>=0.2.0",
 ]
 
 [dependency-groups]
 dev = [
-    "typing_extensions",
+    "typing_extensions>=4.15.0",
     "databricks-sdk>=0.34.0",
     "ruff==0.6.4",
     { include-group = "tests" }
 ]
 
 tests = [
-    "pytest",
+    "pytest>=9.0.0",
     "pytest-timeout>=2.3.1",
 ]
 

--- a/integrations/openai/pyproject.toml
+++ b/integrations/openai/pyproject.toml
@@ -22,15 +22,15 @@ dependencies = [
 
 [dependency-groups]
 dev = [
-    "typing_extensions",
+    "typing_extensions>=4.15.0",
     "databricks-sdk>=0.34.0",
     "ruff==0.6.4",
     { include-group = "tests" }
 ]
 
 tests = [
-    "pytest",
-    "pytest-asyncio",
+    "pytest>=9.0.0",
+    "pytest-asyncio>=1.3.0",
     "pytest-timeout>=2.3.1",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,11 +8,11 @@ authors = [
 readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
-  "typing_extensions",
-  "pydantic",
+  "typing_extensions>=4.15.0",
+  "pydantic>=2.10.0",
   "databricks-sdk>=0.49.0",
   "databricks-vectorsearch>=0.57",
-  "pandas",
+  "pandas>=2.2.0",
   "tiktoken>=0.8.0",
   "tabulate>=0.9.0",
   "mlflow-skinny>=2.19.0",
@@ -23,19 +23,19 @@ file = "LICENSE.txt"
 
 [project.optional-dependencies]
 memory = [
-  "psycopg[binary,pool]>=3.1",
+  "psycopg[binary,pool]>=3.2.10",
 ]
 
 [dependency-groups]
 dev = [
-  "hatch",
+  "hatch>=1.15.1",
   { include-group = "tests" },
   { include-group = "lint" },
 ]
 tests = [
-  "mlflow",
-  "pytest",
-  "pytest-asyncio",
+  "mlflow>=3.0.0",
+  "pytest>=9.0.0",
+  "pytest-asyncio>=1.3.0",
 ]
 doc = [
   "docutils>=0.21.2",


### PR DESCRIPTION
As #222 demonstrated, it is possible for us to introduce dependency to a newer version of a dependency package without breaking our CI.

This PR makes our GitHub Action to test for both `lowest-direct` and `highest` package resolution strategy so we can make sure the lower bounds we write in our package dependency still work.

## Test Plan

GitHub Action on this PR still passes.