### PR TITLE
docs: fix broken link in documentation

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 # Databricks AI Bridge Documentation
 
-We generate our API docs with Sphinx, and they get published to [this directory](https://github.com/databricks-eng/docs-api-ref/tree/main/content-publish/python).
+We generate our API docs with Sphinx, and they get published to the [Databricks AI Bridge docs](https://docs.databricks.com/en/ai/databricks-ai-bridge/index.html).
 
 ## Setup
 Requirements:


### PR DESCRIPTION
## Summary

Fixed issue #283 - Fixed broken link in docs/README.md that pointed to non-existent databricks-eng/docs-api-ref repository.

## Changes

- Replaced broken link with reference to Databricks AI Bridge docs

## Issue

The original link `https://github.com/databricks-eng/docs-api-ref/tree/main/content-publish/python` no longer exists or has been moved.

AI assistance used for code review and implementation