### PR TITLE
ai-sdk-provider: release v0.5.0

### DIFF
--- a/integrations/ai-sdk-provider/CHANGELOG.md
+++ b/integrations/ai-sdk-provider/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0] - 2026-02-26
+
+### Added
+
+- Added `includeTrace` provider option to request Databricks trace data in the response (`databricks_options.return_trace`)
+- Raw response body is now passed through in `doGenerate` results, allowing callers to access `trace_id` and `databricks_output` fields directly
+
+### Fixed
+
+- Made `annotations` field optional in responses agent message schema to handle endpoints that omit it
+- Made `output_index` and `id` optional in `response.output_item.done` stream event schema
+- `raw` stream chunks are now passed through the Databricks stream transformer without modification
+- Added `.passthrough()` to response and stream event schemas to preserve unknown fields (e.g. trace data)
+- Fixed tsdown `fixedExtension: true` to correctly emit `.mjs`/`.cjs` files matching `package.json` exports
+
 ## [0.4.1] - 2026-01-30
 
 ### Fixed

--- a/integrations/ai-sdk-provider/package.json
+++ b/integrations/ai-sdk-provider/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@databricks/ai-sdk-provider",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "description": "Databricks provider for Vercel AI SDK",
   "type": "module",
   "main": "./dist/index.cjs",


### PR DESCRIPTION
## Summary

- Bumps `@databricks/ai-sdk-provider` from `0.4.1` → `0.5.0`
- Updates `CHANGELOG.md` with release notes

## What's in this release (since v0.4.1)

**Added**
- `includeTrace` provider option: set `providerOptions: { databricks: { includeTrace: true } }` to request Databricks trace data in the response (`databricks_options.return_trace`)
- Raw response body is now passed through in `doGenerate` results, giving callers access to `trace_id` and `databricks_output` fields directly

**Fixed**
- `annotations` field made optional in responses agent message schema (some endpoints omit it)
- `output_index` and `id` made optional in `response.output_item.done` stream event schema
- `raw` stream chunks now pass through the Databricks stream transformer unmodified
- Added `.passthrough()` to response/stream event schemas to preserve unknown fields (e.g. trace data)
- `tsdown` `fixedExtension: true` added to correctly emit `.mjs`/`.cjs` files matching `package.json` exports

## Test plan

- [ ] CI passes (tests, lint, typecheck, build)
- [ ] After merge: `npm publish` from `integrations/ai-sdk-provider`

🤖 Generated with [Claude Code](https://claude.com/claude-code)