### PR TITLE
Fixes #211 with_structured_output for json_schema method

### DIFF
--- a/integrations/langchain/src/databricks_langchain/chat_models.py
+++ b/integrations/langchain/src/databricks_langchain/chat_models.py
@@ -975,6 +975,7 @@ class ChatDatabricks(BaseChatModel):
             response_format = {
                 "type": "json_schema",
                 "json_schema": {
+                    "name": kwargs.get("schema_name", "json_schema"),
                     "strict": True,
                     "schema": schema.model_json_schema() if is_pydantic_schema else schema,  # type: ignore[union-attr]
                 },


### PR DESCRIPTION
Fixes #211 

Add "name" key for response_format. It can optional input with key "schema_name". Otherwise default to "json_schema"

Change schema value type from tuple to dict.