### PR TITLE
Add MCP Integration Tests

### DIFF
--- a/databricks_mcp/tests/integration_tests/conftest.py
+++ b/databricks_mcp/tests/integration_tests/conftest.py
@@ -5,7 +5,7 @@ These tests require a live Databricks workspace with a pre-created UC function.
 They are NOT run by default — set RUN_MCP_INTEGRATION_TESTS=1 to enable.
 
 Prerequisites:
-    Run setup_workspace.py once to create the test UC function.
+    The test UC function must exist in the workspace.
 
 Environment Variables:
 ======================
@@ -21,20 +21,35 @@ from __future__ import annotations
 import os
 
 import pytest
+from mcp.shared.exceptions import McpError
 
 from databricks_mcp import DatabricksMCPClient
 
-# =============================================================================
-# Env var gate — skip entire module if not enabled
-# =============================================================================
 
-pytestmark = pytest.mark.skipif(
-    os.environ.get("RUN_MCP_INTEGRATION_TESTS") != "1",
-    reason="MCP integration tests disabled. Set RUN_MCP_INTEGRATION_TESTS=1 to enable.",
-)
+def _find_mcp_error(exc_group: ExceptionGroup) -> McpError | None:  # ty: ignore[unresolved-reference]
+    """Recursively unwrap nested ExceptionGroups to find a McpError."""
+    for exc in exc_group.exceptions:
+        if isinstance(exc, McpError):
+            return exc
+        if isinstance(exc, ExceptionGroup):  # ty: ignore[unresolved-reference]
+            found = _find_mcp_error(exc)
+            if found:
+                return found
+    return None
+
+
+def _skip_if_not_found(exc_group: ExceptionGroup, context: str) -> None:  # ty: ignore[unresolved-reference]
+    """Skip the test if the McpError indicates a missing resource, otherwise re-raise."""
+    mcp_error = _find_mcp_error(exc_group)
+    if mcp_error:
+        msg = str(mcp_error)
+        if "NOT_FOUND" in msg or "not found" in msg.lower():
+            pytest.skip(f"{context}: {mcp_error}")
+    raise exc_group
+
 
 # =============================================================================
-# Constants (must match setup_workspace.py)
+# Constants
 # =============================================================================
 
 CATALOG = "integration_testing"
