### PR TITLE
CI: Added Pytest coverage stats reporting in logs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,7 +36,7 @@ jobs:
         run: |
           uv run --resolution ${{ matrix.uv-resolution }} \
             --exact --group tests --extra memory \
-            pytest tests/
+            pytest --cov --cov-report=term tests/
 
   langchain_test:
     runs-on: ubuntu-latest
@@ -59,7 +59,7 @@ jobs:
         working-directory: integrations/langchain
         run: |
           uv run --resolution ${{ matrix.uv-resolution }} \
-            --exact --group tests pytest tests/unit_tests
+            --exact --group tests pytest --cov --cov-report=term tests/unit_tests
 
   lakebase_memory_test:
     runs-on: ubuntu-latest
@@ -157,7 +157,7 @@ jobs:
         working-directory: integrations/openai
         run: |
           uv run --resolution ${{ matrix.uv-resolution }} \
-            --exact --group tests pytest tests/unit_tests
+            --exact --group tests pytest --cov --cov-report=term tests/unit_tests
 
   openai_cross_version_test:
     runs-on: ubuntu-latest
@@ -220,7 +220,7 @@ jobs:
       - name: Run tests
         working-directory: integrations/llamaindex
         run: |
-          uv run --resolution ${{ matrix.uv-resolution }} --exact --group tests pytest tests/unit_tests
+          uv run --resolution ${{ matrix.uv-resolution }} --exact --group tests pytest --cov --cov-report=term tests/unit_tests
 
   mcp_test:
     runs-on: ubuntu-latest
@@ -242,7 +242,7 @@ jobs:
         working-directory: databricks_mcp
         run: |
           uv run --resolution ${{ matrix.uv-resolution }} \
-            --exact --group tests pytest tests/unit_tests
+            --exact --group tests pytest --cov --cov-report=term tests/unit_tests
 
   dspy_test:
     runs-on: ubuntu-latest
@@ -264,4 +264,4 @@ jobs:
         working-directory: integrations/dspy
         run: |
           uv run --resolution ${{ matrix.uv-resolution }} \
-            --exact --group tests pytest tests/unit_tests
+            --exact --group tests pytest --cov --cov-report=term tests/unit_tests

--- a/databricks_mcp/pyproject.toml
+++ b/databricks_mcp/pyproject.toml
@@ -28,6 +28,7 @@ tests = [
   "pytest>=9.0.0",
   "pytest-asyncio>=1.3.0",
   "pytest-timeout>=2.3.1",
+  "pytest-cov>=4.1.0",
 ]
 
 [build-system]
@@ -55,6 +56,13 @@ filterwarnings = [
     "default::Warning:databricks_mcp",
     "default::Warning:tests",
 ]
+
+[tool.coverage.run]
+source = ["databricks_mcp"]
+branch = true
+
+[tool.coverage.report]
+show_missing = true
 
 [tool.ty.environment]
 root = ["./src", "./tests"]

--- a/integrations/dspy/pyproject.toml
+++ b/integrations/dspy/pyproject.toml
@@ -22,6 +22,7 @@ dev = [
 ]
 tests = [
   "pytest>=9.0.0",
+  "pytest-cov>=4.1.0",
 ]
 
 [build-system]
@@ -53,6 +54,13 @@ filterwarnings = [
     "default::Warning:databricks_dspy",
     "default::Warning:tests",
 ]
+
+[tool.coverage.run]
+source = ["databricks_dspy"]
+branch = true
+
+[tool.coverage.report]
+show_missing = true
 
 [tool.ty.environment]
 root = ["./src", "./tests"]

--- a/integrations/langchain/pyproject.toml
+++ b/integrations/langchain/pyproject.toml
@@ -41,6 +41,7 @@ tests = [
   "pytest-timeout>=2.3.1",
   "pytest-asyncio>=1.3.0",
   "anyio>=4.8.0",
+  "pytest-cov>=4.1.0",
 ]
 
 
@@ -69,6 +70,13 @@ filterwarnings = [
     "default::Warning:databricks_langchain",
     "default::Warning:tests",
 ]
+
+[tool.coverage.run]
+source = ["databricks_langchain"]
+branch = true
+
+[tool.coverage.report]
+show_missing = true
 
 [tool.ty.environment]
 root = ["./src", "./tests"]

--- a/integrations/llamaindex/pyproject.toml
+++ b/integrations/llamaindex/pyproject.toml
@@ -27,6 +27,7 @@ dev = [
 tests = [
     "pytest>=9.0.0",
     "pytest-timeout>=2.3.1",
+    "pytest-cov>=4.1.0",
 ]
 
 [build-system]
@@ -54,6 +55,13 @@ filterwarnings = [
     "default::Warning:databricks_llamaindex",
     "default::Warning:tests",
 ]
+
+[tool.coverage.run]
+source = ["databricks_llamaindex"]
+branch = true
+
+[tool.coverage.report]
+show_missing = true
 
 [tool.ty.environment]
 root = ["./src", "./tests"]

--- a/integrations/openai/pyproject.toml
+++ b/integrations/openai/pyproject.toml
@@ -33,6 +33,7 @@ tests = [
     "pytest>=9.0.0",
     "pytest-asyncio>=1.3.0",
     "pytest-timeout>=2.3.1",
+    "pytest-cov>=4.1.0",
 ]
 
 [build-system]
@@ -60,6 +61,13 @@ filterwarnings = [
     "default::Warning:databricks_openai",
     "default::Warning:tests",
 ]
+
+[tool.coverage.run]
+source = ["databricks_openai"]
+branch = true
+
+[tool.coverage.report]
+show_missing = true
 
 [tool.ty.environment]
 root = ["./src", "./tests"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ tests = [
   "mlflow>=3.0.0",
   "pytest>=9.0.0",
   "pytest-asyncio>=1.3.0",
+  "pytest-cov>=4.1.0",
 ]
 doc = [
   "docutils>=0.21.2",
@@ -105,6 +106,13 @@ filterwarnings = [
     "default::Warning:databricks_ai_bridge",
     "default::Warning:tests",
 ]
+
+[tool.coverage.run]
+source = ["databricks_ai_bridge"]
+branch = true
+
+[tool.coverage.report]
+show_missing = true
 
 [tool.ty.environment]
 root = ["./src", "./tests"]


### PR DESCRIPTION
## Summary
- Added pytest-cov to all packages for measuring unit test coverage
- CI now reports coverage statistics in the logs for each test job
- Coverage configuration added to each package's pyproject.toml

## Test plan
- [x] Verified locally that all tests pass with coverage reporting
- [x] Coverage reports show in terminal output