### PR TITLE
chore: fix responses agent endpoint version in docs

### DIFF
--- a/integrations/ai-sdk-provider/CHANGELOG.md
+++ b/integrations/ai-sdk-provider/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial release of @databricks/ai-sdk-provider
 - Support for Chat Agent endpoint (`agent/v2/chat`)
-- Support for Responses Agent endpoint (`agent/v2/responses`)
+- Support for Responses Agent endpoint (`agent/v1/responses`)
 - Support for FM API endpoint (`llm/v1/chat`)
 - Stream and non-stream (generate) support for all three endpoint types
 - Custom tool calling mechanism for Databricks agents

--- a/integrations/ai-sdk-provider/README.md
+++ b/integrations/ai-sdk-provider/README.md
@@ -6,7 +6,7 @@ Databricks provider for the [Vercel AI SDK](https://sdk.vercel.ai/docs).
 
 - 🚀 Support for three Databricks endpoint types:
   - **Chat Agent** (`agent/v2/chat`) - Databricks chat agent API
-  - **Responses Agent** (`agent/v2/responses`) - Databricks responses agent API
+  - **Responses Agent** (`agent/v1/responses`) - Databricks responses agent API
   - **FM API** (`llm/v1/chat`) - Foundation model chat completions API
 - 🔄 Stream and non-stream (generate) support for all endpoint types
 - 🛠️ Custom tool calling mechanism for Databricks agents

--- a/integrations/ai-sdk-provider/src/databricks-provider.ts
+++ b/integrations/ai-sdk-provider/src/databricks-provider.ts
@@ -14,7 +14,7 @@ export type DatabricksLanguageModelConfig = {
 export interface DatabricksProvider extends ProviderV2 {
   /** Agents */
   chatAgent(modelId: string): LanguageModelV2 // agent/v2/chat
-  responsesAgent(modelId: string): LanguageModelV2 // agent/v2/responses
+  responsesAgent(modelId: string): LanguageModelV2 // agent/v1/responses
 
   /** FMAPI */
   fmapi(modelId: string): LanguageModelV2 // llm/v1/chat


### PR DESCRIPTION
Change agent/v2/responses to agent/v1/responses in CHANGELOG, README, and code comments to reflect the correct API version.