@@ -97,11 +112,9 @@ def cached_tools_list(mcp_client):
     """
     try:
         tools = mcp_client.list_tools()
-    except Exception as e:
-        pytest.skip(
-            f"Could not list tools from MCP server — is the test function set up? "
-            f"Run setup_workspace.py first. Error: {e}"
-        )
+    except ExceptionGroup as e:  # ty: ignore[unresolved-reference]
+        _skip_if_not_found(e, "UC function not found in workspace")
+    assert tools, "list_tools() returned no tools — is the test function set up?"
     return tools
 
 
@@ -151,9 +164,11 @@ def vs_schema_mcp_client(vs_schema_mcp_url, workspace_client):
 def cached_vs_tools_list(vs_mcp_client):
     """Cache the VS list_tools() result; skip if VS MCP endpoint unavailable."""
     try:
-        return vs_mcp_client.list_tools()
-    except Exception as e:
-        pytest.skip(f"VS MCP endpoint not available: {e}")
+        tools = vs_mcp_client.list_tools()
+    except ExceptionGroup as e:  # ty: ignore[unresolved-reference]
+        _skip_if_not_found(e, "VS MCP endpoint not available in workspace")
+    assert tools, "VS list_tools() returned no tools — is the VS index set up?"
+    return tools
 
 
 @pytest.fixture(scope="session")
@@ -196,9 +211,11 @@ def genie_mcp_client(genie_mcp_url, workspace_client):
 def cached_genie_tools_list(genie_mcp_client):
     """Cache the Genie list_tools() result; skip if Genie MCP endpoint unavailable."""
     try:
-        return genie_mcp_client.list_tools()
-    except Exception as e:
-        pytest.skip(f"Genie MCP endpoint not available: {e}")
+        tools = genie_mcp_client.list_tools()
+    except ExceptionGroup as e:  # ty: ignore[unresolved-reference]
+        _skip_if_not_found(e, "Genie MCP endpoint not available in workspace")
+    assert tools, "Genie list_tools() returned no tools — is the Genie space set up?"
+    return tools
 
 
 @pytest.fixture(scope="session")

--- a/databricks_mcp/tests/integration_tests/test_mcp_core.py
+++ b/databricks_mcp/tests/integration_tests/test_mcp_core.py
@@ -10,6 +10,8 @@ from __future__ import annotations
 import os
 
 import pytest
+from conftest import _skip_if_not_found
+from mcp.shared.exceptions import McpError
 from mcp.types import CallToolResult
 
 from databricks_mcp import DatabricksMCPClient
@@ -49,8 +51,8 @@ class TestMCPClientUCFunctions:
         """Schema-level URL should list at least the echo_message function."""
         try:
             tools = schema_mcp_client.list_tools()
-        except Exception as e:
-            pytest.skip(f"Schema-level list_tools failed: {e}")
+        except ExceptionGroup as e:  # ty: ignore[unresolved-reference]
+            _skip_if_not_found(e, "Schema-level UC endpoint not available")
         assert len(tools) >= 1, "Schema-level listing should return at least one tool"
 
     def test_call_tool_echoes_input(self, cached_call_result):
@@ -97,8 +99,8 @@ class TestMCPClientVectorSearch:
         """Schema-level VS URL should list at least one tool."""
         try:
             tools = vs_schema_mcp_client.list_tools()
-        except Exception as e:
-            pytest.skip(f"VS schema-level list_tools failed: {e}")
+        except ExceptionGroup as e:  # ty: ignore[unresolved-reference]
+            _skip_if_not_found(e, "Schema-level VS endpoint not available")
         assert len(tools) >= 1, "Schema-level VS listing should return at least one tool"
 
 
@@ -122,6 +124,86 @@ class TestMCPClientGenie:
         assert isinstance(cached_genie_call_result, CallToolResult)
         assert cached_genie_call_result.content, "call_tool result should have content"
         assert len(cached_genie_call_result.content) > 0
+
+
+# =============================================================================
+# Error paths
+# =============================================================================
+
+
+@pytest.mark.integration
+class TestMCPClientErrorPaths:
+    """Verify DatabricksMCPClient returns helpful errors for invalid inputs.
+
+    Tests the 3-layer customer journey: bad function → bad tool → bad arguments.
+    Each test constructs its own client inline (no shared fixtures).
+    """
+
+    def test_nonexistent_function_raises_error(self, workspace_client):
+        """list_tools() on a nonexistent function raises McpError(BAD_REQUEST: ... not found)."""
+        host = workspace_client.config.host
+        bad_url = f"{host}/api/2.0/mcp/functions/{CATALOG}/{SCHEMA}/nonexistent_fn_xyz"
+        client = DatabricksMCPClient(bad_url, workspace_client)
+
+        with pytest.raises(ExceptionGroup) as exc_info:  # ty: ignore[unresolved-reference]
+            client.list_tools()
+
+        # McpError is nested inside ExceptionGroup(s) from asyncio.run + TaskGroup
+        mcp_errors = exc_info.value.exceptions
+        while mcp_errors and isinstance(mcp_errors[0], ExceptionGroup):  # ty: ignore[unresolved-reference]
+            mcp_errors = mcp_errors[0].exceptions
+        assert len(mcp_errors) == 1 and isinstance(mcp_errors[0], McpError), (
+            f"Expected McpError, got: {mcp_errors}"
+        )
+        assert "BAD_REQUEST" in str(mcp_errors[0]), f"Expected BAD_REQUEST, got: {mcp_errors[0]}"
+        assert "not found" in str(mcp_errors[0]).lower(), (
+            f"Expected 'not found', got: {mcp_errors[0]}"
+        )
+
+    def test_nonexistent_tool_name_raises_error(self, workspace_client):
+        """call_tool() with a malformed tool name raises McpError(BAD_REQUEST: ... malformed)."""
+        host = workspace_client.config.host
+        url = f"{host}/api/2.0/mcp/functions/{CATALOG}/{SCHEMA}/{FUNCTION_NAME}"
+        client = DatabricksMCPClient(url, workspace_client)
+
+        with pytest.raises(ExceptionGroup) as exc_info:  # ty: ignore[unresolved-reference]
+            client.call_tool("nonexistent_tool_xyz", {"message": "test"})
+
+        mcp_errors = exc_info.value.exceptions
+        while mcp_errors and isinstance(mcp_errors[0], ExceptionGroup):  # ty: ignore[unresolved-reference]
+            mcp_errors = mcp_errors[0].exceptions
+        assert len(mcp_errors) == 1 and isinstance(mcp_errors[0], McpError), (
+            f"Expected McpError, got: {mcp_errors}"
+        )
+        assert "BAD_REQUEST" in str(mcp_errors[0]), f"Expected BAD_REQUEST, got: {mcp_errors[0]}"
+        assert "malformed" in str(mcp_errors[0]).lower(), (
+            f"Expected 'malformed', got: {mcp_errors[0]}"
+        )
+
+    def test_wrong_arguments_raises_error(self, workspace_client):
+        """call_tool() with wrong arguments raises McpError(BAD_REQUEST: Missing parameter)."""
+        host = workspace_client.config.host
+        url = f"{host}/api/2.0/mcp/functions/{CATALOG}/{SCHEMA}/{FUNCTION_NAME}"
+        client = DatabricksMCPClient(url, workspace_client)
+
+        tools = client.list_tools()
+        assert len(tools) > 0
+        tool_name = tools[0].name
+
+        # echo_message expects "message", we pass "completely_wrong_arg"
+        with pytest.raises(ExceptionGroup) as exc_info:  # ty: ignore[unresolved-reference]
+            client.call_tool(tool_name, {"completely_wrong_arg": "test"})
+
+        mcp_errors = exc_info.value.exceptions
+        while mcp_errors and isinstance(mcp_errors[0], ExceptionGroup):  # ty: ignore[unresolved-reference]
+            mcp_errors = mcp_errors[0].exceptions
+        assert len(mcp_errors) == 1 and isinstance(mcp_errors[0], McpError), (
+            f"Expected McpError, got: {mcp_errors}"
+        )
+        assert "BAD_REQUEST" in str(mcp_errors[0]), f"Expected BAD_REQUEST, got: {mcp_errors[0]}"
+        assert "missing parameter value" in str(mcp_errors[0]).lower(), (
+            f"Expected 'Missing parameter value', got: {mcp_errors[0]}"
+        )
 
 
 # =============================================================================

--- a/integrations/langchain/src/databricks_langchain/chat_models.py
+++ b/integrations/langchain/src/databricks_langchain/chat_models.py
@@ -471,21 +471,21 @@ class ChatDatabricks(BaseChatModel):
 
         for item in response.output:
             if item.type == "message":
-                if item.content is not None:  # ty:ignore
-                    for content in item.content:  # ty:ignore
+                if item.content is not None:  # ty:ignore[unresolved-attribute]: astral-sh/ty#1479 should fix this
+                    for content in item.content:  # ty:ignore[unresolved-attribute]: astral-sh/ty#1479 should fix this
                         if content.type == "output_text":
                             annotations = []
-                            if content.annotations:  # ty:ignore
+                            if content.annotations:  # ty:ignore[unresolved-attribute]: astral-sh/ty#1479 should fix this
                                 # Convert annotation objects to dictionaries
                                 annotations = [
                                     ann.model_dump() if hasattr(ann, "model_dump") else ann
-                                    for ann in content.annotations  # ty:ignore
+                                    for ann in content.annotations  # ty:ignore[unresolved-attribute]: astral-sh/ty#1479 should fix this
                                 ]
 
                             content_blocks.append(
                                 {
                                     "type": "text",
-                                    "text": content.text,  # ty:ignore
+                                    "text": content.text,  # ty:ignore[unresolved-attribute]: astral-sh/ty#1479 should fix this
                                     "annotations": annotations,
                                     "id": getattr(content, "id", None),
                                 }
@@ -494,7 +494,7 @@ class ChatDatabricks(BaseChatModel):
                             content_blocks.append(
                                 {
                                     "type": "refusal",
-                                    "refusal": content.refusal,  # ty:ignore
+                                    "refusal": content.refusal,  # ty:ignore[unresolved-attribute]: astral-sh/ty#1479 should fix this
                                     "id": getattr(content, "id", None),
                                 }
                             )
@@ -502,34 +502,34 @@ class ChatDatabricks(BaseChatModel):
                 # Convert to dict for content_blocks to maintain backward compatibility
                 item_dict = {
                     "type": "function_call",
-                    "name": item.name,  # ty:ignore
-                    "arguments": item.arguments,  # ty:ignore
-                    "call_id": item.call_id,  # ty:ignore
+                    "name": item.name,  # ty:ignore[unresolved-attribute]: astral-sh/ty#1479 should fix this
+                    "arguments": item.arguments,  # ty:ignore[unresolved-attribute]: astral-sh/ty#1479 should fix this
+                    "call_id": item.call_id,  # ty:ignore[unresolved-attribute]: astral-sh/ty#1479 should fix this
                 }
                 content_blocks.append(item_dict)
 
                 try:
-                    args = json.loads(item.arguments, strict=False)  # ty:ignore
+                    args = json.loads(item.arguments, strict=False)  # ty:ignore[unresolved-attribute]: astral-sh/ty#1479 should fix this
                     error = None
                 except json.JSONDecodeError as e:
                     error = str(e)
-                    args = item.arguments  # ty:ignore
+                    args = item.arguments  # ty:ignore[unresolved-attribute]: astral-sh/ty#1479 should fix this
                 if error is None:
                     tool_calls.append(
                         {
                             "type": "tool_call",
-                            "name": item.name,  # ty:ignore
+                            "name": item.name,  # ty:ignore[unresolved-attribute]: astral-sh/ty#1479 should fix this
                             "args": args,
-                            "id": item.call_id,  # ty:ignore
+                            "id": item.call_id,  # ty:ignore[unresolved-attribute]: astral-sh/ty#1479 should fix this
                         }
                     )
                 else:
                     invalid_tool_calls.append(
                         {
                             "type": "invalid_tool_call",
-                            "name": item.name,  # ty:ignore
+                            "name": item.name,  # ty:ignore[unresolved-attribute]: astral-sh/ty#1479 should fix this
                             "args": args,
-                            "id": item.call_id,  # ty:ignore
+                            "id": item.call_id,  # ty:ignore[unresolved-attribute]: astral-sh/ty#1479 should fix this
                             "error": error,
                         }
                     )
@@ -1660,23 +1660,23 @@ def _convert_responses_api_chunk_to_lc_chunk(
         content.append(
             {
                 "type": "text",
-                "text": chunk.delta,  # ty:ignore
+                "text": chunk.delta,  # ty:ignore[unresolved-attribute]: astral-sh/ty#1479 should fix this
             }
         )
     elif chunk.type == "response.output_item.done":
-        item = chunk.item  # ty:ignore
+        item = chunk.item  # ty:ignore[unresolved-attribute]: astral-sh/ty#1479 should fix this
         if item.type == "function_call_output":
             lc_chunk = ToolMessageChunk(
                 content=item.output,
                 tool_call_id=item.call_id,
             )
         elif item.type == "function_call":
-            id = item.call_id  # ty:ignore
+            id = item.call_id  # ty:ignore[unresolved-attribute]: astral-sh/ty#1479 should fix this
             tool_call_chunks.append(
                 tool_call_chunk(
-                    name=item.name,  # ty:ignore
-                    args=item.arguments,  # ty:ignore
-                    id=item.call_id,  # ty:ignore
+                    name=item.name,  # ty:ignore[unresolved-attribute]: astral-sh/ty#1479 should fix this
+                    args=item.arguments,  # ty:ignore[unresolved-attribute]: astral-sh/ty#1479 should fix this
+                    id=item.call_id,  # ty:ignore[unresolved-attribute]: astral-sh/ty#1479 should fix this
                 )
             )
         elif item.type == "message":
@@ -1687,30 +1687,30 @@ def _convert_responses_api_chunk_to_lc_chunk(
             skip_duplicate_text = (
                 previous_chunk and prev_type == "response.output_text.delta" and id == prev_item_id
             )
-            if item.content is not None:  # ty:ignore
-                for content_item in item.content:  # ty:ignore
+            if item.content is not None:  # ty:ignore[unresolved-attribute]: astral-sh/ty#1479 should fix this
+                for content_item in item.content:  # ty:ignore[unresolved-attribute]: astral-sh/ty#1479 should fix this
                     if content_item.type == "output_text":
                         if skip_duplicate_text:
-                            if content_item.annotations:  # ty:ignore
+                            if content_item.annotations:  # ty:ignore[unresolved-attribute]: astral-sh/ty#1479 should fix this
                                 # Convert annotation objects to dictionaries
                                 annotations = [
                                     ann.model_dump() if hasattr(ann, "model_dump") else ann
-                                    for ann in content_item.annotations  # ty:ignore
+                                    for ann in content_item.annotations  # ty:ignore[unresolved-attribute]: astral-sh/ty#1479 should fix this
                                 ]
                                 content.append({"annotations": annotations})
                         else:
                             annotations = []
-                            if content_item.annotations:  # ty:ignore
+                            if content_item.annotations:  # ty:ignore[unresolved-attribute]: astral-sh/ty#1479 should fix this
                                 # Convert annotation objects to dictionaries
                                 annotations = [
                                     ann.model_dump() if hasattr(ann, "model_dump") else ann
-                                    for ann in content_item.annotations  # ty:ignore
+                                    for ann in content_item.annotations  # ty:ignore[unresolved-attribute]: astral-sh/ty#1479 should fix this
                                 ]
 
                             content.append(
                                 {
                                     "type": "text",
-                                    "text": content_item.text,  # ty:ignore
+                                    "text": content_item.text,  # ty:ignore[unresolved-attribute]: astral-sh/ty#1479 should fix this
                                     "annotations": annotations,
                                 }
                             )
@@ -1718,7 +1718,7 @@ def _convert_responses_api_chunk_to_lc_chunk(
                         content.append(
                             {
                                 "type": "refusal",
-                                "refusal": content_item.refusal,  # ty:ignore
+                                "refusal": content_item.refusal,  # ty:ignore[unresolved-attribute]: astral-sh/ty#1479 should fix this
                             }
                         )
         elif item.type in (
@@ -1738,13 +1738,13 @@ def _convert_responses_api_chunk_to_lc_chunk(
             else:
                 content.append(item)
     elif chunk.type == "response.created":
-        id = chunk.response.id if chunk.response else None  # ty:ignore
+        id = chunk.response.id if chunk.response else None  # ty:ignore[unresolved-attribute]: astral-sh/ty#1479 should fix this
         lc_chunk = AIMessageChunk(content="", id=id)
     elif chunk.type == "response.completed":
         # This indicates the response is done
         return None
     elif chunk.type == "error":
-        raise ValueError(chunk.message)  # ty:ignore
+        raise ValueError(chunk.message)  # ty:ignore[unresolved-attribute]: astral-sh/ty#1479 should fix this
     else:
         # Return None for unknown chunk types
         return None

--- a/integrations/langchain/tests/integration_tests/test_langchain_mcp.py
+++ b/integrations/langchain/tests/integration_tests/test_langchain_mcp.py
@@ -5,8 +5,7 @@ Tests DatabricksMCPServer, DatabricksMultiServerMCPClient against a live
 Databricks MCP server backed by a UC function (echo_message).
 
 Prerequisites:
-    Run databricks_mcp/tests/integration_tests/setup_workspace.py once to create
-    the test UC function.
+    The test UC function must exist in the workspace.
 """
 
 from __future__ import annotations
