### PR TITLE
chore: setup ty and ruff

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,13 +25,10 @@ jobs:
         uses: astral-sh/setup-uv@v6
         with:
           version: ${{ env.UV_VERSION }}
-      - name: Install dependencies
-        run: |
-          uv sync --group lint
       - name: Lint Python code with ruff
         run: |
-          uv run ruff check .
-          uv run ruff format --check .
+          ./for-each-project uv run --group dev ruff check .
+          ./for-each-project uv run --group dev ruff format --check .
 
   core_test:
     runs-on: ubuntu-latest

--- a/databricks_mcp/pyproject.toml
+++ b/databricks_mcp/pyproject.toml
@@ -19,8 +19,9 @@ dependencies = [
 dev = [
   "typing_extensions>=4.15.0",
   "databricks-sdk>=0.49.0",
-  "ruff==0.6.4",
-  { include-group = "tests" }
+  "ruff==0.12.10",
+  "ty>=0.0.11",
+  { include-group = "tests" },
 ]
 
 tests = [
@@ -45,36 +46,8 @@ include = [
 packages = ["src/databricks_mcp"]
 
 [tool.ruff]
-line-length = 100
-target-version = "py39"
-
-[tool.ruff.lint]
-select = [
-  # isort
-  "I",
-  # bugbear rules
-  "B",
-  # remove unused imports
-  "F401",
-  # bare except statements
-  "E722",
-  # print statements
-  "T201",
-  "T203",
-  # misuse of typing.TYPE_CHECKING
-  "TCH004",
-  # import rules
-  "TID251",
-  # undefined-local-with-import-star
-  "F403",
-]
-
-[tool.ruff.format]
-docstring-code-format = true
-docstring-code-line-length = 88
-
-[tool.ruff.lint.pydocstyle]
-convention = "google"
+include = ["pyproject.toml", "src/**/*.py", "tests/**/*.py"]
+extend = "../pyproject.toml"
 
 [tool.pytest.ini_options]
 filterwarnings = [
@@ -82,3 +55,9 @@ filterwarnings = [
     "default::Warning:databricks_mcp",
     "default::Warning:tests",
 ]
+
+[tool.ty.environment]
+root = ["./src", "./tests"]
+
+[tool.ty.src]
+include = ["./src", "./tests"]

--- a/for-each-project
+++ b/for-each-project
@@ -1,0 +1,51 @@
+#!/bin/bash
+
+#
+# for-each-project <command>
+#
+# Run command in each project directory.
+#
+
+set -x
+
+KEEP_GOING=false
+
+# Parse arguments
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    --keep-going)
+      KEEP_GOING=true
+      shift
+      ;;
+    *)
+      break
+      ;;
+  esac
+done
+
+CMD="$*"
+
+PROJECTS=(
+  "."
+  "databricks_mcp"
+  "integrations/dspy"
+  "integrations/llamaindex"
+  "integrations/openai"
+  "integrations/langchain"
+)
+
+main() {
+  for project in "${PROJECTS[@]}"; do
+      if pushd "$project"; then
+        $CMD
+        cmd_exit_status=$?
+        popd
+
+        if [ $cmd_exit_status -ne 0 ] && [ "$KEEP_GOING" = false ]; then
+          exit $cmd_exit_status
+        fi
+      fi
+  done
+}
+
+main

--- a/integrations/dspy/pyproject.toml
+++ b/integrations/dspy/pyproject.toml
@@ -17,7 +17,8 @@ dependencies = [
 [dependency-groups]
 dev = [
   "ruff",
-  { include-group = "tests" }
+  "ty>=0.0.11",
+  { include-group = "tests" },
 ]
 tests = [
   "pytest>=9.0.0",
@@ -39,29 +40,8 @@ include = [
 packages = ["src/databricks_dspy"]
 
 [tool.ruff]
-line-length = 100
-target-version = "py310"
-
-[tool.ruff.lint]
-select = [
-  # isort
-  "I",
-  # bugbear rules
-  "B",
-  # remove unused imports
-  "F401",
-  # bare except statements
-  "E722",
-  # print statements
-  "T201",
-  "T203",
-  # misuse of typing.TYPE_CHECKING
-  "TCH004",
-  # import rules
-  "TID251",
-  # undefined-local-with-import-star
-  "F403",
-]
+include = ["pyproject.toml", "src/**/*.py", "tests/**/*.py"]
+extend = "../../pyproject.toml"
 
 [tool.ruff.format]
 docstring-code-format = true
@@ -73,3 +53,9 @@ filterwarnings = [
     "default::Warning:databricks_dspy",
     "default::Warning:tests",
 ]
+
+[tool.ty.environment]
+root = ["./src", "./tests"]
+
+[tool.ty.src]
+include = ["./src", "./tests"]

--- a/integrations/langchain/pyproject.toml
+++ b/integrations/langchain/pyproject.toml
@@ -30,8 +30,9 @@ memory = [
 [dependency-groups]
 dev = [
   "typing_extensions>=4.15.0",
-  "ruff==0.6.4",
-  { include-group = "tests" }
+  "ruff==0.12.10",
+  "ty>=0.0.11",
+  { include-group = "tests" },
 ]
 
 tests = [
@@ -59,36 +60,8 @@ include = [
 packages = ["src/databricks_langchain"]
 
 [tool.ruff]
-line-length = 100
-target-version = "py39"
-
-[tool.ruff.lint]
-select = [
-  # isort
-  "I",
-  # bugbear rules
-  "B",
-  # remove unused imports
-  "F401",
-  # bare except statements
-  "E722",
-  # print statements
-  "T201",
-  "T203",
-  # misuse of typing.TYPE_CHECKING
-  "TCH004",
-  # import rules
-  "TID251",
-  # undefined-local-with-import-star
-  "F403",
-]
-
-[tool.ruff.format]
-docstring-code-format = true
-docstring-code-line-length = 88
-
-[tool.ruff.lint.pydocstyle]
-convention = "google"
+include = ["pyproject.toml", "src/**/*.py", "tests/**/*.py"]
+extend = "../../pyproject.toml"
 
 [tool.pytest.ini_options]
 filterwarnings = [
@@ -96,3 +69,9 @@ filterwarnings = [
     "default::Warning:databricks_langchain",
     "default::Warning:tests",
 ]
+
+[tool.ty.environment]
+root = ["./src", "./tests"]
+
+[tool.ty.src]
+include = ["./src", "./tests"]

--- a/integrations/langchain/src/databricks_langchain/vectorstores.py
+++ b/integrations/langchain/src/databricks_langchain/vectorstores.py
@@ -360,7 +360,7 @@ class DatabricksVectorSearch(VectorStore):
                 self._index_details.embedding_vector_column["name"]: vector,
                 **metadata,
             }
-            for text, vector, id_, metadata in zip(texts, vectors, ids, metadatas)
+            for text, vector, id_, metadata in zip(texts, vectors, ids, metadatas, strict=False)
         ]
 
         upsert_resp = self.index.upsert(updates)

--- a/integrations/langchain/tests/unit_tests/test_chat_models.py
+++ b/integrations/langchain/tests/unit_tests/test_chat_models.py
@@ -191,7 +191,7 @@ def test_chat_model_stream(llm: ChatDatabricks) -> None:
             {"role": "user", "content": "36939 * 8922.4"},
         ]
     )
-    for chunk, expected in zip(res, _MOCK_STREAM_RESPONSE):
+    for chunk, expected in zip(res, _MOCK_STREAM_RESPONSE, strict=False):
         assert chunk.content == expected["choices"][0]["delta"]["content"]  # type: ignore[index]
 
 
@@ -202,7 +202,7 @@ def test_chat_model_stream_custom_outputs(mock_client_delta, llm: ChatDatabricks
             {"role": "user", "content": "36939 * 8922.4", "custom_outputs": {"foo": "bar"}},
         ]
     )
-    for chunk, expected in zip(res, _MOCK_STREAM_DELTA_RESPONSE):
+    for chunk, expected in zip(res, _MOCK_STREAM_DELTA_RESPONSE, strict=False):
         assert chunk.custom_outputs == expected["custom_outputs"]
         assert chunk.content == expected["delta"]["content"]
 
@@ -223,7 +223,7 @@ def test_chat_model_stream_with_usage(llm: ChatDatabricks) -> None:
         ],
         stream_usage=True,
     )
-    for chunk, expected in zip(res, _MOCK_STREAM_RESPONSE):
+    for chunk, expected in zip(res, _MOCK_STREAM_RESPONSE, strict=False):
         assert chunk.content == expected["choices"][0]["delta"]["content"]  # type: ignore[index]
         _assert_usage(chunk, expected)
 
@@ -238,7 +238,7 @@ def test_chat_model_stream_with_usage(llm: ChatDatabricks) -> None:
             {"role": "user", "content": "36939 * 8922.4"},
         ],
     )
