### PR TITLE
OpenAI Clients: use openai key when possible

### DIFF
--- a/integrations/openai/src/databricks_openai/utils/clients.py
+++ b/integrations/openai/src/databricks_openai/utils/clients.py
@@ -13,6 +13,8 @@ from typing_extensions import override
 _APPS_ENDPOINT_PREFIX = "apps/"
 # Domain pattern indicating a Databricks App URL
 _DATABRICKS_APPS_DOMAIN = "databricksapps"
+
+
 def _get_openai_api_key():
     """Return OPENAI_API_KEY from env if set, otherwise 'no-token'.
 

--- a/integrations/openai/tests/unit_tests/test_clients.py
+++ b/integrations/openai/tests/unit_tests/test_clients.py
@@ -69,9 +69,10 @@ class TestDatabricksOpenAI:
     def test_init_with_default_workspace_client(self):
         """Test initialization with default WorkspaceClient."""
         env = {k: v for k, v in os.environ.items() if k != "OPENAI_API_KEY"}
-        with patch.dict("os.environ", env, clear=True), patch(
-            "databricks_openai.utils.clients.WorkspaceClient"
-        ) as mock_ws_client_class:
+        with (
+            patch.dict("os.environ", env, clear=True),
+            patch("databricks_openai.utils.clients.WorkspaceClient") as mock_ws_client_class,
+        ):
             mock_client = MagicMock(spec=WorkspaceClient)
             mock_client.config.host = "https://default.databricks.com"
             mock_client.config.authenticate.return_value = {"Authorization": "Bearer default-token"}
@@ -89,9 +90,10 @@ class TestDatabricksOpenAI:
             assert client.api_key == "no-token"
 
     def test_init_uses_openai_api_key_env_var(self):
-        with patch.dict("os.environ", {"OPENAI_API_KEY": "sk-from-env"}), patch(
-            "databricks_openai.utils.clients.WorkspaceClient"
-        ) as mock_ws_client_class:
+        with (
+            patch.dict("os.environ", {"OPENAI_API_KEY": "sk-from-env"}),
+            patch("databricks_openai.utils.clients.WorkspaceClient") as mock_ws_client_class,
+        ):
             mock_client = MagicMock(spec=WorkspaceClient)
             mock_client.config.host = "https://default.databricks.com"
             mock_client.config.authenticate.return_value = {"Authorization": "Bearer token"}
@@ -127,9 +129,10 @@ class TestAsyncDatabricksOpenAI:
     def test_init_with_default_workspace_client(self):
         """Test initialization with default WorkspaceClient."""
         env = {k: v for k, v in os.environ.items() if k != "OPENAI_API_KEY"}
-        with patch.dict("os.environ", env, clear=True), patch(
-            "databricks_openai.utils.clients.WorkspaceClient"
-        ) as mock_ws_client_class:
+        with (
+            patch.dict("os.environ", env, clear=True),
+            patch("databricks_openai.utils.clients.WorkspaceClient") as mock_ws_client_class,
+        ):
             mock_client = MagicMock(spec=WorkspaceClient)
             mock_client.config.host = "https://default.databricks.com"
             mock_client.config.authenticate.return_value = {"Authorization": "Bearer default-token"}


### PR DESCRIPTION
context: https://databricks.slack.com/archives/C022KUWGVQS/p1771818328131179?thread_ts=1771612303.565839&cid=C022KUWGVQS

context PR: https://github.com/mlflow/mlflow/pull/21038

manually tested + added unit tests

matters for openai agents tracing

before, when pointing towards databricks LLM + openai key is set, we weren't respecting the key when creating the client:
```
ERROR:openai.agents:[non-fatal] Tracing client error 401: {
  "error": {
    "message": "Incorrect API key provided: no-token. You can find your API key at https://platform.openai.com/account/api-keys.",
    "type": "invalid_request_error",
    "param": null,
    "code": "invalid_api_key"
  }
}
```

after, when pointing towards databricks LLM + openai key is set:
```
ERROR:openai.agents:[non-fatal] Tracing client error 400: {
  "error": {
    "message": "Unknown parameter: 'data[2].span_data.usage.total_tokens'.",
    "type": "invalid_request_error",
    "param": "data[2].span_data.usage.total_tokens",
    "code": "unknown_parameter"
  }
}
```