@@ -16,6 +15,7 @@ import os
 from datetime import timedelta
 
 import pytest
+from mcp.shared.exceptions import McpError
 
 pytestmark = pytest.mark.skipif(
     os.environ.get("RUN_MCP_INTEGRATION_TESTS") != "1",
@@ -68,12 +68,13 @@ def cached_langchain_tools(mcp_server):
         return await client.get_tools()
 
     try:
-        return asyncio.run(_get())
+        tools = asyncio.run(_get())
     except Exception as e:
         pytest.skip(
-            f"Could not get tools from MCP server — is the test function set up? "
-            f"Run setup_workspace.py first. Error: {e}"
+            f"Could not get tools from MCP server — is the test function set up? Error: {e}"
         )
+    assert tools, "get_tools() returned no tools — is the test function set up?"
+    return tools
 
 
 # =============================================================================
@@ -109,23 +110,22 @@ class TestDatabricksMCPServerUCFunctions:
 
     # -- Execution --
 
-    def test_tool_invoke_echoes_input(self, workspace_client, mcp_server):
+    @pytest.mark.asyncio
+    async def test_tool_invoke_echoes_input(self, workspace_client, mcp_server):
         from databricks_langchain import DatabricksMultiServerMCPClient
 
-        async def _test():
-            client = DatabricksMultiServerMCPClient([mcp_server])
-            tools = await client.get_tools()
-            assert len(tools) > 0
-            result = await tools[0].ainvoke({"message": "hello"})
-            assert result is not None
-            result_str = str(result)
-            assert "hello" in result_str, f"Echo should return 'hello', got: {result}"
-
-        asyncio.run(_test())
+        client = DatabricksMultiServerMCPClient([mcp_server])
+        tools = await client.get_tools()
+        assert len(tools) > 0
+        result = await tools[0].ainvoke({"message": "hello"})
+        assert result is not None
+        result_str = str(result)
+        assert "hello" in result_str, f"Echo should return 'hello', got: {result}"
 
     # -- Kwargs pass-through --
 
-    def test_handle_tool_error_string_applied_to_tools(self, workspace_client):
+    @pytest.mark.asyncio
+    async def test_handle_tool_error_string_applied_to_tools(self, workspace_client):
         from databricks_langchain import (
             DatabricksMCPServer,
             DatabricksMultiServerMCPClient,
@@ -140,19 +140,16 @@ class TestDatabricksMCPServerUCFunctions:
             handle_tool_error="Custom error occurred",
         )
 
-        async def _test():
-            client = DatabricksMultiServerMCPClient([server])
-            tools = await client.get_tools()
-            assert len(tools) > 0
-            for tool in tools:
-                assert tool.handle_tool_error == "Custom error occurred", (
-                    f"Expected handle_tool_error='Custom error occurred', "
-                    f"got: {tool.handle_tool_error}"
-                )
+        client = DatabricksMultiServerMCPClient([server])
+        tools = await client.get_tools()
+        assert len(tools) > 0
+        for tool in tools:
+            assert tool.handle_tool_error == "Custom error occurred", (
+                f"Expected handle_tool_error='Custom error occurred', got: {tool.handle_tool_error}"
+            )
 
-        asyncio.run(_test())
-
-    def test_handle_tool_error_true_applied_to_tools(self, workspace_client):
+    @pytest.mark.asyncio
+    async def test_handle_tool_error_true_applied_to_tools(self, workspace_client):
         from databricks_langchain import (
             DatabricksMCPServer,
             DatabricksMultiServerMCPClient,
@@ -167,16 +164,13 @@ class TestDatabricksMCPServerUCFunctions:
             handle_tool_error=True,
         )
 
-        async def _test():
-            client = DatabricksMultiServerMCPClient([server])
-            tools = await client.get_tools()
-            assert len(tools) > 0
-            for tool in tools:
-                assert tool.handle_tool_error is True, (
-                    f"Expected handle_tool_error=True, got: {tool.handle_tool_error}"
-                )
-
-        asyncio.run(_test())
+        client = DatabricksMultiServerMCPClient([server])
+        tools = await client.get_tools()
+        assert len(tools) > 0
+        for tool in tools:
+            assert tool.handle_tool_error is True, (
+                f"Expected handle_tool_error=True, got: {tool.handle_tool_error}"
+            )
 
     def test_timeout_kwarg_accepted(self, workspace_client):
         from databricks_langchain import DatabricksMCPServer
@@ -196,7 +190,8 @@ class TestDatabricksMCPServerUCFunctions:
 
     # -- Auth paths --
 
-    def test_pat_auth_produces_working_client(self, workspace_client):
+    @pytest.mark.asyncio
+    async def test_pat_auth_produces_working_client(self, workspace_client):
         from databricks.sdk import WorkspaceClient
 
         from databricks_langchain import (
@@ -217,14 +212,12 @@ class TestDatabricksMCPServerUCFunctions:
             workspace_client=pat_wc,
         )
 
-        async def _test():
-            client = DatabricksMultiServerMCPClient([server])
-            tools = await client.get_tools()
-            assert len(tools) > 0
+        client = DatabricksMultiServerMCPClient([server])
+        tools = await client.get_tools()
+        assert len(tools) > 0
 
-        asyncio.run(_test())
-
-    def test_oauth_m2m_auth_produces_working_client(self):
+    @pytest.mark.asyncio
+    async def test_oauth_m2m_auth_produces_working_client(self):
         from databricks.sdk import WorkspaceClient
 
         from databricks_langchain import (
@@ -254,12 +247,9 @@ class TestDatabricksMCPServerUCFunctions:
             workspace_client=oauth_wc,
         )
 
-        async def _test():
-            client = DatabricksMultiServerMCPClient([server])
-            tools = await client.get_tools()
-            assert len(tools) > 0
-
-        asyncio.run(_test())
+        client = DatabricksMultiServerMCPClient([server])
+        tools = await client.get_tools()
+        assert len(tools) > 0
 
     # -- Schema-level --
 
@@ -277,7 +267,8 @@ class TestDatabricksMCPServerUCFunctions:
             f"URL should end with '{expected_suffix}', got: {server.url}"
         )
 
