### PR TITLE
Timeout Fix

### DIFF
--- a/integrations/openai/src/databricks_openai/agents/mcp_server.py
+++ b/integrations/openai/src/databricks_openai/agents/mcp_server.py
@@ -138,7 +138,7 @@ class McpServer(MCPServerStreamableHttp):
 
         if "client_session_timeout_seconds" not in mcpserver_kwargs:
             mcpserver_kwargs["client_session_timeout_seconds"] = params["timeout"]
-        
+
         super().__init__(params=params, **mcpserver_kwargs)
 
     @mlflow.trace(span_type=SpanType.TOOL)
@@ -154,7 +154,6 @@ class McpServer(MCPServerStreamableHttp):
             GetSessionIdCallback | None,
         ]
     ]:
-        print(f"self.params: {self.params}")
         kwargs = {
             "url": self.params["url"],
             "headers": self.params.get("headers", None),


### PR DESCRIPTION
Looks like the `client_session_timeout_seconds` default to 5 seconds was stopping our original timeout from being respected. Github issue: https://github.com/openai/openai-agents-python/issues/1026

Updated the code to pass along the same timeout to cleint_session_timeout_seconds if its not explicitly specified.

### Tests
Added Unit Tests
Successfully ran a 15 second tool
<img width="2178" height="1203" alt="image" src="https://github.com/user-attachments/assets/5edca65e-e130-46a7-a20a-d4d3d74e08af" />
