### PR TITLE
Add mlflow span attribute logging for Genie ask_question inputs and outputs

### DIFF
--- a/src/databricks_ai_bridge/genie.py
+++ b/src/databricks_ai_bridge/genie.py
@@ -461,7 +461,15 @@ class Genie:
     def ask_question(self, question, conversation_id: Optional[str] = None):
         import mlflow
 
-        with mlflow.start_span(name="ask_question"):
+        with mlflow.start_span(name="ask_question") as span:
+            span.set_attributes(
+                {
+                    "space_id": self.space_id,
+                    "input.question": question,
+                    "input.conversation_id": conversation_id or "",
+                }
+            )
+
             # check if a conversation_id is supplied
             # if yes, continue an existing genie conversation
             # otherwise start a new conversation
@@ -472,4 +480,13 @@ class Genie:
             genie_response = self.poll_for_result(resp["conversation_id"], resp["message_id"])
             if not genie_response.conversation_id:
                 genie_response.conversation_id = resp["conversation_id"]
+
+            span.set_attributes(
+                {
+                    "output.query": genie_response.query or "",
+                    "output.description": genie_response.description or "",
+                    "output.conversation_id": genie_response.conversation_id or "",
+                }
+            )
+
             return genie_response


### PR DESCRIPTION
- Added mlflow span attribute logging to `Genie.ask_question` for improved observability: logs `space_id`, `input.question`, `input.conversation_id` as input attributes and `output.query`, `output.description`, `output.conversation_id` as output attributes (intentionally excludes `output.result` to avoid logging potentially large query results).
- Added two unit tests verifying span attributes are correctly set for both new conversations and continued conversations.

## Test plan
- [x] `test_ask_question_mlflow_trace_logs_inputs_and_outputs` — verifies input/output attributes on a new conversation with a query attachment
- [x] `test_ask_question_mlflow_trace_with_conversation_id` — verifies input/output attributes when continuing an existing conversation with a text attachment
- [x] All 74 existing tests in `test_genie.py` continue to pass


Made with [Cursor](https://cursor.com)