-    def test_schema_level_get_tools_returns_tools(self, workspace_client):
+    @pytest.mark.asyncio
+    async def test_schema_level_get_tools_returns_tools(self, workspace_client):
         from databricks_langchain import (
             DatabricksMCPServer,
             DatabricksMultiServerMCPClient,
@@ -290,12 +281,9 @@ class TestDatabricksMCPServerUCFunctions:
             workspace_client=workspace_client,
         )
 
-        async def _test():
-            client = DatabricksMultiServerMCPClient([server])
-            tools = await client.get_tools()
-            assert len(tools) >= 1, "Schema-level listing should return at least one tool"
-
-        asyncio.run(_test())
+        client = DatabricksMultiServerMCPClient([server])
+        tools = await client.get_tools()
+        assert len(tools) >= 1, "Schema-level listing should return at least one tool"
 
 
 # =============================================================================
@@ -322,7 +310,8 @@ class TestDatabricksMCPServerVectorSearch:
             f"URL should end with '{expected_suffix}', got: {server.url}"
         )
 
-    def test_from_vector_search_tool_invoke(self, workspace_client):
+    @pytest.mark.asyncio
+    async def test_from_vector_search_tool_invoke(self, workspace_client):
         """Get tools (verify BaseTool type) and invoke a VS tool."""
         from langchain_core.tools import BaseTool
 
@@ -339,33 +328,31 @@ class TestDatabricksMCPServerVectorSearch:
             workspace_client=workspace_client,
         )
 
-        async def _test():
-            client = DatabricksMultiServerMCPClient([server])
-            try:
-                tools = await client.get_tools()
-            except Exception as e:
-                pytest.skip(f"VS MCP endpoint not available: {e}")
-            assert len(tools) > 0
-            for tool in tools:
-                assert isinstance(tool, BaseTool), f"Expected BaseTool, got {type(tool)}"
-            tool = tools[0]
-            # Dynamically extract first required param from tool schema
-            # args_schema may be a Pydantic model class or a plain dict
-            raw_schema = tool.args_schema
-            if isinstance(raw_schema, dict):
-                schema = raw_schema
-            elif raw_schema is not None and hasattr(raw_schema, "schema"):
-                schema = raw_schema.schema()
-            else:
-                schema = {}
-            properties = schema.get("properties", {})
-            param_name = next(iter(properties), "query")
-            result = await tool.ainvoke({param_name: "test"})
-            assert result is not None
+        client = DatabricksMultiServerMCPClient([server])
+        try:
+            tools = await client.get_tools()
+        except McpError as e:
+            pytest.skip(f"VS MCP endpoint not available: {e}")
+        assert len(tools) > 0
+        for tool in tools:
+            assert isinstance(tool, BaseTool), f"Expected BaseTool, got {type(tool)}"
+        tool = tools[0]
+        # Dynamically extract first required param from tool schema
+        # args_schema may be a Pydantic model class or a plain dict
+        raw_schema = tool.args_schema
+        if isinstance(raw_schema, dict):
+            schema = raw_schema
+        elif raw_schema is not None and hasattr(raw_schema, "schema"):
+            schema = raw_schema.schema()
+        else:
+            schema = {}
+        properties = schema.get("properties", {})
+        param_name = next(iter(properties), "query")
+        result = await tool.ainvoke({param_name: "test"})
+        assert result is not None
 
