### PR TITLE
Generic Python Lakebase Checkpointing

### DIFF
--- a/src/databricks_ai_bridge/lakebase_checkpointer.py
+++ b/src/databricks_ai_bridge/lakebase_checkpointer.py
@@ -1,4 +1,4 @@
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 from datetime import datetime
 from .lakebase import LakebaseClient
 from typing import Tuple
@@ -8,12 +8,26 @@ from typing import Any, Union, Tuple
 from uuid import uuid4
 
 class GenericCheckpoint(BaseModel):
-    # Define the fields for your checkpoint
-    id : str = str(uuid4())
+    ####################
+    # CHECKPOINT COLUMNS
+    ####################
+    id : str = Field(default_factory = lambda: str(uuid4())) # `id` column must exist for locating the checkpoint, even in subclasses.
     state : dict = {}
-    creation_timestamp : datetime = datetime.now()
-    update_timestamp : datetime = datetime.now()
-    # Implement abstract methods
+    creation_timestamp : datetime = Field(default_factory=datetime.now)
+    update_timestamp : datetime = Field(default_factory=datetime.now)
+    ####################
+    # UPDATE ATTRIBUTES
+    ####################
+    def update(self, **kwargs):
+        for k,v in kwargs.items():
+            # Check attribute exists
+            assert hasattr(self, k), f"Attribute {k} does not exist in {self.__class__.__name__}"
+            setattr(self, k, v)
+        self.update_timestamp = datetime.now()
+    #################################
+    # SQL GENERATION IMPLEMENTATIONS
+    #################################
+    # If subclassing the `GenericCheckpoint` class, implement new methods to handle any changes in attributes.
     def generate_insert_sql(self, table_name : str) -> Tuple[str, tuple]:
         sql = f"""
             INSERT INTO {table_name}
@@ -44,12 +58,18 @@ class GenericCheckpoint(BaseModel):
         return sql, None
     
     def generate_retrieve_checkpoint_sql(self, table_name : str) -> Tuple[str, tuple]:
+        sql_all, params = self.generate_retrieval_all_checkpoints_sql(table_name = table_name)
+        sql = f"""
+            {sql_all} LIMIT 1
+        """
+        return sql, params
+    
+    def generate_retrieval_all_checkpoints_sql(self, table_name : str) -> Tuple[str, tuple]:
         sql = f"""
             SELECT id, state, creation_timestamp, update_timestamp
             FROM {table_name}
             WHERE id = %s
             ORDER BY update_timestamp DESC
-            LIMIT 1
         """
         return sql, (self.id,)
 
@@ -72,10 +92,16 @@ class LakebaseCheckpointer:
         _checkpoint = self.checkpoint_class(id = id)
         # Get the most recently updated checkpoint for this id
         sql, params = _checkpoint.generate_retrieve_checkpoint_sql(table_name = self.table_name)
-        response = self.client.execute(sql=sql, params = params)[0]
-        if response:
-            response = self.checkpoint_class(**response)
-        return response
+        response = self.client.execute(sql=sql, params = params)
+        if len(response) == 0:
+            return None
+        return self.checkpoint_class(**response[0])
+    
+    def get_all_checkpoints(self, id : str) -> list[GenericCheckpoint]:
+        _checkpoint = self.checkpoint_class(id = id)
+        sql, params = _checkpoint.generate_retrieval_all_checkpoints_sql(table_name = self.table_name)
+        response = self.client.execute(sql=sql, params = params)
+        return [self.checkpoint_class(**_resp) for _resp in response]
 
     def checkpoint_exists(self, id : str) -> bool:
         sql = f"""
@@ -87,31 +113,29 @@ class LakebaseCheckpointer:
         count = response[0]["count"]
         return True if count > 0 else False
     
-    def update_checkpoint(self, id : str, state : dict) -> None:
+    def update_most_recent_checkpoint(self, id : str, **checkpoint_kwargs) -> None:
         # Get the most recent checkpoint
         _checkpoint = self.get_most_recent_checkpoint(id = id)
-        # Set the new state value locally
-        _checkpoint.state = state
-        _checkpoint.update_timestamp = datetime.now()
+        _checkpoint.update(**checkpoint_kwargs)
         sql, params = _checkpoint.generate_update_sql(table_name = self.table_name)
         self.client.execute(sql = sql, params = params)
         return
 
-    def insert_checkpoint(self, id : str, state : dict) -> None:
+    def insert_checkpoint(self, id : str, **checkpoint_kwargs) -> None:
         _checkpoint = self.checkpoint_class(
-            id = id, state = state, creation_timestamp = datetime.now(), update_timestamp = datetime.now()
+            id = id, **checkpoint_kwargs
         )
         sql, params = _checkpoint.generate_insert_sql(table_name = self.table_name)
         response = self.client.execute(sql=sql, params=params)
         return
 
-    def save_checkpoint(self, id : str, state : dict, overwrite : bool = False) -> None:
+    def save_checkpoint(self, id : str, overwrite : bool = False, **checkpoint_kwargs) -> None:
         if overwrite:
             checkpoint_exists = self.checkpoint_exists(id = id)
             if checkpoint_exists:
-                self.update_checkpoint(id = id, state = state)
+                self.update_checkpoint(id = id, **checkpoint_kwargs)
             else:
-                self.insert_checkpoint(id = id, state = state)
+                self.insert_checkpoint(id = id, **checkpoint_kwargs)
         else:
-            # Don't overwrite existing checkpoints, so just insert a new one
-            self.insert_checkpoint(id = id, state = state)
+            # Don't overwrite the most recent checkpoint, so just insert a new one
+            self.insert_checkpoint(id = id, **checkpoint_kwargs)


### PR DESCRIPTION
# What
Added classes and functions to handle generic agent checkpointing with lakebase instances.

# Why
Existing checkpoint implementations depend on langchain / langgraph

# What Changed
Added `lakebase_checkpointer.py` file which contains two key classes:
- `GenericCheckpoint` - class that defines the checkpoints schema. Can be subclassed to change checkpoint schema.
- `Lakebase_Checkpointer` - accepts a `LakebaseClient` and the checkpoint class as input. Implements helper functions for interacting with `LakebaseClient` with the checkpoint class (saves, inserts, updates, get).