-    for chunk, expected in zip(res, _MOCK_STREAM_RESPONSE):
+    for chunk, expected in zip(res, _MOCK_STREAM_RESPONSE, strict=False):
         assert chunk.content == expected["choices"][0]["delta"]["content"]  # type: ignore[index]
         _assert_usage(chunk, expected)
 

--- a/integrations/langchain/tests/unit_tests/test_vectorstores.py
+++ b/integrations/langchain/tests/unit_tests/test_vectorstores.py
@@ -163,7 +163,7 @@ def test_add_texts() -> None:
                 "text": text,
                 "text_vector": vector,
             }
-            for text, vector, id_ in zip(INPUT_TEXTS, vectors, ids)
+            for text, vector, id_ in zip(INPUT_TEXTS, vectors, ids, strict=False)
         ]
     )
     assert len(added_ids) == len(INPUT_TEXTS)
@@ -182,7 +182,7 @@ def test_add_texts_handle_single_text() -> None:
                 "text": text,
                 "text_vector": vector,
             }
-            for text, vector, id_ in zip(INPUT_TEXTS, vectors, added_ids)
+            for text, vector, id_ in zip(INPUT_TEXTS, vectors, added_ids, strict=False)
         ]
     )
     assert len(added_ids) == 1
@@ -201,7 +201,7 @@ def test_add_texts_with_default_id() -> None:
                 "text": text,
                 "text_vector": vector,
             }