-        asyncio.run(_test())
-
-    def test_from_vector_search_schema_level(self, workspace_client):
+    @pytest.mark.asyncio
+    async def test_from_vector_search_schema_level(self, workspace_client):
         """Schema-level VS: verify URL pattern and listing returns ≥1 tool."""
         from databricks_langchain import (
             DatabricksMCPServer,
@@ -383,28 +370,123 @@ class TestDatabricksMCPServerVectorSearch:
             f"URL should end with '{expected_suffix}', got: {server.url}"
         )
 
-        async def _test():
-            client = DatabricksMultiServerMCPClient([server])
-            try:
-                tools = await client.get_tools()
-            except Exception as e:
-                pytest.skip(f"VS schema-level MCP endpoint not available: {e}")
-            assert len(tools) >= 1, "Schema-level VS listing should return at least one tool"
-
-        asyncio.run(_test())
+        client = DatabricksMultiServerMCPClient([server])
+        try:
+            tools = await client.get_tools()
+        except McpError as e:
+            pytest.skip(f"VS schema-level MCP endpoint not available: {e}")
+        assert len(tools) >= 1, "Schema-level VS listing should return at least one tool"
 
 
 # =============================================================================
-# DatabricksMcpHttpClientFactory Token Refresh Tests
+# DatabricksMultiServerMCPClient — Multiple Servers
 # =============================================================================
 
 
 @pytest.mark.integration
-class TestDatabricksMcpHttpClientFactoryTokenRefresh:
-    """Verify DatabricksMcpHttpClientFactory re-creates auth providers for token refresh."""
+class TestDatabricksMultiServerMCPClientMultipleServers:
+    """Test DatabricksMultiServerMCPClient with UC + VS servers loaded together."""
 
-    def test_sequential_invocations_succeed(self, workspace_client):
-        """Two sequential get_tools() calls succeed — proves token refresh works."""
+    @pytest.mark.asyncio
+    async def test_multi_server_lists_and_invokes_tools_from_all_servers(self, workspace_client):
+        """Loading UC + VS servers returns tools from both, and each is invocable."""
+        from langchain_core.tools import BaseTool
+
+        from databricks_langchain import (
+            DatabricksMCPServer,
+            DatabricksMultiServerMCPClient,
+        )
+
+        uc_server = DatabricksMCPServer.from_uc_function(
+            catalog=CATALOG,
+            schema=SCHEMA,
+            function_name=FUNCTION_NAME,
+            name="multi-uc",
+            workspace_client=workspace_client,
+        )
+        vs_server = DatabricksMCPServer.from_vector_search(
+            catalog=CATALOG,
+            schema=VS_SCHEMA,
+            index_name=VS_INDEX,
+            name="multi-vs",
+            workspace_client=workspace_client,
+        )
+
+        client = DatabricksMultiServerMCPClient([uc_server, vs_server])
+        tools = await client.get_tools()
+        assert len(tools) >= 2, f"Expected tools from both servers, got {len(tools)}"
+        for tool in tools:
+            assert isinstance(tool, BaseTool), f"Expected BaseTool, got {type(tool)}"
+
+        # Verify tools from both servers are present (names are fully-qualified)
+        tool_names = [t.name for t in tools]
+        uc_tools = [t for t in tools if FUNCTION_NAME in t.name]
+        vs_tools = [t for t in tools if VS_INDEX in t.name]
+        assert uc_tools, f"Expected UC tools containing '{FUNCTION_NAME}', got: {tool_names}"
+        assert vs_tools, f"Expected VS tools containing '{VS_INDEX}', got: {tool_names}"
+
+        # Invoke UC echo tool
+        uc_result = await uc_tools[0].ainvoke({"message": "multi-server-test"})
+        assert "multi-server-test" in str(uc_result), (
+            f"Echo should return 'multi-server-test', got: {uc_result}"
+        )
+
+        # Invoke VS tool
+        raw_schema = vs_tools[0].args_schema
+        if isinstance(raw_schema, dict):
+            schema = raw_schema
+        elif raw_schema is not None and hasattr(raw_schema, "schema"):
+            schema = raw_schema.schema()
+        else:
+            schema = {}
+        properties = schema.get("properties", {})
+        param_name = next(iter(properties), "query")
+        vs_result = await vs_tools[0].ainvoke({param_name: "test"})
+        assert vs_result is not None
+
+
+# =============================================================================
+# Error Paths
+# =============================================================================
+
+
+@pytest.mark.integration
+class TestDatabricksMCPServerErrorPaths:
+    """Test error handling through LangChain MCP wrappers."""
+
+    @pytest.mark.asyncio
+    async def test_nonexistent_function_raises_error(self, workspace_client):
+        """get_tools() on a nonexistent function raises ExceptionGroup > McpError(BAD_REQUEST)."""
+        from databricks_langchain import (
+            DatabricksMCPServer,
+            DatabricksMultiServerMCPClient,
+        )
+
+        server = DatabricksMCPServer.from_uc_function(
+            catalog=CATALOG,
+            schema=SCHEMA,
+            function_name="nonexistent_fn_xyz",
+            name="error-test",
+            workspace_client=workspace_client,
+        )
+
+        with pytest.raises(ExceptionGroup) as exc_info:  # ty: ignore[unresolved-reference]
+            client = DatabricksMultiServerMCPClient([server])
+            await client.get_tools()
+
+        # Unwrap nested ExceptionGroups to find McpError
+        errors = exc_info.value.exceptions
+        while errors and isinstance(errors[0], ExceptionGroup):  # ty: ignore[unresolved-reference]
+            errors = errors[0].exceptions
+        assert len(errors) == 1 and isinstance(errors[0], McpError), (
+            f"Expected McpError, got: {errors}"
+        )
+        assert "BAD_REQUEST" in str(errors[0]), f"Expected BAD_REQUEST, got: {errors[0]}"
+        assert "not found" in str(errors[0]).lower(), f"Expected 'not found', got: {errors[0]}"
+
+    @pytest.mark.asyncio
+    async def test_tool_invoke_wrong_arguments_raises_error(self, workspace_client):
+        """ainvoke() with wrong arguments raises McpError(BAD_REQUEST: Missing parameter)."""
         from databricks_langchain import (
             DatabricksMCPServer,
             DatabricksMultiServerMCPClient,
@@ -414,21 +496,38 @@ class TestDatabricksMcpHttpClientFactoryTokenRefresh:
             catalog=CATALOG,
             schema=SCHEMA,
             function_name=FUNCTION_NAME,
-            name="token-refresh-test",
+            name="error-args-test",
             workspace_client=workspace_client,
         )
 
-        async def _test():
+        with pytest.raises(McpError, match="BAD_REQUEST"):
             client = DatabricksMultiServerMCPClient([server])
-            tools_1 = await client.get_tools()
-            assert len(tools_1) > 0
-            tools_2 = await client.get_tools()
-            assert len(tools_2) > 0
+            tools = await client.get_tools()
+            assert len(tools) > 0
+            await tools[0].ainvoke({"wrong_arg": "test"})
 
