### PR TITLE
ai-sdk-provider: add GitHub Actions CI and fix dedupe logic

### DIFF
--- a/.github/workflows/ai-sdk-provider.yml
+++ b/.github/workflows/ai-sdk-provider.yml
@@ -1,0 +1,125 @@
+name: ai-sdk-provider
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "integrations/ai-sdk-provider/**"
+      - ".github/workflows/ai-sdk-provider.yml"
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - ready_for_review
+    paths:
+      - "integrations/ai-sdk-provider/**"
+      - ".github/workflows/ai-sdk-provider.yml"
+  workflow_dispatch:
+
+defaults:
+  run:
+    working-directory: integrations/ai-sdk-provider
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    name: "test (node: ${{ matrix.node-version }})"
+    strategy:
+      matrix:
+        node-version: ["18", "20", "22"]
+    timeout-minutes: 10
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      - name: Install dependencies
+        run: rm -f package-lock.json && npm install
+
+      - name: Run tests
+        run: npm run test
+
+  lint:
+    runs-on: ubuntu-latest
+    name: lint
+    timeout-minutes: 10
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Install dependencies
+        run: rm -f package-lock.json && npm install
+
+      - name: Run linter
+        run: npm run lint
+
+  typecheck:
+    runs-on: ubuntu-latest
+    name: typecheck
+    timeout-minutes: 10
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Install dependencies
+        run: rm -f package-lock.json && npm install
+
+      - name: Run typecheck
+        run: npm run typecheck
+
+  format:
+    runs-on: ubuntu-latest
+    name: format
+    timeout-minutes: 10
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Install dependencies
+        run: rm -f package-lock.json && npm install
+
+      - name: Check formatting
+        run: npm run format:check
+
+  build:
+    runs-on: ubuntu-latest
+    name: build
+    timeout-minutes: 10
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Install dependencies
+        run: rm -f package-lock.json && npm install
+
+      - name: Build package
+        run: npm run build
+
+      - name: Check package exports
+        run: npm run check-package

--- a/integrations/ai-sdk-provider/src/responses-agent-language-model/responses-convert-to-message-parts.ts
+++ b/integrations/ai-sdk-provider/src/responses-agent-language-model/responses-convert-to-message-parts.ts
@@ -1,4 +1,5 @@
 import type { LanguageModelV2Content, LanguageModelV2StreamPart } from '@ai-sdk/provider'
+import { randomUUID } from 'node:crypto'
 import { type ResponsesAgentChunk, type ResponsesAgentResponse } from './responses-agent-schema'
 import { DATABRICKS_TOOL_CALL_ID } from '../tools'
 import {
@@ -65,7 +66,7 @@ export const convertResponsesAgentChunkToMessagePart = (
         type: 'source',
         url: chunk.annotation.url,
         title: chunk.annotation.title,
-        id: crypto.randomUUID(),
+        id: randomUUID(),
         sourceType: 'url',
       })
       break

--- a/integrations/ai-sdk-provider/tsconfig.json
+++ b/integrations/ai-sdk-provider/tsconfig.json
@@ -12,7 +12,7 @@
     "declarationMap": true,
     "sourceMap": true,
     "outDir": "./dist",
-    "lib": ["ES2022"],
+    "lib": ["ES2023"],
     "baseUrl": ".",
     "paths": {
       "@databricks/ai-sdk-provider": ["./src/index.ts"],


### PR DESCRIPTION
I noticed the dedupe logic wasn't always working with KA agents, took a close look at the code and saw the issue. I also added GH workflow to run the tests on every PR

----------------

## Summary

- Add GitHub Actions workflow for ai-sdk-provider with:
  - Tests on Node.js 18, 20, 22
  - Linting, typechecking, and format checking
  - Build verification and package export checks
  - Path filtering to only run on relevant changes

- Fix shouldDedupeOutputItemDone to only consider text-deltas after the last response.output_item.done event, not the entire stream history. This fixes duplicate text appearing when multiple messages are streamed in sequence.

- Add comprehensive unit tests for shouldDedupeOutputItemDone covering edge cases and the new behavior.