-            for text, vector, id_ in zip(INPUT_TEXTS, vectors, added_ids)
+            for text, vector, id_ in zip(INPUT_TEXTS, vectors, added_ids, strict=False)
         ]
     )
     assert len(added_ids) == len(INPUT_TEXTS)
@@ -222,7 +222,9 @@ def test_add_texts_with_metadata() -> None:
                 "text_vector": vector,
                 **metadata,  # type: ignore[arg-type]
             }
-            for text, vector, id_, metadata in zip(INPUT_TEXTS, vectors, added_ids, metadatas)
+            for text, vector, id_, metadata in zip(
+                INPUT_TEXTS, vectors, added_ids, metadatas, strict=False
+            )
         ]
     )
     assert len(added_ids) == len(INPUT_TEXTS)

--- a/integrations/llamaindex/pyproject.toml
+++ b/integrations/llamaindex/pyproject.toml
@@ -19,8 +19,9 @@ dependencies = [
 dev = [
     "typing_extensions>=4.15.0",
     "databricks-sdk>=0.34.0",
-    "ruff==0.6.4",
-    { include-group = "tests" }
+    "ruff==0.12.10",
+    "ty>=0.0.11",
+    { include-group = "tests" },
 ]
 
 tests = [
@@ -44,36 +45,8 @@ include = [
 packages = ["src/databricks_llamaindex"]
 
 [tool.ruff]
-line-length = 100
-target-version = "py39"
-
-[tool.ruff.lint]
-select = [
-    # isort
-    "I",
-    # bugbear rules
-    "B",
-    # remove unused imports
-    "F401",
-    # bare except statements
-    "E722",
-    # print statements
-    "T201",
-    "T203",
-    # misuse of typing.TYPE_CHECKING
-    "TCH004",
-    # import rules
-    "TID251",
-    # undefined-local-with-import-star
-    "F403",
-]
-
-[tool.ruff.format]
-docstring-code-format = true
-docstring-code-line-length = 88
-
-[tool.ruff.lint.pydocstyle]
-convention = "google"
+include = ["pyproject.toml", "src/**/*.py", "tests/**/*.py"]
+extend = "../../pyproject.toml"
 
 [tool.pytest.ini_options]
 filterwarnings = [
@@ -81,3 +54,9 @@ filterwarnings = [
     "default::Warning:databricks_llamaindex",
     "default::Warning:tests",
 ]
+
+[tool.ty.environment]
+root = ["./src", "./tests"]
+
+[tool.ty.src]
+include = ["./src", "./tests"]

--- a/integrations/openai/pyproject.toml
+++ b/integrations/openai/pyproject.toml
@@ -24,8 +24,9 @@ dependencies = [
 dev = [
     "typing_extensions>=4.15.0",
     "databricks-sdk>=0.34.0",
-    "ruff==0.6.4",
-    { include-group = "tests" }
+    "ruff==0.12.10",
+    "ty>=0.0.11",
+    { include-group = "tests" },
 ]
 
 tests = [
@@ -50,36 +51,8 @@ include = [
 packages = ["src/databricks_openai"]
 
 [tool.ruff]
-line-length = 100
-target-version = "py39"
-
-[tool.ruff.lint]
-select = [
-    # isort
-    "I",
-    # bugbear rules
-    "B",
-    # remove unused imports
-    "F401",
-    # bare except statements
-    "E722",
-    # print statements
-    "T201",
-    "T203",
-    # misuse of typing.TYPE_CHECKING
-    "TCH004",
-    # import rules
-    "TID251",
-    # undefined-local-with-import-star
-    "F403",
-]
-
-[tool.ruff.format]
-docstring-code-format = true
-docstring-code-line-length = 88
-
-[tool.ruff.lint.pydocstyle]
-convention = "google"
+include = ["pyproject.toml", "src/**/*.py", "tests/**/*.py"]
+extend = "../../pyproject.toml"
 
 [tool.pytest.ini_options]
 filterwarnings = [
@@ -87,3 +60,9 @@ filterwarnings = [
     "default::Warning:databricks_openai",
     "default::Warning:tests",
 ]
+
+[tool.ty.environment]
+root = ["./src", "./tests"]
+
+[tool.ty.src]
+include = ["./src", "./tests"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ memory = [
 [dependency-groups]
 dev = [
   "hatch>=1.15.1",
+  "ty>=0.0.11",
   { include-group = "tests" },
   { include-group = "lint" },
 ]
@@ -67,6 +68,7 @@ packages = ["src/databricks_ai_bridge"]
 [tool.ruff]
 line-length = 100
 target-version = "py39"
+include = ["pyproject.toml", "src/**/*.py", "tests/**/*.py"]
 
 [tool.ruff.lint]
 select = [
@@ -82,7 +84,7 @@ select = [
   "T201",
   "T203",
   # misuse of typing.TYPE_CHECKING
-  "TCH004",
+  "TC004",
   # import rules
   "TID251",
   # undefined-local-with-import-star
@@ -103,3 +105,9 @@ filterwarnings = [
     "default::Warning:databricks_ai_bridge",
     "default::Warning:tests",
 ]
+
+[tool.ty.environment]
+root = ["./src", "./tests"]
+
+[tool.ty.src]
+include = ["./src", "./tests"]


### PR DESCRIPTION
## Summary

We are not doing typechecking in this repo, and we should. Typechecker helps catching simple errors and it also helps our users to typechecker their code when calling us.

Also refactored how we manage Ruff configuration a bit. Every subproject now inherit ruff configurations from the root `pyproject.toml` and this allows us to only configure once and apply to all the projects.

## Test Plan

```
./for-each-project uv run ty check
```

https://gist.github.com/fanzeyi/203fc3c6ef4f3be185f6f5ba4b9f1eac