-        asyncio.run(_test())
 
-    def test_factory_creates_new_oauth_provider(self, workspace_client):
-        """DatabricksMcpHttpClientFactory re-creates DatabricksOAuthClientProvider when called."""
+# =============================================================================
+# DatabricksMcpHttpClientFactory Auth Test
+# =============================================================================
+
+
+@pytest.mark.integration
+class TestDatabricksMcpHttpClientFactoryAuth:
+    """Verify DatabricksMcpHttpClientFactory creates fresh auth providers per request.
+
+    The factory creates a brand new DatabricksOAuthClientProvider on every request, so there is never
+    a cached token that could go stale. Each get_tools() / tool invocation gets
+    a fresh provider that calls workspace_client.config.authenticate() for a new
+    token. This test verifies that mechanism by asserting provider identity.
+    """
+
+    def test_factory_creates_new_oauth_provider_per_request(self, workspace_client):
+        """Each factory call creates a distinct DatabricksOAuthClientProvider instance.
+
+        This guarantees token freshness: since providers are never reused, each
+        request calls workspace_client.config.authenticate() independently.
+        """
         import httpx
         from databricks_mcp import DatabricksOAuthClientProvider
 
@@ -436,13 +535,13 @@ class TestDatabricksMcpHttpClientFactoryTokenRefresh:
             DatabricksMcpHttpClientFactory,
         )
 
+        # A user would never import this factory directly, but still tests the internal factory logic
         factory = DatabricksMcpHttpClientFactory()
         original_auth = DatabricksOAuthClientProvider(workspace_client)
 
         client_1 = factory(timeout=httpx.Timeout(10), auth=original_auth)
         client_2 = factory(timeout=httpx.Timeout(10), auth=original_auth)
 
-        # Each call should produce a client with a *different* auth provider instance
         assert client_1.auth is not original_auth, (
             "Factory should create a new DatabricksOAuthClientProvider, not reuse the original"
         )

--- a/integrations/openai/tests/integration_tests/test_openai_mcp.py
+++ b/integrations/openai/tests/integration_tests/test_openai_mcp.py
@@ -5,16 +5,15 @@ Tests McpServerToolkit (vanilla OpenAI SDK) and McpServer (OpenAI Agents SDK)
 against a live Databricks MCP server backed by a UC function (echo_message).
 
 Prerequisites:
