### PR TITLE
Adding DCR support to create UC Connections for external clients for MCP

### DIFF
--- a/databricks_mcp/src/databricks_mcp/__init__.py
+++ b/databricks_mcp/src/databricks_mcp/__init__.py
@@ -1,4 +1,5 @@
+from databricks_mcp.connector import register_mcp_server_via_dcr
 from databricks_mcp.mcp import DatabricksMCPClient
 from databricks_mcp.oauth_provider import DatabricksOAuthClientProvider
 
-__all__ = ["DatabricksOAuthClientProvider", "DatabricksMCPClient"]
+__all__ = ["DatabricksOAuthClientProvider", "DatabricksMCPClient", "register_mcp_server_via_dcr"]

--- a/databricks_mcp/src/databricks_mcp/connector.py
+++ b/databricks_mcp/src/databricks_mcp/connector.py
@@ -1,0 +1,615 @@
+"""MCP OAuth Discovery and Dynamic Client Registration for Databricks.
+
+This module provides functionality for discovering OAuth metadata and performing
+Dynamic Client Registration (DCR) for MCP (Model Context Protocol) connections.
+"""
+
+import json
+import logging
+import re
+from typing import Any, Dict, Optional, Tuple
+from urllib.parse import urljoin, urlparse
+
+import requests
+from databricks.sdk import WorkspaceClient
+from databricks.sdk.service import catalog
+from databricks_ai_bridge.utils.annotations import experimental
+
+# Configure logging
+logger = logging.getLogger(__name__)
+
+# Constants
+DEFAULT_TIMEOUT = 10
+DEFAULT_PORT = "443"
+WWW_AUTHENTICATE_HEADER = "WWW-Authenticate"
+CONTENT_TYPE_JSON = "application/json"
+
+# ---------------- Helpers ----------------
+
+
+def _fetch_json(url: str, description: str) -> Dict[str, Any]:
+    """Fetch and parse JSON from a URL.
+
+    Args:
+        url: The URL to fetch from
+        description: Human-readable description for error messages
+
+    Returns:
+        Parsed JSON as a dictionary
+
+    Raises:
+        RuntimeError: If the request fails or JSON parsing fails
+    """
+    logger.debug(f"Fetching {description} from {url}")
+
+    try:
+        resp = requests.get(url, timeout=DEFAULT_TIMEOUT)
+        resp.raise_for_status()
+    except requests.exceptions.Timeout as e:
+        raise RuntimeError(f"Timeout while fetching {description} from {url}") from e
+    except requests.exceptions.RequestException as e:
+        raise RuntimeError(f"Failed to fetch {description} from {url}: {e}") from e
+
+    try:
+        data = resp.json()
+        logger.debug(f"Successfully fetched {description}")
+        return data
+    except ValueError as e:
+        raise RuntimeError(
+            f"Failed to parse {description} from {url} as JSON: {e}. Response: {resp.text[:200]}"
+        ) from e
+
+
+def _parse_www_authenticate(header_value: str) -> Dict[str, str]:
+    """Parse WWW-Authenticate header value into key-value parameters.
+
+    Parses headers like:
+        'Bearer resource_metadata="https://example.com/meta", scope="read write"'
+
+    Args:
+        header_value: The WWW-Authenticate header value
+
+    Returns:
+        Dictionary of parsed parameters from the header (quotes are removed from values)
+
+    Example:
+        >>> _parse_www_authenticate('Bearer scope="read write" realm="api"')
+        {'scope': 'read write', 'realm': 'api'}
+    """
+    if not header_value:
+        return {}
+
+    # Split off the auth scheme (e.g., "Bearer") from parameters
+    parts = header_value.split(" ", 1)
+    params_part = parts[1] if len(parts) == 2 else parts[0]
+    params = {}
+
+    # Extract key="value" pairs using regex
+    # Pattern: (\w+) captures parameter name, ([^"]*) captures value between quotes
+    for m in re.finditer(r'(\w+)\s*=\s*"([^"]*)"', params_part):
+        # Store without quotes: group(1) is key, group(2) is value
+        params[m.group(1)] = m.group(2)
+
+    logger.debug(f"Parsed WWW-Authenticate parameters: {list(params.keys())}")
+    return params
+
+
+def _try_resource_metadata_from_header(www_auth_header: str) -> Optional[str]:
+    """Extract resource metadata URL from WWW-Authenticate header.
+
+    Tries multiple parameter names in order of preference:
+    1. resource_metadata (official spec)
+    2. Common variations (authorization_uri, resource, as_uri, auth_uri)
+    3. First URL found in the header (fallback)
+
+    Args:
+        www_auth_header: The WWW-Authenticate header value
+
+    Returns:
+        The resource metadata URL if found, None otherwise
+    """
+    params = _parse_www_authenticate(www_auth_header)
+
+    # Official param per spec: resource_metadata
+    if "resource_metadata" in params:
+        logger.debug("Found resource_metadata in WWW-Authenticate header")
+        return params["resource_metadata"]
+
+    # Some servers use variations
+    for key in ("authorization_uri", "resource", "as_uri", "auth_uri"):
+        if key in params:
+            logger.debug(f"Found {key} in WWW-Authenticate header")
+            return params[key]
+
+    # Very last resort: extract first URL found in the header
+    # Pattern matches: http:// or https:// followed by any non-whitespace/comma/bracket chars
+    m = re.search(r"https?://[^\s,>]+", www_auth_header)
+    if m:
+        logger.debug("Extracted URL from WWW-Authenticate header as fallback")
+        return m.group(0)
+
+    logger.debug("No resource metadata URL found in WWW-Authenticate header")
+    return None
+
+
+def _build_well_known_candidates(mcp_url: str) -> Tuple[str, str]:
+    """Build candidate URLs for well-known OAuth protected resource metadata.
+
+    Args:
+        mcp_url: The MCP URL to derive well-known URLs from
+
+    Returns:
+        Tuple of two candidate URLs:
+        - Path-specific well-known URL
+        - Generic well-known URL
+    """
+    if not mcp_url:
+        raise ValueError("mcp_url cannot be empty")
+
+    parsed = urlparse(mcp_url)
+    if not parsed.scheme or not parsed.netloc:
+        raise ValueError(f"Invalid MCP URL: {mcp_url}")
+
+    base = f"{parsed.scheme}://{parsed.netloc}"
+    path = parsed.path.lstrip("/")  # e.g. "public/mcp"
+
+    candidates = (
+        f"{base}/.well-known/oauth-protected-resource/{path}",
+        f"{base}/.well-known/oauth-protected-resource",
+    )
+    logger.debug(f"Built well-known candidates: {candidates}")
+    return candidates
+
+
+# ---------------- Protected Resource Discovery ----------------
+
+
+def discover_protected_resource_metadata(mcp_url: str) -> Tuple[Dict[str, Any], Optional[str]]:
+    """Discover OAuth Protected Resource metadata from an MCP URL.
+
+    Attempts discovery in the following order:
+    1. From WWW-Authenticate header in 401 response
+    2. From path-specific well-known URL
+    3. From generic well-known URL
+
+    Args:
+        mcp_url: The MCP endpoint URL
+
+    Returns:
+        Tuple of (Protected Resource metadata dictionary, WWW-Authenticate header value or None)
+
+    Raises:
+        ValueError: If mcp_url is invalid
+        RuntimeError: If discovery fails via all methods
+    """
+    if not mcp_url:
+        raise ValueError("mcp_url cannot be empty")
+
+    logger.info(f"Discovering Protected Resource metadata for {mcp_url}")
+
+    try:
+        resp = requests.get(mcp_url, timeout=DEFAULT_TIMEOUT)
+    except requests.exceptions.RequestException as e:
+        raise RuntimeError(f"Failed to connect to MCP URL {mcp_url}: {e}") from e
+
+    if resp.status_code != 401:
+        raise RuntimeError(
+            f"Expected HTTP 401 from MCP URL for OAuth discovery, got {resp.status_code}. "
+            f"The MCP endpoint may not be protected or properly configured. "
+            f"Headers: {dict(resp.headers)}"
+        )
+
+    www_auth = resp.headers.get(WWW_AUTHENTICATE_HEADER)
+
+    # 1. Header method
+    if www_auth:
+        url_from_header = _try_resource_metadata_from_header(www_auth)
+        if url_from_header:
+            try:
+                metadata = _fetch_json(url_from_header, "Protected Resource metadata (from header)")
+                return metadata, www_auth
+            except RuntimeError as e:
+                logger.warning(f"Failed to fetch from header URL: {e}")
+                # fall through to well-known fallback
+
+    # 2. Well-known fallback
+    c1, c2 = _build_well_known_candidates(mcp_url)
+    for candidate in (c1, c2):
+        try:
+            metadata = _fetch_json(candidate, "Protected Resource metadata (well-known)")
+            return metadata, www_auth  # Return www_auth even if using well-known (may be None)
+        except RuntimeError as e:
+            logger.debug(f"Failed to fetch from {candidate}: {e}")
+            continue
+
+    raise RuntimeError(
+        "Could not discover Protected Resource Metadata via header or well-known URIs. "
+        "Ensure the MCP server supports OAuth discovery."
+    )
+
+
+# ---------------- AS Discovery ----------------
+
+
+def discover_authorization_server_metadata(resource_meta: Dict[str, Any]) -> Dict[str, Any]:
+    """Discover Authorization Server metadata from Protected Resource metadata.
+
+    Extracts the authorization server URL from the resource metadata and
+    attempts to fetch the authorization server metadata from well-known endpoints.
+
+    Args:
+        resource_meta: Protected Resource metadata dictionary
+
+    Returns:
+        Authorization Server metadata as a dictionary
+
+    Raises:
+        RuntimeError: If authorization server URL cannot be determined or metadata cannot be fetched
+    """
+    if not resource_meta:
+        raise ValueError("resource_meta cannot be empty")
+
+    logger.info("Discovering Authorization Server metadata")
+
+    # Extract authorization server base URL
+    if "authorization_servers" in resource_meta and resource_meta["authorization_servers"]:
+        as_base = resource_meta["authorization_servers"][0]
+        logger.debug(f"Using authorization_servers[0]: {as_base}")
+    elif "authorization_server" in resource_meta:
+        as_base = resource_meta["authorization_server"]
+        logger.debug(f"Using authorization_server: {as_base}")
+    elif "issuer" in resource_meta:
+        as_base = resource_meta["issuer"]
+        logger.debug(f"Using issuer: {as_base}")
+    else:
+        raise RuntimeError(
+            "Could not determine authorization server URL from Protected Resource metadata. "
+            "Expected one of: authorization_servers, authorization_server, or issuer. "
+            f"Available keys: {list(resource_meta.keys())}"
+        )
+
+    # Build candidate well-known URLs
+    # Parse the as_base to extract base URL and path for multi-tenant support
+    parsed = urlparse(as_base)
+    base_url = f"{parsed.scheme}://{parsed.netloc}"
+    path = parsed.path.rstrip("/")
+
+    candidates = []
+
+    # Standard path appending (works for most single-tenant setups)
+    candidates.append(urljoin(as_base.rstrip("/") + "/", ".well-known/oauth-authorization-server"))
+    candidates.append(urljoin(as_base.rstrip("/") + "/", ".well-known/openid-configuration"))
+
+    # Path insertion variants (for multi-tenant setups like https://auth.example.com/tenant1)
+    if path:  # Only add these if there's a path component
+        # OAuth 2.0 Authorization Server Metadata with path insertion
+        candidates.append(f"{base_url}/.well-known/oauth-authorization-server{path}")
+        # OpenID Connect Discovery 1.0 with path insertion
+        candidates.append(f"{base_url}/.well-known/openid-configuration{path}")
+
+    logger.debug(f"Trying authorization server metadata URLs: {candidates}")
+
+    last_error = None
+    for url in candidates:
+        try:
+            return _fetch_json(url, "Authorization Server metadata")
+        except RuntimeError as e:
+            logger.debug(f"Failed to fetch from {url}: {e}")
+            last_error = e
+
+    raise RuntimeError(
+        f"Unable to fetch Authorization Server metadata from any candidate URL. "
+        f"Last error: {last_error}"
+    ) from last_error
+
+
+# ---------------- DCR ----------------
+
+
+def _select_oauth_scope(
+    resource_meta: Dict[str, Any], www_auth_header: Optional[str] = None
+) -> str:
+    """Select OAuth scope following MCP specification priority order.
+
+    Per MCP spec, clients SHOULD follow this priority order:
+    1. Use 'scope' parameter from WWW-Authenticate header (if present)
+    2. Use 'scopes_supported' from Protected Resource Metadata (if available)
+    3. Omit scope parameter (return empty string if neither available)
+
+    Args:
+        resource_meta: Protected Resource metadata dictionary
+        www_auth_header: Optional WWW-Authenticate header from 401 response
+
+    Returns:
+        Space-separated scope string, or empty string if no scope should be requested
+    """
+    # Priority 1: Check WWW-Authenticate header for scope parameter
+    if www_auth_header:
+        params = _parse_www_authenticate(www_auth_header)
+        if "scope" in params:
+            scope = params["scope"]
+            logger.debug(f"Using scope from WWW-Authenticate header: {scope}")
+            return scope
+
+    # Priority 2: Use scopes_supported from Protected Resource Metadata
+    if "scopes_supported" in resource_meta and resource_meta["scopes_supported"]:
+        scopes = resource_meta["scopes_supported"]
+        if isinstance(scopes, list):
+            scope = " ".join(scopes)
+        else:
+            scope = str(scopes)
+        logger.debug(f"Using scopes_supported from Protected Resource Metadata: {scope}")
+        return scope
+
+    # Priority 3: No scope parameter
+    logger.debug("No scope information available; omitting scope parameter")
+    return ""
+
+
+def perform_dynamic_client_registration(
+    as_meta: Dict[str, Any],
+    resource_meta: Dict[str, Any],
+    www_auth_header: Optional[str] = None,
+    workspace_client: Optional[WorkspaceClient] = None,
+) -> Dict[str, Any]:
+    """Perform Dynamic Client Registration with the Authorization Server.
+
+    Registers a new OAuth client with the authorization server using the
+    registration endpoint from the AS metadata.
+
+    Args:
+        as_meta: Authorization Server metadata dictionary
+        resource_meta: Protected Resource metadata dictionary (for scope selection)
+        www_auth_header: Optional WWW-Authenticate header from 401 response (for scope selection)
+        workspace_client: Optional WorkspaceClient instance. If None, a new one is created.
+
+    Returns:
+        Registration response with client credentials and endpoints
+
+    Raises:
+        ValueError: If as_meta is invalid
+        RuntimeError: If DCR is not supported or registration fails
+    """
+    if not as_meta:
+        raise ValueError("as_meta cannot be empty")
+
+    logger.info("Performing Dynamic Client Registration")
+
+    # Validate required endpoints
+    reg_endpoint = as_meta.get("registration_endpoint")
+    if not reg_endpoint:
+        raise RuntimeError(
+            "Authorization Server does NOT support Dynamic Client Registration "
+            "(missing 'registration_endpoint'). "
+            f"Available endpoints: {[k for k in as_meta.keys() if 'endpoint' in k]}"
+        )
+
+    authz = as_meta.get("authorization_endpoint")
+    token = as_meta.get("token_endpoint")
+    if not authz or not token:
+        raise RuntimeError(
+            "Authorization Server metadata missing required endpoints. "
+            f"authorization_endpoint: {authz}, token_endpoint: {token}"
+        )
+
+    # Get Databricks workspace configuration
+    w = workspace_client or WorkspaceClient()
+    if not w.config.host:
+        raise RuntimeError("WorkspaceClient host is not configured")
+
+    redirect_uri = f"{w.config.host.rstrip('/')}/login/oauth/http.html"
+    logger.debug(f"Using redirect URI: {redirect_uri}")
+
+    # Select OAuth scope following MCP specification priority order
+    selected_scope = _select_oauth_scope(resource_meta, www_auth_header=www_auth_header)
+
+    # Build registration payload
+    payload = {
+        "client_name": "Databricks",
+        "redirect_uris": [redirect_uri],
+        "grant_types": ["authorization_code"],
+        "response_types": ["code"],
+        "token_endpoint_auth_method": "none",
+    }
+    logger.debug(f"Registration payload: {json.dumps(payload, indent=2)}")
+
+    # Perform registration
+    try:
+        resp = requests.post(
+            reg_endpoint,
+            json=payload,
+            headers={"Content-Type": CONTENT_TYPE_JSON},
+            timeout=DEFAULT_TIMEOUT,
+        )
+        resp.raise_for_status()
+    except requests.exceptions.RequestException as e:
+        raise RuntimeError(f"Dynamic Client Registration request failed: {e}") from e
+
+    # Parse registration response
+    try:
+        reg = resp.json()
+    except ValueError as e:
+        raise RuntimeError(
+            f"Failed to parse DCR response JSON: {e}. Response: {resp.text[:200]}"
+        ) from e
+
+    # Validate response
+    if "client_id" not in reg:
+        raise RuntimeError(
+            f"DCR response missing 'client_id'. Full response: {json.dumps(reg, indent=2)}"
+        )
+
+    logger.info(f"Successfully registered client: {reg.get('client_id')}")
+
+    # Augment response with additional metadata
+    reg["authorization_endpoint"] = authz
+    reg["token_endpoint"] = token
+    reg["redirect_uri"] = redirect_uri
+    reg["registration_method"] = "dcr"
+    reg["scope"] = selected_scope  # Store selected scope for UC connection
+
+    return reg
+
+
+def create_uc_connection(
+    mcp_url: str,
+    connection_name: str,
+    dcr_result: Dict[str, Any],
+    workspace_client: Optional[WorkspaceClient] = None,
+) -> str:
+    """Create a Unity Catalog HTTP connection for MCP.
+
+    Args:
+        mcp_url: The MCP endpoint URL
+        connection_name: Name for the Unity Catalog connection (metastore-level resource)
+        dcr_result: DCR result dictionary with client credentials and endpoints
+        workspace_client: Optional WorkspaceClient instance. If None, a new one is created.
+
+    Returns:
+        The workspace URL to view the connection
+
+    Raises:
+        ValueError: If inputs are invalid
+        RuntimeError: If connection creation fails
+    """
+    if not mcp_url:
+        raise ValueError("mcp_url cannot be empty")
+    if not connection_name:
+        raise ValueError("connection_name cannot be empty")
+    if not dcr_result:
+        raise ValueError("dcr_result cannot be empty")
+
+    # Parse and validate MCP URL early, before creating WorkspaceClient
+    parsed = urlparse(mcp_url)
+    if not parsed.scheme or not parsed.netloc:
+        raise ValueError(f"Invalid MCP URL: {mcp_url}")
+
+    logger.info(f"Creating Unity Catalog connection: {connection_name}")
+
+    w = workspace_client or WorkspaceClient()
+
+    host = f"{parsed.scheme}://{parsed.netloc}"
+    base_path = parsed.path or "/"
+    if not base_path.startswith("/"):
+        base_path = "/" + base_path
+
+    # Validate required fields from dcr_result
+    client_id = dcr_result.get("client_id")
+    if not client_id:
+        raise ValueError("dcr_result missing required field: client_id")
+
+    logger.debug(f"Connection config - host: {host}, base_path: {base_path}")
+
+    try:
+        w.connections.create(
+            connection_type=catalog.ConnectionType.HTTP,
+            name=connection_name,
+            options={
+                "host": host,
+                "port": DEFAULT_PORT,
+                "base_path": base_path,
+                "oauth_credential_exchange_method": "header_and_body",
+                "client_id": client_id,
+                "client_secret": dcr_result.get("client_secret", ""),
+                "authorization_endpoint": dcr_result.get("authorization_endpoint", ""),
+                "token_endpoint": dcr_result.get("token_endpoint", ""),
+                "oauth_scope": dcr_result.get("scope", ""),
+                "is_mcp_connection": "true",
+            },
+        )
+        logger.info(f"Successfully created Unity Catalog connection: {connection_name}")
+
+        # Construct workspace URL for viewing the connection
+        workspace_id = w.get_workspace_id()
+        connection_url = f"{w.config.host}/explore/connections/{connection_name}?o={workspace_id}&activeTab=overview"
+        return connection_url
+    except Exception as e:
+        raise RuntimeError(f"Failed to create Unity Catalog connection: {e}") from e
+
+
+# ---------------- Public Entry Point ----------------
+
+
+@experimental
+def register_mcp_server_via_dcr(
+    connection_name: str,
+    mcp_url: str,
+    workspace_client: Optional[WorkspaceClient] = None,
+) -> str:
+    """Register an MCP server via OAuth discovery and Dynamic Client Registration.
+
+    This function performs the complete OAuth discovery and DCR flow:
+    1. Check if Unity Catalog connection already exists (prevents duplicates)
+    2. Discover Protected Resource Metadata (header + well-known fallback)
+    3. Discover Authorization Server Metadata
+    4. Select OAuth scope following MCP spec priority order:
+       a. scope from WWW-Authenticate header (if present)
+       b. scopes_supported from Protected Resource Metadata (if available)
+       c. omit scope parameter (if neither available)
+    5. Perform Dynamic Client Registration with Databricks redirect URI
+    6. Create Unity Catalog connection with the registered client
+
+    Args:
+        connection_name: Name for the Unity Catalog connection
+        mcp_url: The MCP endpoint URL
+        workspace_client: Optional WorkspaceClient instance. If None, a new one is created.
+
+    Returns:
+        The workspace URL to view the connection
+
+    Raises:
+        ValueError: If inputs are invalid
+        RuntimeError: If any step of the discovery or registration process fails
+
+    Example:
+        >>> connection_url = register_mcp_server_via_dcr(
+        ...     connection_name="my_mcp_connection", mcp_url="https://mcp.example.com/api"
+        ... )
+        >>> print(connection_url)
+        'https://workspace.cloud.databricks.com/explore/connections/my_mcp_connection?o=1234567890&activeTab=overview'
+    """
+    if not connection_name:
+        raise ValueError("connection_name cannot be empty")
+    if not mcp_url:
+        raise ValueError("mcp_url cannot be empty")
+
+    logger.info(f"Starting MCP client registration for connection: {connection_name}")
+    logger.info(f"MCP URL: {mcp_url}")
+
+    # Check if connection already exists to prevent duplicates
+    w = workspace_client or WorkspaceClient()
+    try:
+        w.connections.get(connection_name)
+        logger.info(f"Connection '{connection_name}' already exists, skipping DCR")
+        # Construct workspace URL for the existing connection
+        workspace_id = w.get_workspace_id()
+        connection_url = f"{w.config.host}/explore/connections/{connection_name}?o={workspace_id}&activeTab=overview"
+        return connection_url
+    except Exception:
+        # Connection doesn't exist, proceed with DCR
+        logger.debug(f"Connection '{connection_name}' does not exist, proceeding with DCR")
+        pass
+
+    try:
+        # Step 1: Discover Protected Resource Metadata
+        prm, www_auth_header = discover_protected_resource_metadata(mcp_url)
+        logger.debug(f"Protected Resource Metadata: {json.dumps(prm, indent=2)}")
+
+        # Step 2: Discover Authorization Server Metadata
+        as_meta = discover_authorization_server_metadata(prm)
+        logger.debug(f"Authorization Server Metadata keys: {list(as_meta.keys())}")
+
+        # Step 3: Perform Dynamic Client Registration
+        dcr_result = perform_dynamic_client_registration(
+            as_meta, prm, www_auth_header, workspace_client
+        )
+
+        # Step 4: Create Unity Catalog Connection
+        connection_url = create_uc_connection(mcp_url, connection_name, dcr_result, w)
+
+        logger.info("Successfully completed MCP client registration")
+        return connection_url
+
+    except Exception as e:
+        logger.error(f"MCP client registration failed: {e}")
+        raise

