### PR TITLE
databricks-langchain0.16.1: bump min version of db-ai-bridge required in databricks-langchain

### DIFF
--- a/integrations/langchain/pyproject.toml
+++ b/integrations/langchain/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "databricks-langchain"
-version = "0.16.0"
+version = "0.16.1"
 description = "Support for Databricks AI support in LangChain"
 authors = [
     { name="Databricks", email="agent-feedback@databricks.com" },
@@ -11,7 +11,7 @@ requires-python = ">=3.10"
 dependencies = [
     "langchain>=1.0.0",
     "databricks-vectorsearch>=0.50",
-    "databricks-ai-bridge>=0.13.0",
+    "databricks-ai-bridge>=0.15.0",
     "mlflow>=3.0.0",
     "pydantic>2.10.0",
     "unitycatalog-langchain[databricks]>=0.3.0",
@@ -25,7 +25,7 @@ dependencies = [
 [project.optional-dependencies]
 memory = [
   "langgraph-checkpoint-postgres>=2.0.5",
-  "databricks-ai-bridge[memory]>=0.10.0",
+  "databricks-ai-bridge[memory]>=0.14.0",
 ]
 
 [dependency-groups]


### PR DESCRIPTION
 databricks-langchain v0.16.0 added an import of databricks_ai_bridge._compat.mlflow_trace in genie.py, but the _compat module was only introduced in databricks-ai-bridge v0.15.0. Customers with an existing databricks-ai-bridge installation older than 0.15.0 hit a ModuleNotFoundError on import


<img width="3154" height="1164" alt="image" src="https://github.com/user-attachments/assets/08cf35ac-18d2-4e76-9a5e-6af04ddafad4" />

- Bump databricks-ai-bridge minimum from >=0.13.0 to >=0.15.0 to fix ModuleNotFoundError: No module named 'databricks_ai_bridge._compat'
- Bump databricks-ai-bridge[memory] minimum from >=0.10.0 to >=0.14.0 to pull in the lakebase token cache duration fix (15 min per Databricks docs) https://github.com/databricks/databricks-ai-bridge/blob/7496f21cecc1283b9e8678bc5e9eea084726a62f/CHANGELOG.md
- Patch release databricks-langchain 0.16.0 → 0.16.1
 
First replicated error using venv:
```
pip install databricks-langchain==0.16.0 databricks-ai-bridge==0.13.0
python -c "from databricks_langchain.genie import Genie"
```
fails with 
```
ie"
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/private/tmp/test-langchain-bump/lib/python3.12/site-packages/databricks_langchain/__init__.py", line 23, in <module>
    from databricks_langchain.genie import GenieAgent
  File "/private/tmp/test-langchain-bump/lib/python3.12/site-packages/databricks_langchain/genie.py", line 5, in <module>
    from databricks_ai_bridge._compat import mlflow_trace
ModuleNotFoundError: No module named 'databricks_ai_bridge._compat'
``` 
then updated ver 
```
pip install -e "integrations/langchain[dev]"
```

import works:
```
python -c "from databricks_langchain.genie import Genie; print('OK')"
```
verify correct versions are installed:
```
(test-langchain-bump) jenny.sun@K1GXRYC4V1 databricks-ai-bridge % pip show databricks-ai-bridge | grep Version
Version: 0.15.0
(test-langchain-bump) jenny.sun@K1GXRYC4V1 databricks-ai-bridge % pip show databricks-langchain | grep Version
Version: 0.16.1
```