-    Run databricks_mcp/tests/integration_tests/setup_workspace.py once to create
-    the test UC function.
+    The test UC function must exist in the workspace.
 """
 
 from __future__ import annotations
 
-import asyncio
 import os
 
 import pytest
+from mcp.shared.exceptions import McpError
 
 pytestmark = pytest.mark.skipif(
     os.environ.get("RUN_MCP_INTEGRATION_TESTS") != "1",
@@ -56,12 +55,13 @@ def toolkit(workspace_client):
 def toolkit_tools(toolkit):
     """Cache get_tools() result to minimize API calls."""
     try:
-        return toolkit.get_tools()
+        tools = toolkit.get_tools()
     except Exception as e:
         pytest.skip(
-            f"Could not get tools from MCP server — is the test function set up? "
-            f"Run setup_workspace.py first. Error: {e}"
+            f"Could not get tools from MCP server — is the test function set up? Error: {e}"
         )
+    assert tools, "get_tools() returned no tools — is the test function set up?"
+    return tools
 
 
 # =============================================================================
@@ -142,7 +142,7 @@ class TestMcpServerToolkitUCFunctions:
         )
         try:
             tools = toolkit.get_tools()
-        except Exception as e:
+        except ValueError as e:
             pytest.skip(f"Schema-level listing failed: {e}")
         assert len(tools) >= 1, "Schema-level listing should return at least one tool"
 
@@ -232,7 +232,7 @@ class TestMcpServerToolkitVectorSearch:
         )
         try:
             tools = toolkit.get_tools()
-        except Exception as e:
+        except ValueError as e:
             pytest.skip(f"VS MCP endpoint not available: {e}")
         assert len(tools) > 0
         for tool in tools:
@@ -260,7 +260,7 @@ class TestMcpServerToolkitVectorSearch:
         )
         try:
             tools = toolkit.get_tools()
-        except Exception as e:
+        except ValueError as e:
             pytest.skip(f"VS schema-level MCP endpoint not available: {e}")
         assert len(tools) >= 1, "Schema-level VS listing should return at least one tool"
         for tool in tools:
@@ -278,47 +278,44 @@ class TestMcpServerAgentsUCFunctions:
 
     # -- Listing --
 
-    def test_server_lists_tools(self, workspace_client):
+    @pytest.mark.asyncio
+    async def test_server_lists_tools(self, workspace_client):
         from databricks_openai.agents import McpServer
 
-        async def _test():
-            async with McpServer.from_uc_function(
-                catalog=CATALOG,
-                schema=SCHEMA,
-                function_name=FUNCTION_NAME,
-                workspace_client=workspace_client,
-            ) as server:
-                tools = await server.list_tools()
-                assert len(tools) > 0
-
-        asyncio.run(_test())
+        async with McpServer.from_uc_function(
+            catalog=CATALOG,
+            schema=SCHEMA,
+            function_name=FUNCTION_NAME,
+            workspace_client=workspace_client,
+        ) as server:
+            tools = await server.list_tools()
+            assert len(tools) > 0
 
     # -- Execution --
 
-    def test_call_tool_returns_result_with_content(self, workspace_client):
+    @pytest.mark.asyncio
+    async def test_call_tool_returns_result_with_content(self, workspace_client):
         from mcp.types import CallToolResult
 
         from databricks_openai.agents import McpServer
 
-        async def _test():
-            async with McpServer.from_uc_function(
-                catalog=CATALOG,
-                schema=SCHEMA,
-                function_name=FUNCTION_NAME,
-                workspace_client=workspace_client,
-            ) as server:
-                tools = await server.list_tools()
-                tool_name = tools[0].name
-                result = await server.call_tool(tool_name, {"message": "hello"})
-                assert isinstance(result, CallToolResult)
-                assert result.content, "call_tool result should have content"
-                assert len(result.content) > 0
-
-        asyncio.run(_test())
+        async with McpServer.from_uc_function(
+            catalog=CATALOG,
+            schema=SCHEMA,
+            function_name=FUNCTION_NAME,
+            workspace_client=workspace_client,
+        ) as server:
+            tools = await server.list_tools()
+            tool_name = tools[0].name
+            result = await server.call_tool(tool_name, {"message": "hello"})
+            assert isinstance(result, CallToolResult)
+            assert result.content, "call_tool result should have content"
+            assert len(result.content) > 0
 
     # -- Auth paths --
 
-    def test_pat_auth_agents_sdk(self, workspace_client):
+    @pytest.mark.asyncio
+    async def test_pat_auth_agents_sdk(self, workspace_client):
         """McpServer with PAT-authenticated WorkspaceClient lists tools."""
         from databricks.sdk import WorkspaceClient
 
@@ -330,19 +327,17 @@ class TestMcpServerAgentsUCFunctions:
 
         pat_wc = WorkspaceClient(host=workspace_client.config.host, token=token, auth_type="pat")
 
-        async def _test():
-            async with McpServer.from_uc_function(
-                catalog=CATALOG,
-                schema=SCHEMA,
-                function_name=FUNCTION_NAME,
-                workspace_client=pat_wc,
-            ) as server:
-                tools = await server.list_tools()
-                assert len(tools) > 0
+        async with McpServer.from_uc_function(
+            catalog=CATALOG,
+            schema=SCHEMA,
+            function_name=FUNCTION_NAME,
+            workspace_client=pat_wc,
+        ) as server:
+            tools = await server.list_tools()
+            assert len(tools) > 0
 
-        asyncio.run(_test())
-
-    def test_oauth_m2m_auth_agents_sdk(self):
+    @pytest.mark.asyncio
+    async def test_oauth_m2m_auth_agents_sdk(self):
         """McpServer with OAuth M2M WorkspaceClient lists tools."""
         from databricks.sdk import WorkspaceClient
 
@@ -363,50 +358,45 @@ class TestMcpServerAgentsUCFunctions:
             client_secret=client_secret,
         )
 
-        async def _test():
-            async with McpServer.from_uc_function(
-                catalog=CATALOG,
-                schema=SCHEMA,
-                function_name=FUNCTION_NAME,
-                workspace_client=oauth_wc,
-            ) as server:
-                tools = await server.list_tools()
-                assert len(tools) > 0
-
-        asyncio.run(_test())
+        async with McpServer.from_uc_function(
+            catalog=CATALOG,
+            schema=SCHEMA,
+            function_name=FUNCTION_NAME,
+            workspace_client=oauth_wc,
+        ) as server:
+            tools = await server.list_tools()
+            assert len(tools) > 0
 
     # -- MLflow tracing --
 
-    def test_call_tool_creates_mlflow_trace(self, workspace_client):
+    @pytest.mark.asyncio
+    async def test_call_tool_creates_mlflow_trace(self, workspace_client):
         """McpServer.call_tool() creates an MLflow trace with SpanType.TOOL."""
         import mlflow
         from mlflow.entities import SpanType
 
         from databricks_openai.agents import McpServer
 
-        async def _test():
-            async with McpServer.from_uc_function(
-                catalog=CATALOG,
-                schema=SCHEMA,
-                function_name=FUNCTION_NAME,
-                workspace_client=workspace_client,
-            ) as server:
-                tools = await server.list_tools()
-                tool_name = tools[0].name
-                await server.call_tool(tool_name, {"message": "tracing-test"})
+        async with McpServer.from_uc_function(
+            catalog=CATALOG,
+            schema=SCHEMA,
+            function_name=FUNCTION_NAME,
+            workspace_client=workspace_client,
+        ) as server:
+            tools = await server.list_tools()
+            tool_name = tools[0].name
+            await server.call_tool(tool_name, {"message": "tracing-test"})
 
-            trace_id = mlflow.get_last_active_trace_id()
-            assert trace_id is not None, "call_tool should produce an MLflow trace"
-            trace = mlflow.get_trace(trace_id)
-            assert trace is not None, "Should be able to retrieve the trace by ID"
-            spans = trace.data.spans
-            assert len(spans) > 0, "Trace should contain at least one span"
-            root_span = spans[0]
-            assert root_span.span_type == SpanType.TOOL, (
-                f"Expected span_type={SpanType.TOOL}, got: {root_span.span_type}"
-            )
-
-        asyncio.run(_test())
+        trace_id = mlflow.get_last_active_trace_id()
+        assert trace_id is not None, "call_tool should produce an MLflow trace"
+        trace = mlflow.get_trace(trace_id)
+        assert trace is not None, "Should be able to retrieve the trace by ID"
+        spans = trace.data.spans
+        assert len(spans) > 0, "Trace should contain at least one span"
+        root_span = spans[0]
+        assert root_span.span_type == SpanType.TOOL, (
+            f"Expected span_type={SpanType.TOOL}, got: {root_span.span_type}"
+        )
 
     # -- Timeout kwargs --
 
@@ -445,48 +435,154 @@ class TestMcpServerAgentsUCFunctions:
 class TestMcpServerAgentsVectorSearch:
     """Test McpServer.from_vector_search() via Agents SDK (index-level + schema-level)."""
 
-    def test_from_vector_search_call_tool(self, workspace_client):
+    @pytest.mark.asyncio
+    async def test_from_vector_search_call_tool(self, workspace_client):
         """List tools and call_tool on a VS tool via Agents SDK context manager."""
         from mcp.types import CallToolResult
 
         from databricks_openai.agents import McpServer
 
-        async def _test():
-            async with McpServer.from_vector_search(
-                catalog=CATALOG,
-                schema=VS_SCHEMA,
-                index_name=VS_INDEX,
-                workspace_client=workspace_client,
-            ) as server:
-                try:
-                    tools = await server.list_tools()
-                except Exception as e:
-                    pytest.skip(f"VS MCP endpoint not available: {e}")
-                assert len(tools) > 0
-                tool = tools[0]
-                # Dynamically extract first param from tool's inputSchema
-                properties = tool.inputSchema.get("properties", {})
-                param_name = next(iter(properties), "query")
-                result = await server.call_tool(tool.name, {param_name: "test"})
-                assert isinstance(result, CallToolResult)
-                assert result.content, "VS call_tool result should have content"
+        async with McpServer.from_vector_search(
+            catalog=CATALOG,
+            schema=VS_SCHEMA,
+            index_name=VS_INDEX,
+            workspace_client=workspace_client,
+        ) as server:
+            try:
+                tools = await server.list_tools()
+            except McpError as e:
+                pytest.skip(f"VS MCP endpoint not available: {e}")
+            assert len(tools) > 0
+            tool = tools[0]
+            # Dynamically extract first param from tool's inputSchema
+            properties = tool.inputSchema.get("properties", {})
+            param_name = next(iter(properties), "query")
+            result = await server.call_tool(tool.name, {param_name: "test"})
+            assert isinstance(result, CallToolResult)
+            assert result.content, "VS call_tool result should have content"
 
-        asyncio.run(_test())
-
-    def test_from_vector_search_schema_level_lists_tools(self, workspace_client):
+    @pytest.mark.asyncio
+    async def test_from_vector_search_schema_level_lists_tools(self, workspace_client):
         """Schema-level VS listing via Agents SDK context manager returns ≥1 tool."""
         from databricks_openai.agents import McpServer
 
-        async def _test():
-            async with McpServer.from_vector_search(
+        async with McpServer.from_vector_search(
+            catalog=CATALOG,
+            schema=VS_SCHEMA,
+            workspace_client=workspace_client,
+        ) as server:
+            try:
+                tools = await server.list_tools()
+            except McpError as e:
+                pytest.skip(f"VS schema-level MCP endpoint not available: {e}")
+            assert len(tools) >= 1, "Schema-level VS listing should return at least one tool"
+
+
+# =============================================================================
+# Error Paths
+# =============================================================================
+
+
+@pytest.mark.integration
+class TestMcpServerToolkitErrorPaths:
+    """Test error handling in McpServerToolkit wrapper."""
+
+    def test_nonexistent_function_raises_value_error(self, workspace_client):
+        """get_tools() on a nonexistent function wraps the error in ValueError with server name."""
+        from databricks_openai import McpServerToolkit
+
+        toolkit = McpServerToolkit.from_uc_function(
+            catalog=CATALOG,
+            schema=SCHEMA,
+            function_name="nonexistent_fn_xyz",
+            name="error-test",
+            workspace_client=workspace_client,
+        )
+        with pytest.raises(ValueError, match="Error listing tools from error-test MCP Server"):
+            toolkit.get_tools()
+
+    def test_execute_nonexistent_tool_raises_error(self, workspace_client):
+        """call_tool with a nonexistent tool name raises ExceptionGroup > McpError(BAD_REQUEST)."""
+        from databricks_openai import McpServerToolkit
+
+        toolkit = McpServerToolkit.from_uc_function(
+            catalog=CATALOG,
+            schema=SCHEMA,
+            function_name=FUNCTION_NAME,
+            workspace_client=workspace_client,
+        )
+        with pytest.raises(ExceptionGroup) as exc_info:  # ty: ignore[unresolved-reference]
+            toolkit.databricks_mcp_client.call_tool("nonexistent_tool_xyz", {"message": "test"})
+
+        # Unwrap to find McpError
+        def find_mcp_error(eg):
+            for exc in eg.exceptions:
+                if isinstance(exc, McpError):
+                    return exc
+                if isinstance(exc, ExceptionGroup):  # ty: ignore[unresolved-reference]
+                    found = find_mcp_error(exc)
+                    if found:
+                        return found
+            return None
+
+        mcp_error = find_mcp_error(exc_info.value)
+        assert mcp_error is not None, f"Expected McpError, got: {exc_info.value}"
+        assert "BAD_REQUEST" in str(mcp_error), f"Expected BAD_REQUEST, got: {mcp_error}"
+
+    def test_execute_wrong_arguments_raises_error(self, toolkit_tools):
+        """execute() with wrong arguments raises ExceptionGroup > McpError(BAD_REQUEST)."""
+        tool = toolkit_tools[0]
+        # echo_message expects "message", we pass "wrong_arg"
+        with pytest.raises(ExceptionGroup):  # ty: ignore[unresolved-reference]
+            tool.execute(wrong_arg="test")
+
+
+@pytest.mark.integration
+class TestMcpServerAgentsErrorPaths:
+    """Test error handling in McpServer (Agents SDK) wrapper."""
+
+    @pytest.mark.asyncio
+    async def test_nonexistent_function_raises_mcp_error(self, workspace_client):
+        """McpServer with a nonexistent function raises McpError(BAD_REQUEST: ... not found)."""
+        from databricks_openai.agents import McpServer
+
+        with pytest.raises(McpError, match="BAD_REQUEST"):
+            async with McpServer.from_uc_function(
                 catalog=CATALOG,
-                schema=VS_SCHEMA,
+                schema=SCHEMA,
+                function_name="nonexistent_fn_xyz",
                 workspace_client=workspace_client,
             ) as server:
-                try:
-                    tools = await server.list_tools()
-                except Exception as e:
-                    pytest.skip(f"VS schema-level MCP endpoint not available: {e}")
-                assert len(tools) >= 1, "Schema-level VS listing should return at least one tool"
+                await server.list_tools()
 
-        asyncio.run(_test())
+    @pytest.mark.asyncio
+    async def test_call_tool_nonexistent_tool_raises_mcp_error(self, workspace_client):
+        """call_tool() with a malformed tool name raises McpError(BAD_REQUEST: ... malformed)."""
+        from databricks_openai.agents import McpServer
+
+        with pytest.raises(McpError, match="BAD_REQUEST"):
+            async with McpServer.from_uc_function(
+                catalog=CATALOG,
+                schema=SCHEMA,
+                function_name=FUNCTION_NAME,
+                workspace_client=workspace_client,
+            ) as server:
+                await server.call_tool("nonexistent_tool_xyz", {"message": "test"})
+
+    @pytest.mark.asyncio
+    async def test_call_tool_wrong_arguments_raises_user_error(self, workspace_client):
+        """call_tool() with wrong arguments raises UserError about missing parameters."""
+        from agents.exceptions import UserError
+
+        from databricks_openai.agents import McpServer
+
+        with pytest.raises(UserError, match="missing required parameters"):
+            async with McpServer.from_uc_function(
+                catalog=CATALOG,
+                schema=SCHEMA,
+                function_name=FUNCTION_NAME,
+                workspace_client=workspace_client,
+            ) as server:
+                tools = await server.list_tools()
+                tool_name = tools[0].name
+                await server.call_tool(tool_name, {"wrong_arg": "test"})

--- a/src/databricks_ai_bridge/lakebase.py
+++ b/src/databricks_ai_bridge/lakebase.py
@@ -223,7 +223,7 @@ class LakebasePool(_LakebaseBase):
         max_size = pool_kwargs.pop("max_size", DEFAULT_MAX_SIZE)
         timeout = pool_kwargs.pop("timeout", DEFAULT_TIMEOUT)
 
-        self._pool: ConnectionPool[psycopg.Connection[DictRow]] = ConnectionPool(  # ty:ignore[invalid-assignment]
+        self._pool: ConnectionPool[psycopg.Connection[DictRow]] = ConnectionPool(  # type: ignore[invalid-assignment]
             conninfo=self._conninfo(),
             kwargs=default_kwargs,
             min_size=min_size,  # type: ignore[invalid-argument-type]
@@ -316,7 +316,7 @@ class AsyncLakebasePool(_LakebaseBase):
         max_size = pool_kwargs.pop("max_size", DEFAULT_MAX_SIZE)
         timeout = pool_kwargs.pop("timeout", DEFAULT_TIMEOUT)
 
-        self._pool: AsyncConnectionPool[psycopg.AsyncConnection[DictRow]] = AsyncConnectionPool(  # ty:ignore[invalid-assignment]
+        self._pool: AsyncConnectionPool[psycopg.AsyncConnection[DictRow]] = AsyncConnectionPool(  # type: ignore[invalid-assignment]
             conninfo=self._conninfo(),
             kwargs=default_kwargs,
             min_size=min_size,  # type: ignore[invalid-argument-type]


### PR DESCRIPTION
## Summary

Adds MCP integration tests covering the core `DatabricksMCPClient`, OpenAI wrappers (`McpServerToolkit` + `McpServer`), and LangChain wrappers (`DatabricksMCPServer` + `DatabricksMultiServerMCPClient`). Tests validate against a live Databricks MCP server across **UC Functions**, **Vector Search**, and **Genie**.

**64 integration tests** (21 core + 25 OpenAI + 18 LangChain), gated behind `RUN_MCP_INTEGRATION_TESTS=1`.

### What's tested

- Tool listing and execution for UC Functions, Vector Search, and Genie
- Schema-level listing (UC + VS)
- Multi-server client with UC + VS servers loaded together
- PAT and OAuth-M2M auth paths
- `get_databricks_resources()` normalization and type correctness
- `handle_tool_error`, `timeout` kwargs pass-through (LangChain)
- MLflow tracing, timeout defaults/override (OpenAI Agents)
- Auth provider freshness per request (LangChain factory)
- Error paths: nonexistent function, nonexistent tool name, wrong arguments — across all 3 layers

## Test plan
- [x] All 64 MCP integration tests pass (21 core + 25 OpenAI + 18 LangChain)
- [x] Existing unit tests unaffected
- [x] CI Run: https://github.com/databricks-eng/ai-oss-integration-tests-runner/actions/runs/22639223391