--- a/databricks_mcp/tests/unit_tests/test_connector.py
+++ b/databricks_mcp/tests/unit_tests/test_connector.py
@@ -1,0 +1,733 @@
+"""Unit tests for databricks_mcp.connector module."""
+
+from unittest.mock import Mock, patch
+
+import pytest
+import requests
+from databricks.sdk import WorkspaceClient
+from databricks.sdk.service import catalog
+
+from databricks_mcp.connector import (
+    _build_well_known_candidates,
+    _fetch_json,
+    _parse_www_authenticate,
+    _try_resource_metadata_from_header,
+    create_uc_connection,
+    discover_authorization_server_metadata,
+    discover_protected_resource_metadata,
+    perform_dynamic_client_registration,
+    register_mcp_server_via_dcr,
+)
+
+
+class TestFetchJson:
+    """Tests for _fetch_json helper function."""
+
+    @patch("databricks_mcp.connector.requests.get")
+    def test_fetch_json_success(self, mock_get):
+        """Test successful JSON fetch."""
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"key": "value"}
+        mock_get.return_value = mock_response
+
+        result = _fetch_json("https://example.com/data", "test data")
+
+        assert result == {"key": "value"}
+        mock_get.assert_called_once_with("https://example.com/data", timeout=10)
+
+    @patch("databricks_mcp.connector.requests.get")
+    def test_fetch_json_timeout(self, mock_get):
+        """Test timeout handling."""
+        mock_get.side_effect = requests.exceptions.Timeout()
+
+        with pytest.raises(RuntimeError, match="Timeout while fetching"):
+            _fetch_json("https://example.com/data", "test data")
+
+    @patch("databricks_mcp.connector.requests.get")
+    def test_fetch_json_http_error(self, mock_get):
+        """Test HTTP error handling."""
+        mock_response = Mock()
+        mock_response.status_code = 404
+        mock_response.raise_for_status.side_effect = requests.exceptions.HTTPError()
+        mock_get.return_value = mock_response
+
+        with pytest.raises(RuntimeError, match="Failed to fetch"):
+            _fetch_json("https://example.com/data", "test data")
+
+    @patch("databricks_mcp.connector.requests.get")
+    def test_fetch_json_invalid_json(self, mock_get):
+        """Test invalid JSON response handling."""
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.json.side_effect = ValueError("Invalid JSON")
+        mock_response.text = "not json"
+        mock_get.return_value = mock_response
+
+        with pytest.raises(RuntimeError, match="Failed to parse.*as JSON"):
+            _fetch_json("https://example.com/data", "test data")
+
+
+class TestParseWwwAuthenticate:
+    """Tests for _parse_www_authenticate helper function."""
+
+    def test_parse_empty_header(self):
+        """Test parsing empty header."""
+        result = _parse_www_authenticate("")
+        assert result == {}
+
+    def test_parse_single_param(self):
+        """Test parsing single parameter."""
+        header = 'Bearer resource_metadata="https://example.com/metadata"'
+        result = _parse_www_authenticate(header)
+        assert result == {"resource_metadata": "https://example.com/metadata"}
+
+    def test_parse_multiple_params(self):
+        """Test parsing multiple parameters."""
+        header = 'Bearer resource_metadata="https://example.com/meta" realm="api"'
+        result = _parse_www_authenticate(header)
+        assert result == {
+            "resource_metadata": "https://example.com/meta",
+            "realm": "api",
+        }
+
+    def test_parse_no_scheme(self):
+        """Test parsing without auth scheme."""
+        header = 'resource="https://example.com" scope="read"'
+        result = _parse_www_authenticate(header)
+        # The regex looks for word characters before =, so "https://example.com" won't match
+        # because of the : and / characters. This test should expect only scope to be parsed.
+        assert result == {"scope": "read"}
+
+
+class TestTryResourceMetadataFromHeader:
+    """Tests for _try_resource_metadata_from_header function."""
+
+    def test_official_param(self):
+        """Test extraction using official resource_metadata parameter."""
+        header = 'Bearer resource_metadata="https://example.com/metadata"'
+        result = _try_resource_metadata_from_header(header)
+        assert result == "https://example.com/metadata"
+
+    def test_authorization_uri_param(self):
+        """Test extraction using authorization_uri parameter."""
+        header = 'Bearer authorization_uri="https://example.com/auth"'
+        result = _try_resource_metadata_from_header(header)
+        assert result == "https://example.com/auth"
+
+    def test_resource_param(self):
+        """Test extraction using resource parameter."""
+        header = 'Bearer resource="https://example.com/resource"'
+        result = _try_resource_metadata_from_header(header)
+        assert result == "https://example.com/resource"
+
+    def test_fallback_to_url_extraction(self):
+        """Test fallback to URL regex extraction."""
+        header = "Bearer some text https://example.com/fallback more text"
+        result = _try_resource_metadata_from_header(header)
+        assert result == "https://example.com/fallback"
+
+    def test_no_url_found(self):
+        """Test when no URL can be extracted."""
+        header = "Bearer realm=api"
+        result = _try_resource_metadata_from_header(header)
+        assert result is None
+
+
+class TestBuildWellKnownCandidates:
+    """Tests for _build_well_known_candidates function."""
+
+    def test_simple_url(self):
+        """Test with simple URL."""
+        c1, c2 = _build_well_known_candidates("https://example.com/mcp")
+        assert c1 == "https://example.com/.well-known/oauth-protected-resource/mcp"
+        assert c2 == "https://example.com/.well-known/oauth-protected-resource"
+
+    def test_url_with_nested_path(self):
+        """Test with nested path."""
+        c1, c2 = _build_well_known_candidates("https://example.com/api/v1/mcp")
+        assert c1 == "https://example.com/.well-known/oauth-protected-resource/api/v1/mcp"
+        assert c2 == "https://example.com/.well-known/oauth-protected-resource"
+
+    def test_url_with_port(self):
+        """Test with custom port."""
+        c1, c2 = _build_well_known_candidates("https://example.com:8080/mcp")
+        assert c1 == "https://example.com:8080/.well-known/oauth-protected-resource/mcp"
+        assert c2 == "https://example.com:8080/.well-known/oauth-protected-resource"
+
+    def test_empty_url(self):
+        """Test with empty URL."""
+        with pytest.raises(ValueError, match="mcp_url cannot be empty"):
+            _build_well_known_candidates("")
+
+    def test_invalid_url(self):
+        """Test with invalid URL."""
+        with pytest.raises(ValueError, match="Invalid MCP URL"):
+            _build_well_known_candidates("not-a-url")
+
+
+class TestDiscoverProtectedResourceMetadata:
+    """Tests for discover_protected_resource_metadata function."""
+
+    @patch("databricks_mcp.connector.requests.get")
+    @patch("databricks_mcp.connector._fetch_json")
+    def test_success_from_header(self, mock_fetch_json, mock_get):
+        """Test successful discovery from WWW-Authenticate header."""
+        mock_response = Mock()
+        mock_response.status_code = 401
+        mock_response.headers = {
+            "WWW-Authenticate": 'Bearer resource_metadata="https://example.com/metadata"'
+        }
+        mock_get.return_value = mock_response
+        mock_fetch_json.return_value = {"authorization_servers": ["https://auth.example.com"]}
+
+        metadata, www_auth_header = discover_protected_resource_metadata("https://example.com/mcp")
+
+        assert metadata == {"authorization_servers": ["https://auth.example.com"]}
+        assert www_auth_header == 'Bearer resource_metadata="https://example.com/metadata"'
+        mock_fetch_json.assert_called_once()
+
+    @patch("databricks_mcp.connector.requests.get")
+    @patch("databricks_mcp.connector._fetch_json")
+    def test_success_from_well_known(self, mock_fetch_json, mock_get):
+        """Test successful discovery from well-known URL."""
+        mock_response = Mock()
+        mock_response.status_code = 401
+        mock_response.headers = {}
+        mock_get.return_value = mock_response
+        mock_fetch_json.return_value = {"authorization_servers": ["https://auth.example.com"]}
+
+        metadata, www_auth_header = discover_protected_resource_metadata("https://example.com/mcp")
+
+        assert metadata == {"authorization_servers": ["https://auth.example.com"]}
+        assert www_auth_header is None
+        assert mock_fetch_json.call_count >= 1
+
+    @patch("databricks_mcp.connector.requests.get")
+    def test_non_401_response(self, mock_get):
+        """Test error when response is not 401."""
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.headers = {}
+        mock_get.return_value = mock_response
+
+        with pytest.raises(RuntimeError, match="Expected HTTP 401"):
+            discover_protected_resource_metadata("https://example.com/mcp")
+
+    def test_empty_url(self):
+        """Test with empty URL."""
+        with pytest.raises(ValueError, match="mcp_url cannot be empty"):
+            discover_protected_resource_metadata("")
+
+    @patch("databricks_mcp.connector.requests.get")
+    def test_connection_error(self, mock_get):
+        """Test connection error handling."""
+        mock_get.side_effect = requests.exceptions.ConnectionError()
+
+        with pytest.raises(RuntimeError, match="Failed to connect to MCP URL"):
+            discover_protected_resource_metadata("https://example.com/mcp")
+
+
+class TestDiscoverAuthorizationServerMetadata:
+    """Tests for discover_authorization_server_metadata function."""
+
+    @patch("databricks_mcp.connector._fetch_json")
+    def test_success_with_authorization_servers(self, mock_fetch_json):
+        """Test successful discovery using authorization_servers field."""
+        resource_meta = {"authorization_servers": ["https://auth.example.com"]}
+        mock_fetch_json.return_value = {
+            "authorization_endpoint": "https://auth.example.com/authorize",
+            "token_endpoint": "https://auth.example.com/token",
+        }
+
+        result = discover_authorization_server_metadata(resource_meta)
+
+        assert "authorization_endpoint" in result
+        assert "token_endpoint" in result
+
+    @patch("databricks_mcp.connector._fetch_json")
+    def test_success_with_authorization_server(self, mock_fetch_json):
+        """Test successful discovery using authorization_server field."""
+        resource_meta = {"authorization_server": "https://auth.example.com"}
+        mock_fetch_json.return_value = {
+            "authorization_endpoint": "https://auth.example.com/authorize"
+        }
+
+        result = discover_authorization_server_metadata(resource_meta)
+
+        assert "authorization_endpoint" in result
+
+    @patch("databricks_mcp.connector._fetch_json")
+    def test_success_with_issuer(self, mock_fetch_json):
+        """Test successful discovery using issuer field."""
+        resource_meta = {"issuer": "https://auth.example.com"}
+        mock_fetch_json.return_value = {"token_endpoint": "https://auth.example.com/token"}
+
+        result = discover_authorization_server_metadata(resource_meta)
+
+        assert "token_endpoint" in result
+
+    def test_missing_authorization_server(self):
+        """Test error when authorization server cannot be determined."""
+        resource_meta = {"some_other_field": "value"}
+
+        with pytest.raises(RuntimeError, match="Could not determine authorization server URL"):
+            discover_authorization_server_metadata(resource_meta)
+
+    def test_empty_resource_meta(self):
+        """Test with empty resource metadata."""
+        with pytest.raises(ValueError, match="resource_meta cannot be empty"):
+            discover_authorization_server_metadata({})
+
+    @patch("databricks_mcp.connector._fetch_json")
+    def test_all_candidates_fail(self, mock_fetch_json):
+        """Test when all candidate URLs fail."""
+        resource_meta = {"authorization_server": "https://auth.example.com"}
+        mock_fetch_json.side_effect = RuntimeError("Failed to fetch")
+
+        with pytest.raises(RuntimeError, match="Unable to fetch Authorization Server metadata"):
+            discover_authorization_server_metadata(resource_meta)
+
+    @patch("databricks_mcp.connector._fetch_json")
+    def test_multi_tenant_path_insertion(self, mock_fetch_json):
+        """Test multi-tenant discovery with path insertion."""
+        resource_meta = {"authorization_server": "https://auth.example.com/tenant1"}
+
+        # Simulate failure for standard URLs, success for path insertion variant
+        def fetch_side_effect(url, description):
+            if url == "https://auth.example.com/.well-known/oauth-authorization-server/tenant1":
+                return {
+                    "authorization_endpoint": "https://auth.example.com/tenant1/authorize",
+                    "token_endpoint": "https://auth.example.com/tenant1/token",
+                }
+            raise RuntimeError(f"Not found: {url}")
+
+        mock_fetch_json.side_effect = fetch_side_effect
+
+        result = discover_authorization_server_metadata(resource_meta)
+
+        assert result["authorization_endpoint"] == "https://auth.example.com/tenant1/authorize"
+        assert result["token_endpoint"] == "https://auth.example.com/tenant1/token"
+        # Verify it tried the path insertion variant
+        assert any(
+            "/.well-known/oauth-authorization-server/tenant1" in str(call)
+            for call in mock_fetch_json.call_args_list
+        )
+
+
+class TestSelectOAuthScope:
+    """Tests for _select_oauth_scope function."""
+
+    def test_scope_from_www_auth_header(self):
+        """Test scope selection from WWW-Authenticate header (priority 1)."""
+        from databricks_mcp.connector import _select_oauth_scope
+
+        resource_meta = {"scopes_supported": ["read", "write"]}
+        www_auth_header = 'Bearer scope="admin delete"'
+
+        scope = _select_oauth_scope(resource_meta, www_auth_header)
+
+        assert scope == "admin delete"
+
+    def test_scope_from_scopes_supported_list(self):
+        """Test scope selection from scopes_supported list (priority 2)."""
+        from databricks_mcp.connector import _select_oauth_scope
+
+        resource_meta = {"scopes_supported": ["read", "write", "delete"]}
+
+        scope = _select_oauth_scope(resource_meta, www_auth_header=None)
+
+        assert scope == "read write delete"
+
+    def test_scope_from_scopes_supported_string(self):
+        """Test scope selection from scopes_supported string (priority 2)."""
+        from databricks_mcp.connector import _select_oauth_scope
+
+        resource_meta = {"scopes_supported": "read write"}
+
+        scope = _select_oauth_scope(resource_meta, www_auth_header=None)
+
+        assert scope == "read write"
+
+    def test_no_scope_available(self):
+        """Test when no scope information is available (priority 3)."""
+        from databricks_mcp.connector import _select_oauth_scope
+
+        resource_meta = {}
+
+        scope = _select_oauth_scope(resource_meta, www_auth_header=None)
+
+        assert scope == ""
+
+    def test_empty_scopes_supported(self):
+        """Test when scopes_supported is empty."""
+        from databricks_mcp.connector import _select_oauth_scope
+
+        resource_meta = {"scopes_supported": []}
+
+        scope = _select_oauth_scope(resource_meta, www_auth_header=None)
+
+        assert scope == ""
+
+    def test_header_priority_over_metadata(self):
+        """Test that WWW-Authenticate header takes priority over metadata."""
+        from databricks_mcp.connector import _select_oauth_scope
+
+        resource_meta = {"scopes_supported": ["read", "write"]}
+        www_auth_header = 'Bearer scope="admin"'
+
+        scope = _select_oauth_scope(resource_meta, www_auth_header)
+
+        # Should use header scope, not metadata
+        assert scope == "admin"
+        assert scope != "read write"
+
+
+class TestPerformDynamicClientRegistration:
+    """Tests for perform_dynamic_client_registration function."""
+
+    @patch("databricks_mcp.connector.requests.post")
+    def test_success(self, mock_post):
+        """Test successful dynamic client registration."""
+        as_meta = {
+            "registration_endpoint": "https://auth.example.com/register",
+            "authorization_endpoint": "https://auth.example.com/authorize",
+            "token_endpoint": "https://auth.example.com/token",
+        }
+
+        mock_workspace = Mock(spec=WorkspaceClient)
+        mock_workspace.config.host = "https://databricks.example.com"
+
+        mock_response = Mock()
+        mock_response.status_code = 201
+        mock_response.json.return_value = {
+            "client_id": "test-client-id",
+            "client_secret": "test-secret",
+        }
+        mock_post.return_value = mock_response
+
+        resource_meta = {"scopes_supported": ["read", "write"]}
+        result = perform_dynamic_client_registration(
+            as_meta, resource_meta, www_auth_header=None, workspace_client=mock_workspace
+        )
+
+        assert result["client_id"] == "test-client-id"
+        assert result["client_secret"] == "test-secret"
+        assert result["authorization_endpoint"] == "https://auth.example.com/authorize"
+        assert result["token_endpoint"] == "https://auth.example.com/token"
+        assert result["registration_method"] == "dcr"
+        assert result["scope"] == "read write"
+        assert "redirect_uri" in result
+
+    def test_missing_registration_endpoint(self):
+        """Test error when registration_endpoint is missing."""
+        as_meta = {
+            "authorization_endpoint": "https://auth.example.com/authorize",
+            "token_endpoint": "https://auth.example.com/token",
+        }
+
+        mock_workspace = Mock(spec=WorkspaceClient)
+        mock_workspace.config.host = "https://databricks.example.com"
+
+        resource_meta = {}
+        with pytest.raises(RuntimeError, match="does NOT support Dynamic Client Registration"):
+            perform_dynamic_client_registration(
+                as_meta, resource_meta, www_auth_header=None, workspace_client=mock_workspace
+            )
+
+    def test_missing_authorization_endpoint(self):
+        """Test error when authorization_endpoint is missing."""
+        as_meta = {
+            "registration_endpoint": "https://auth.example.com/register",
+            "token_endpoint": "https://auth.example.com/token",
+        }
+
+        mock_workspace = Mock(spec=WorkspaceClient)
+        mock_workspace.config.host = "https://databricks.example.com"
+
+        resource_meta = {}
+        with pytest.raises(RuntimeError, match="missing required endpoints"):
+            perform_dynamic_client_registration(
+                as_meta, resource_meta, www_auth_header=None, workspace_client=mock_workspace
+            )
+
+    @patch("databricks_mcp.connector.requests.post")
+    def test_registration_http_error(self, mock_post):
+        """Test HTTP error during registration."""
+        as_meta = {
+            "registration_endpoint": "https://auth.example.com/register",
+            "authorization_endpoint": "https://auth.example.com/authorize",
+            "token_endpoint": "https://auth.example.com/token",
+        }
+
+        mock_workspace = Mock(spec=WorkspaceClient)
+        mock_workspace.config.host = "https://databricks.example.com"
+
+        mock_post.side_effect = requests.exceptions.HTTPError()
+
+        resource_meta = {}
+        with pytest.raises(RuntimeError, match="Dynamic Client Registration request failed"):
+            perform_dynamic_client_registration(
+                as_meta, resource_meta, www_auth_header=None, workspace_client=mock_workspace
+            )
+
+    @patch("databricks_mcp.connector.requests.post")
+    def test_invalid_json_response(self, mock_post):
+        """Test invalid JSON in registration response."""
+        as_meta = {
+            "registration_endpoint": "https://auth.example.com/register",
+            "authorization_endpoint": "https://auth.example.com/authorize",
+            "token_endpoint": "https://auth.example.com/token",
+        }
+
+        mock_workspace = Mock(spec=WorkspaceClient)
+        mock_workspace.config.host = "https://databricks.example.com"
+
+        mock_response = Mock()
+        mock_response.json.side_effect = ValueError("Invalid JSON")
+        mock_response.text = "not json"
+        mock_post.return_value = mock_response
+
+        resource_meta = {}
+        with pytest.raises(RuntimeError, match="Failed to parse DCR response"):
+            perform_dynamic_client_registration(
+                as_meta, resource_meta, www_auth_header=None, workspace_client=mock_workspace
+            )
+
+    @patch("databricks_mcp.connector.requests.post")
+    def test_missing_client_id_in_response(self, mock_post):
+        """Test error when client_id is missing from response."""
+        as_meta = {
+            "registration_endpoint": "https://auth.example.com/register",
+            "authorization_endpoint": "https://auth.example.com/authorize",
+            "token_endpoint": "https://auth.example.com/token",
+        }
+
+        mock_workspace = Mock(spec=WorkspaceClient)
+        mock_workspace.config.host = "https://databricks.example.com"
+
+        mock_response = Mock()
+        mock_response.status_code = 201
+        mock_response.json.return_value = {"client_secret": "test-secret"}
+        mock_post.return_value = mock_response
+
+        resource_meta = {}
+        with pytest.raises(RuntimeError, match="DCR response missing 'client_id'"):
+            perform_dynamic_client_registration(
+                as_meta, resource_meta, www_auth_header=None, workspace_client=mock_workspace
+            )
+
+    def test_empty_as_meta(self):
+        """Test with empty as_meta."""
+        resource_meta = {}
+        with pytest.raises(ValueError, match="as_meta cannot be empty"):
+            perform_dynamic_client_registration({}, resource_meta, None, None)
+
+
+class TestCreateUcConnection:
+    """Tests for create_uc_connection function."""
+
+    @patch("databricks_mcp.connector.WorkspaceClient")
+    def test_success(self, mock_workspace_class):
+        """Test successful connection creation."""
+        mock_workspace = Mock(spec=WorkspaceClient)
+        mock_workspace.connections.create = Mock()
+        mock_workspace.config.host = "https://workspace.databricks.com"
+        mock_workspace.get_workspace_id = Mock(return_value=1234567890)
+        mock_workspace_class.return_value = mock_workspace
+
+        mcp_url = "https://mcp.example.com/api/v1"
+        connection_name = "test_connection"
+        as_meta = {
+            "client_id": "test-client-id",
+            "client_secret": "test-secret",
+            "authorization_endpoint": "https://auth.example.com/authorize",
+            "token_endpoint": "https://auth.example.com/token",
+        }
+
+        result = create_uc_connection(mcp_url, connection_name, as_meta, mock_workspace)
+
+        # Verify connection was created
+        mock_workspace.connections.create.assert_called_once()
+        call_kwargs = mock_workspace.connections.create.call_args[1]
+        assert call_kwargs["name"] == connection_name
+        assert call_kwargs["connection_type"] == catalog.ConnectionType.HTTP
+        assert call_kwargs["options"]["client_id"] == "test-client-id"
+        assert call_kwargs["options"]["host"] == "https://mcp.example.com"
+        assert call_kwargs["options"]["base_path"] == "/api/v1"
+
+        # Verify returned URL format
+        assert (
+            result
+            == "https://workspace.databricks.com/explore/connections/test_connection?o=1234567890&activeTab=overview"
+        )
+
+    def test_empty_mcp_url(self):
+        """Test with empty MCP URL."""
+        with pytest.raises(ValueError, match="mcp_url cannot be empty"):
+            create_uc_connection("", "test_connection", {"client_id": "test"})
+
+    def test_empty_connection_name(self):
+        """Test with empty connection name."""
+        with pytest.raises(ValueError, match="connection_name cannot be empty"):
+            create_uc_connection("https://example.com", "", {"client_id": "test"})
+
+    def test_empty_dcr_result(self):
+        """Test with empty dcr_result."""
+        with pytest.raises(ValueError, match="dcr_result cannot be empty"):
+            create_uc_connection("https://example.com", "test", {})
+
+    def test_invalid_mcp_url(self):
+        """Test with invalid MCP URL."""
+        with pytest.raises(ValueError, match="Invalid MCP URL"):
+            create_uc_connection("not-a-url", "test", {"client_id": "test"})
+
+    def test_missing_client_id(self):
+        """Test with missing client_id in dcr_result."""
+        mock_workspace = Mock(spec=WorkspaceClient)
+
+        with pytest.raises(ValueError, match="dcr_result missing required field: client_id"):
+            create_uc_connection(
+                "https://example.com", "test", {"client_secret": "secret"}, mock_workspace
+            )
+
+    @patch("databricks_mcp.connector.WorkspaceClient")
+    def test_connection_creation_error(self, mock_workspace_class):
+        """Test error during connection creation."""
+        mock_workspace = Mock(spec=WorkspaceClient)
+        mock_workspace.connections.create.side_effect = Exception("Connection error")
+        mock_workspace_class.return_value = mock_workspace
+
+        with pytest.raises(RuntimeError, match="Failed to create Unity Catalog connection"):
+            create_uc_connection(
+                "https://example.com",
+                "test",
+                {"client_id": "test"},
+                mock_workspace,
+            )
+
+
+class TestRegisterMcpServerViaDcr:
+    """Tests for register_mcp_server_via_dcr function."""
+
+    @patch("databricks_mcp.connector.WorkspaceClient")
+    @patch("databricks_mcp.connector.create_uc_connection")
+    @patch("databricks_mcp.connector.perform_dynamic_client_registration")
+    @patch("databricks_mcp.connector.discover_authorization_server_metadata")
+    @patch("databricks_mcp.connector.discover_protected_resource_metadata")
+    def test_success(
+        self,
+        mock_discover_prm,
+        mock_discover_as,
+        mock_perform_dcr,
+        mock_create_conn,
+        mock_workspace_class,
+    ):
+        """Test successful end-to-end registration."""
+        # Mock WorkspaceClient for duplicate check
+        mock_workspace = Mock()
+        mock_workspace.connections.get.side_effect = Exception("Not found")
+        mock_workspace_class.return_value = mock_workspace
+
+        mock_discover_prm.return_value = (
+            {"authorization_server": "https://auth.example.com"},
+            'Bearer scope="read write"',
+        )
+        mock_discover_as.return_value = {
+            "registration_endpoint": "https://auth.example.com/register",
+            "authorization_endpoint": "https://auth.example.com/authorize",
+            "token_endpoint": "https://auth.example.com/token",
+        }
+        mock_perform_dcr.return_value = {
+            "client_id": "test-client-id",
+            "client_secret": "test-secret",
+            "authorization_endpoint": "https://auth.example.com/authorize",
+            "token_endpoint": "https://auth.example.com/token",
+            "redirect_uri": "https://databricks.example.com/login/oauth/http.html",
+            "registration_method": "dcr",
+            "scope": "read write",
+        }
+        mock_create_conn.return_value = "https://workspace.databricks.com/explore/connections/test_connection?o=1234567890&activeTab=overview"
+
+        result = register_mcp_server_via_dcr("test_connection", "https://mcp.example.com/api")
+
+        assert (
+            result
+            == "https://workspace.databricks.com/explore/connections/test_connection?o=1234567890&activeTab=overview"
+        )
+        mock_discover_prm.assert_called_once_with("https://mcp.example.com/api")
+        mock_create_conn.assert_called_once()
+
+    def test_empty_connection_name(self):
+        """Test with empty connection name."""
+        with pytest.raises(ValueError, match="connection_name cannot be empty"):
+            register_mcp_server_via_dcr("", "https://mcp.example.com")
+
+    def test_empty_mcp_url(self):
+        """Test with empty MCP URL."""
+        with pytest.raises(ValueError, match="mcp_url cannot be empty"):
+            register_mcp_server_via_dcr("test_connection", "")
+
+    @patch("databricks_mcp.connector.WorkspaceClient")
+    def test_connection_already_exists(self, mock_workspace_class):
+        """Test that existing connection is returned without running DCR."""
+        mock_workspace = Mock()
+        mock_existing_conn = Mock()
+        mock_workspace.connections.get.return_value = mock_existing_conn
+        mock_workspace.config.host = "https://workspace.databricks.com"
+        mock_workspace.get_workspace_id = Mock(return_value=1234567890)
+        mock_workspace_class.return_value = mock_workspace
+
+        result = register_mcp_server_via_dcr("existing_connection", "https://mcp.example.com/api")
+
+        assert (
+            result
+            == "https://workspace.databricks.com/explore/connections/existing_connection?o=1234567890&activeTab=overview"
+        )
+        # Verify that DCR flow was not triggered
+        mock_workspace.connections.get.assert_called_once_with("existing_connection")
+
+    @patch("databricks_mcp.connector.WorkspaceClient")
+    @patch("databricks_mcp.connector.discover_protected_resource_metadata")
+    def test_discovery_failure(self, mock_discover_prm, mock_workspace_class):
+        """Test handling of discovery failure."""
+        # Mock WorkspaceClient for duplicate check
+        mock_workspace = Mock()
+        mock_workspace.connections.get.side_effect = Exception("Not found")
+        mock_workspace_class.return_value = mock_workspace
+
+        mock_discover_prm.side_effect = RuntimeError("Discovery failed")
+
+        with pytest.raises(RuntimeError, match="Discovery failed"):
+            register_mcp_server_via_dcr("test_connection", "https://mcp.example.com/api")
+
+    @patch("databricks_mcp.connector.WorkspaceClient")
+    @patch("databricks_mcp.connector.perform_dynamic_client_registration")
+    @patch("databricks_mcp.connector.discover_authorization_server_metadata")
+    @patch("databricks_mcp.connector.discover_protected_resource_metadata")
+    def test_dcr_failure(
+        self,
+        mock_discover_prm,
+        mock_discover_as,
+        mock_perform_dcr,
+        mock_workspace_class,
+    ):
+        """Test handling of DCR failure."""
+        # Mock WorkspaceClient for duplicate check
+        mock_workspace = Mock()
+        mock_workspace.connections.get.side_effect = Exception("Not found")
+        mock_workspace_class.return_value = mock_workspace
+
+        mock_discover_prm.return_value = (
+            {"authorization_server": "https://auth.example.com"},
+            None,
+        )
+        mock_discover_as.return_value = {
+            "registration_endpoint": "https://auth.example.com/register",
+            "authorization_endpoint": "https://auth.example.com/authorize",
+            "token_endpoint": "https://auth.example.com/token",
+        }
+        mock_perform_dcr.side_effect = RuntimeError("DCR failed")
+
+        with pytest.raises(RuntimeError, match="DCR failed"):
+            register_mcp_server_via_dcr("test_connection", "https://mcp.example.com/api")


### PR DESCRIPTION
Adding DCR support to create UC Connections for external clients for MCP

Tested:
result = register_mcp_client_via_dcr("test_notion_connection", "https://mcp.notion.com/mcp")
print(result)

Connection created:
https://e2-dogfood.staging.cloud.databricks.com/explore/connections/test_notion_connection?o=6051921418418893&activeTab=overview