### PR TITLE
bump ai-sdk version in langchainjs

### DIFF
--- a/integrations/langchainjs/package-lock.json
+++ b/integrations/langchainjs/package-lock.json
@@ -20,6 +20,7 @@
       },
       "devDependencies": {
         "@arethetypeswrong/cli": "^0.15.0",
+        "@eslint/js": "^10.0.0",
         "@types/node": "^22.0.0",
         "dotenv": "^17.2.3",
         "eslint": "^10.0.1",
@@ -757,6 +758,27 @@
       },
       "engines": {
         "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/js": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-10.0.1.tgz",
+      "integrity": "sha512-zeR9k5pd4gxjZ0abRoIaxdc7I3nDktoXZk2qOv9gCNWx3mVwEn32VRhyLaRsDiJjTs0xq/T8mfPtyuXu7GWBcA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      },
+      "peerDependencies": {
+        "eslint": "^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "eslint": {
+          "optional": true
+        }
       }
     },
     "node_modules/@eslint/object-schema": {

--- a/integrations/langchainjs/package.json
+++ b/integrations/langchainjs/package.json
@@ -65,6 +65,7 @@
     "@arethetypeswrong/cli": "^0.15.0",
     "@types/node": "^22.0.0",
     "dotenv": "^17.2.3",
+    "@eslint/js": "^10.0.0",
     "eslint": "^10.0.1",
     "langchain": "^1.2.10",
     "prettier": "^3.0.0",


### PR DESCRIPTION
bump min version of the databricks ai sdk provider

ensured that all of the dependabot alerts are still resolved