### PR TITLE
CD: allow start workflow from different refs

### DIFF
--- a/.github/workflows/generate_release_workflows.py
+++ b/.github/workflows/generate_release_workflows.py
@@ -84,13 +84,28 @@ jobs:
       - name: Verify version matches tag
         id: verify-version
         run: |
-          TAG_VERSION=${{GITHUB_REF#refs/tags/{pkg.name}-v}}
+          # Get package version from pyproject.toml
           PKG_VERSION=$(python -c "import tomllib; print(tomllib.load(open('pyproject.toml', 'rb'))['project']['version'])")
           echo "version=$PKG_VERSION" >> $GITHUB_OUTPUT
-          if [ "$TAG_VERSION" != "$PKG_VERSION" ]; then
-            echo "Tag version ($TAG_VERSION) does not match package version ($PKG_VERSION)"
+
+          # Construct the expected tag name
+          TAG_NAME="{pkg.name}-v$PKG_VERSION"
+
+          # Check if the tag exists on GitHub and points to the current commit
+          CURRENT_COMMIT=$(git rev-parse HEAD)
+          TAG_COMMIT=$(git ls-remote --tags origin "refs/tags/$TAG_NAME" | cut -f1)
+
+          if [ -z "$TAG_COMMIT" ]; then
+            echo "Tag $TAG_NAME does not exist on GitHub"
             exit 1
           fi
+
+          if [ "$CURRENT_COMMIT" != "$TAG_COMMIT" ]; then
+            echo "Tag $TAG_NAME exists but points to commit $TAG_COMMIT, not current commit $CURRENT_COMMIT"
+            exit 1
+          fi
+
+          echo "Verified: Tag $TAG_NAME exists and points to current commit $CURRENT_COMMIT"
 
       - name: Build package
         run: python -m build

--- a/.github/workflows/release-databricks-ai-bridge.yml
+++ b/.github/workflows/release-databricks-ai-bridge.yml
@@ -40,13 +40,28 @@ jobs:
       - name: Verify version matches tag
         id: verify-version
         run: |
-          TAG_VERSION=${GITHUB_REF#refs/tags/databricks-ai-bridge-v}
+          # Get package version from pyproject.toml
           PKG_VERSION=$(python -c "import tomllib; print(tomllib.load(open('pyproject.toml', 'rb'))['project']['version'])")
           echo "version=$PKG_VERSION" >> $GITHUB_OUTPUT
-          if [ "$TAG_VERSION" != "$PKG_VERSION" ]; then
-            echo "Tag version ($TAG_VERSION) does not match package version ($PKG_VERSION)"
+
+          # Construct the expected tag name
+          TAG_NAME="databricks-ai-bridge-v$PKG_VERSION"
+
+          # Check if the tag exists on GitHub and points to the current commit
+          CURRENT_COMMIT=$(git rev-parse HEAD)
+          TAG_COMMIT=$(git ls-remote --tags origin "refs/tags/$TAG_NAME" | cut -f1)
+
+          if [ -z "$TAG_COMMIT" ]; then
+            echo "Tag $TAG_NAME does not exist on GitHub"
             exit 1
           fi
+
+          if [ "$CURRENT_COMMIT" != "$TAG_COMMIT" ]; then
+            echo "Tag $TAG_NAME exists but points to commit $TAG_COMMIT, not current commit $CURRENT_COMMIT"
+            exit 1
+          fi
+
+          echo "Verified: Tag $TAG_NAME exists and points to current commit $CURRENT_COMMIT"
 
       - name: Build package
         run: python -m build

--- a/.github/workflows/release-databricks-langchain.yml
+++ b/.github/workflows/release-databricks-langchain.yml
@@ -43,13 +43,28 @@ jobs:
       - name: Verify version matches tag
         id: verify-version
         run: |
-          TAG_VERSION=${GITHUB_REF#refs/tags/databricks-langchain-v}
+          # Get package version from pyproject.toml
           PKG_VERSION=$(python -c "import tomllib; print(tomllib.load(open('pyproject.toml', 'rb'))['project']['version'])")
           echo "version=$PKG_VERSION" >> $GITHUB_OUTPUT
-          if [ "$TAG_VERSION" != "$PKG_VERSION" ]; then
-            echo "Tag version ($TAG_VERSION) does not match package version ($PKG_VERSION)"
+
+          # Construct the expected tag name
+          TAG_NAME="databricks-langchain-v$PKG_VERSION"
+
+          # Check if the tag exists on GitHub and points to the current commit
+          CURRENT_COMMIT=$(git rev-parse HEAD)
+          TAG_COMMIT=$(git ls-remote --tags origin "refs/tags/$TAG_NAME" | cut -f1)
+
+          if [ -z "$TAG_COMMIT" ]; then
+            echo "Tag $TAG_NAME does not exist on GitHub"
             exit 1
           fi
+
+          if [ "$CURRENT_COMMIT" != "$TAG_COMMIT" ]; then
+            echo "Tag $TAG_NAME exists but points to commit $TAG_COMMIT, not current commit $CURRENT_COMMIT"
+            exit 1
+          fi
+
+          echo "Verified: Tag $TAG_NAME exists and points to current commit $CURRENT_COMMIT"
 
       - name: Build package
         run: python -m build

--- a/.github/workflows/release-databricks-mcp.yml
+++ b/.github/workflows/release-databricks-mcp.yml
@@ -43,13 +43,28 @@ jobs:
       - name: Verify version matches tag
         id: verify-version
         run: |
-          TAG_VERSION=${GITHUB_REF#refs/tags/databricks-mcp-v}
+          # Get package version from pyproject.toml
           PKG_VERSION=$(python -c "import tomllib; print(tomllib.load(open('pyproject.toml', 'rb'))['project']['version'])")
           echo "version=$PKG_VERSION" >> $GITHUB_OUTPUT
-          if [ "$TAG_VERSION" != "$PKG_VERSION" ]; then
-            echo "Tag version ($TAG_VERSION) does not match package version ($PKG_VERSION)"
+
+          # Construct the expected tag name
+          TAG_NAME="databricks-mcp-v$PKG_VERSION"
+
+          # Check if the tag exists on GitHub and points to the current commit
+          CURRENT_COMMIT=$(git rev-parse HEAD)
+          TAG_COMMIT=$(git ls-remote --tags origin "refs/tags/$TAG_NAME" | cut -f1)
+
+          if [ -z "$TAG_COMMIT" ]; then
+            echo "Tag $TAG_NAME does not exist on GitHub"
             exit 1
           fi
+
+          if [ "$CURRENT_COMMIT" != "$TAG_COMMIT" ]; then
+            echo "Tag $TAG_NAME exists but points to commit $TAG_COMMIT, not current commit $CURRENT_COMMIT"
+            exit 1
+          fi
+
+          echo "Verified: Tag $TAG_NAME exists and points to current commit $CURRENT_COMMIT"
 
       - name: Build package
         run: python -m build

--- a/.github/workflows/release-databricks-openai.yml
+++ b/.github/workflows/release-databricks-openai.yml
@@ -43,13 +43,28 @@ jobs:
       - name: Verify version matches tag
         id: verify-version
         run: |
-          TAG_VERSION=${GITHUB_REF#refs/tags/databricks-openai-v}
+          # Get package version from pyproject.toml
           PKG_VERSION=$(python -c "import tomllib; print(tomllib.load(open('pyproject.toml', 'rb'))['project']['version'])")
           echo "version=$PKG_VERSION" >> $GITHUB_OUTPUT
-          if [ "$TAG_VERSION" != "$PKG_VERSION" ]; then
-            echo "Tag version ($TAG_VERSION) does not match package version ($PKG_VERSION)"
+
+          # Construct the expected tag name
+          TAG_NAME="databricks-openai-v$PKG_VERSION"
+
+          # Check if the tag exists on GitHub and points to the current commit
+          CURRENT_COMMIT=$(git rev-parse HEAD)
+          TAG_COMMIT=$(git ls-remote --tags origin "refs/tags/$TAG_NAME" | cut -f1)
+
+          if [ -z "$TAG_COMMIT" ]; then
+            echo "Tag $TAG_NAME does not exist on GitHub"
             exit 1
           fi
+
+          if [ "$CURRENT_COMMIT" != "$TAG_COMMIT" ]; then
+            echo "Tag $TAG_NAME exists but points to commit $TAG_COMMIT, not current commit $CURRENT_COMMIT"
+            exit 1
+          fi
+
+          echo "Verified: Tag $TAG_NAME exists and points to current commit $CURRENT_COMMIT"
 
       - name: Build package
         run: python -m build


### PR DESCRIPTION

This should relax the requirement of having to pick the right ref to run the workflow from. The goal was to just make sure we are releasing on the right commit. Running on the correct ref or not shouldn't matter.

Test run: https://github.com/fanzeyi/databricks-ai-bridge/actions/runs/21885566262/job/63179429546

```
Run # Get package version from pyproject.toml
  # Get package version from pyproject.toml
  PKG_VERSION=$(python -c "import tomllib; print(tomllib.load(open('pyproject.toml', 'rb'))['project']['version'])")
  echo "version=$PKG_VERSION" >> $GITHUB_OUTPUT
  
  # Construct the expected tag name
  TAG_NAME="databricks-ai-bridge-v$PKG_VERSION"
  
  # Check if the tag exists on GitHub and points to the current commit
  CURRENT_COMMIT=$(git rev-parse HEAD)
  TAG_COMMIT=$(git ls-remote --tags origin "refs/tags/$TAG_NAME" | cut -f1)
  
  if [ -z "$TAG_COMMIT" ]; then
    echo "Tag $TAG_NAME does not exist on GitHub"
    exit 1
  fi
  
  if [ "$CURRENT_COMMIT" != "$TAG_COMMIT" ]; then
    echo "Tag $TAG_NAME exists but points to commit $TAG_COMMIT, not current commit $CURRENT_COMMIT"
    exit 1
  fi
  
  echo "Verified: Tag $TAG_NAME exists and points to current commit $CURRENT_COMMIT"
  shell: /usr/bin/bash -e {0}
  env:
    pythonLocation: /opt/hostedtoolcache/Python/3.12.12/x64
    PKG_CONFIG_PATH: /opt/hostedtoolcache/Python/3.12.12/x64/lib/pkgconfig
    Python_ROOT_DIR: /opt/hostedtoolcache/Python/3.12.12/x64
    Python2_ROOT_DIR: /opt/hostedtoolcache/Python/3.12.12/x64
    Python3_ROOT_DIR: /opt/hostedtoolcache/Python/3.12.12/x64
    LD_LIBRARY_PATH: /opt/hostedtoolcache/Python/3.12.12/x64/lib
Verified: Tag databricks-ai-bridge-v0.14.0 exists and points to current commit c0b3319c7918d550430770b9fc2f26324e0a6c05
```