### PR TITLE
Support updated Workspace URL Path for AI Gateway via DatabricksOpenAI

### DIFF
--- a/integrations/openai/src/databricks_openai/utils/clients.py
+++ b/integrations/openai/src/databricks_openai/utils/clients.py
@@ -3,7 +3,7 @@ from typing import Any, Generator
 from urllib.parse import urlparse
 
 from databricks.sdk import WorkspaceClient
-from httpx import URL, AsyncClient, Auth, Client, Request, Response
+from httpx import AsyncClient, Auth, Client, Request, Response
 from openai import APIConnectionError, APIStatusError, AsyncOpenAI, OpenAI
 from openai.resources.chat import AsyncChat, Chat
 from openai.resources.chat.completions import AsyncCompletions, Completions
@@ -363,8 +363,7 @@ def _truncate_input_ids(input_items: Any) -> None:
 
 
 class DatabricksResponses(Responses):
-    """Responses resource that handles apps/ prefix routing, id truncation,
-    and base URL swapping for AI Gateway mlflow/v1 → openai/v1."""
+    """Responses resource that handles apps/ prefix routing and id truncation."""
 
     def __init__(self, client, workspace_client: WorkspaceClient):
         super().__init__(client)
@@ -396,17 +395,7 @@ class DatabricksResponses(Responses):
             except (APIStatusError, APIConnectionError) as e:
                 raise _wrap_app_error(e, app_name) from e
 
-        # When using use_ai_gateway (mlflow/v1), swap to openai/v1 for responses
-        openai_base_url = getattr(self._client, "_openai_base_url", None)
-        if openai_base_url:
-            original_base_url = self._client._base_url
-            self._client._base_url = URL(f"{openai_base_url}/")
-            try:
-                response = super().create(**kwargs)
-            finally:
-                self._client._base_url = original_base_url
-        else:
-            response = super().create(**kwargs)
+        response = super().create(**kwargs)
         _truncate_response_ids(response)
         return response
 
@@ -489,13 +478,6 @@ class DatabricksOpenAI(OpenAI):
             workspace_client, base_url, use_ai_gateway, http_client, use_ai_gateway_native_api
         )
 
-        # When using use_ai_gateway (mlflow/v1), store the gateway root so that
-        # DatabricksResponses can swap to openai/v1 for the responses API.
-        self._openai_base_url: str | None = None
-        if use_ai_gateway and target_base_url.endswith("/mlflow/v1"):
-            gateway_root = target_base_url[: -len("/mlflow/v1")]
-            self._openai_base_url = f"{gateway_root}/openai/v1"
-
         # Authentication is handled via http_client, not api_key
         super().__init__(
             base_url=target_base_url,
@@ -543,8 +525,7 @@ class AsyncDatabricksChat(AsyncChat):
 
 
 class AsyncDatabricksResponses(AsyncResponses):
-    """Async Responses resource that handles apps/ prefix routing, id truncation,
-    and base URL swapping for AI Gateway mlflow/v1 → openai/v1."""
+    """Async Responses resource that handles apps/ prefix routing and id truncation."""
 
     def __init__(self, client, workspace_client: WorkspaceClient):
         super().__init__(client)
@@ -576,17 +557,7 @@ class AsyncDatabricksResponses(AsyncResponses):
             except (APIStatusError, APIConnectionError) as e:
                 raise _wrap_app_error(e, app_name) from e
 
-        # When using use_ai_gateway (mlflow/v1), swap to openai/v1 for responses
-        openai_base_url = getattr(self._client, "_openai_base_url", None)
-        if openai_base_url:
-            original_base_url = self._client._base_url
-            self._client._base_url = URL(f"{openai_base_url}/")
-            try:
-                response = await super().create(**kwargs)
-            finally:
-                self._client._base_url = original_base_url
-        else:
-            response = await super().create(**kwargs)
+        response = await super().create(**kwargs)
         _truncate_response_ids(response)
         return response
 
@@ -668,13 +639,6 @@ class AsyncDatabricksOpenAI(AsyncOpenAI):
         target_base_url = _resolve_base_url(
             workspace_client, base_url, use_ai_gateway, sync_http_client, use_ai_gateway_native_api
         )
-
-        # When using use_ai_gateway (mlflow/v1), store the gateway root so that
-        # AsyncDatabricksResponses can swap to openai/v1 for the responses API.
-        self._openai_base_url: str | None = None
-        if use_ai_gateway and target_base_url.endswith("/mlflow/v1"):
-            gateway_root = target_base_url[: -len("/mlflow/v1")]
-            self._openai_base_url = f"{gateway_root}/openai/v1"
 
         # Authentication is handled via http_client, not api_key
         super().__init__(

--- a/integrations/openai/src/databricks_openai/utils/clients.py
+++ b/integrations/openai/src/databricks_openai/utils/clients.py
@@ -113,7 +113,7 @@ def _discover_ai_gateway_host(
     http_client: Client,
     host: str,
 ) -> str | None:
-    """Discover the AI Gateway host URL (scheme + netloc only).
+    """Discover the legacy AI Gateway host URL (scheme + netloc only).
 
     Calls GET /api/ai-gateway/v2/endpoints. If successful and endpoints exist,
     extracts the ai_gateway_url from the first endpoint response and returns
@@ -136,61 +136,84 @@ def _discover_ai_gateway_host(
         return None
 
 
+def _is_workspace_ai_gateway_available(
+    http_client: Client,
+    host: str,
+) -> bool:
+    """Check whether the workspace supports the /ai-gateway/ URL prefix.
+
+    Makes a lightweight GET to {host}/ai-gateway/openai/v1/models.
+    The proxy returns a bare 404 with no content-type when the route doesn't
+    exist; the backend always returns JSON (even for error responses).
+    """
+    try:
+        response = http_client.get(f"{host}/ai-gateway/openai/v1/models")
+        content_type = response.headers.get("content-type", "")
+        return response.status_code != 404 or "application/json" in content_type
+    except Exception:
+        return False
+
+
 def _get_ai_gateway_base_url(
     http_client: Client,
     host: str,
+    api_path: str,
 ) -> str | None:
-    """Check if AI Gateway V2 is enabled and return its MLflow base URL.
+    """Return the AI Gateway base URL for the given API path.
 
-    Returns the AI Gateway base URL with /mlflow/v1 path appended, or None if
-    the gateway is not available.
+    Args:
+        http_client: Authorized HTTP client.
+        host: Workspace host URL.
+        api_path: API path prefix, e.g. "mlflow/v1" or "openai/v1".
+
+    Trickle-down resolution order:
+      1. New workspace URL: {host}/ai-gateway/{api_path}
+      2. Legacy *.ai-gateway.* host: {gateway_host}/{api_path}
+      3. None (gateway not available)
     """
+    # Step 1: Try the new workspace-based /ai-gateway/ path
+    if _is_workspace_ai_gateway_available(http_client, host):
+        return f"{host}/ai-gateway/{api_path}"
+
+    # Step 2: Fall back to legacy *.ai-gateway.* hostname
     gateway_host = _discover_ai_gateway_host(http_client, host)
-    return f"{gateway_host}/mlflow/v1" if gateway_host else None
+    return f"{gateway_host}/{api_path}" if gateway_host else None
 
 
 def _resolve_base_url(
     workspace_client: WorkspaceClient,
     base_url: str | None,
-    use_ai_gateway_mlflow_api: bool,
+    use_ai_gateway: bool,
     http_client: Client,
     use_ai_gateway_native_api: bool,
 ) -> str:
     """Resolve the target base URL for the OpenAI client."""
     if use_ai_gateway_native_api and base_url is not None:
         raise ValueError("Cannot specify both 'use_ai_gateway_native_api' and 'base_url'.")
-    if use_ai_gateway_native_api and use_ai_gateway_mlflow_api:
-        raise ValueError(
-            "Cannot specify both 'use_ai_gateway_native_api' and 'use_ai_gateway_mlflow_api'."
-        )
+    if use_ai_gateway_native_api and use_ai_gateway:
+        raise ValueError("Cannot specify both 'use_ai_gateway_native_api' and 'use_ai_gateway'.")
 
     if base_url is not None:
         if _DATABRICKS_APPS_DOMAIN in base_url:
             _validate_oauth_for_apps(workspace_client)
         return base_url
 
-    # Native provider API via AI Gateway (e.g. OpenAI-compatible /openai path)
-    if use_ai_gateway_native_api:
-        gateway_host = _discover_ai_gateway_host(http_client, workspace_client.config.host)
-        if gateway_host:
-            return f"{gateway_host}/openai/v1"
-        raise ValueError(
-            "Please ensure AI Gateway V2 is enabled for the workspace "
-            "when use_ai_gateway_native_api is set to True."
-        )
+    host = workspace_client.config.host
 
-    # MLflow-format AI Gateway endpoints
-    if use_ai_gateway_mlflow_api:
-        gateway_url = _get_ai_gateway_base_url(http_client, workspace_client.config.host)
+    # AI Gateway routing
+    if use_ai_gateway_native_api or use_ai_gateway:
+        api_path = "openai/v1" if use_ai_gateway_native_api else "mlflow/v1"
+        gateway_url = _get_ai_gateway_base_url(http_client, host, api_path)
         if gateway_url:
             return gateway_url
+        flag_name = "use_ai_gateway_native_api" if use_ai_gateway_native_api else "use_ai_gateway"
         raise ValueError(
             "Please ensure AI Gateway V2 is enabled for the workspace "
-            "when use_ai_gateway_mlflow_api is set to True."
+            f"when {flag_name} is set to True."
         )
 
     # Fallback to using serving endpoints
-    return f"{workspace_client.config.host}/serving-endpoints"
+    return f"{host}/serving-endpoints"
 
 
 def _get_authorized_http_client(workspace_client: WorkspaceClient) -> Client:
@@ -396,10 +419,9 @@ class DatabricksOpenAI(OpenAI):
         use_ai_gateway_native_api: If True, auto-detect AI Gateway V2 and route requests through
             its native OpenAI-compatible API (``<ai_gateway_url>/openai/v1``). This allows use of
             provider-native features not available through the MLflow API. Cannot be combined
-            with ``base_url`` or ``use_ai_gateway_mlflow_api``. Defaults to False.
-        use_ai_gateway_mlflow_api: If True, auto-detect AI Gateway V2 availability and route
-            requests through it using the MLflow API (``<ai_gateway_url>/mlflow/v1``).
-            Defaults to False.
+            with ``base_url`` or ``use_ai_gateway``. Defaults to False.
+        use_ai_gateway: If True, auto-detect AI Gateway V2 availability and route
+            requests through it using the MLflow API. Defaults to False.
 
     Example - Query a serving or AI gateway endpoint:
         >>> client = DatabricksOpenAI()
@@ -441,7 +463,7 @@ class DatabricksOpenAI(OpenAI):
         workspace_client: WorkspaceClient | None = None,
         base_url: str | None = None,
         use_ai_gateway_native_api: bool = False,
-        use_ai_gateway_mlflow_api: bool = False,
+        use_ai_gateway: bool = False,
     ):
         if workspace_client is None:
             workspace_client = WorkspaceClient()
@@ -450,11 +472,7 @@ class DatabricksOpenAI(OpenAI):
 
         http_client = _get_authorized_http_client(workspace_client)
         target_base_url = _resolve_base_url(
-            workspace_client,
-            base_url,
-            use_ai_gateway_mlflow_api,
-            http_client,
-            use_ai_gateway_native_api,
+            workspace_client, base_url, use_ai_gateway, http_client, use_ai_gateway_native_api
         )
 
         # Authentication is handled via http_client, not api_key
@@ -563,10 +581,9 @@ class AsyncDatabricksOpenAI(AsyncOpenAI):
         use_ai_gateway_native_api: If True, auto-detect AI Gateway V2 and route requests through
             its native OpenAI-compatible API (``<ai_gateway_url>/openai/v1``). This allows use of
             provider-native features not available through the MLflow API. Cannot be combined
-            with ``base_url`` or ``use_ai_gateway_mlflow_api``. Defaults to False.
-        use_ai_gateway_mlflow_api: If True, auto-detect AI Gateway V2 availability and route
-            requests through it using the MLflow API (``<ai_gateway_url>/mlflow/v1``).
-            Defaults to False.
+            with ``base_url`` or ``use_ai_gateway``. Defaults to False.
+        use_ai_gateway: If True, auto-detect AI Gateway V2 availability and route
+            requests through it using the MLflow API. Defaults to False.
 
     Example - Query a serving or AI gateway endpoint:
         >>> client = AsyncDatabricksOpenAI()
@@ -608,7 +625,7 @@ class AsyncDatabricksOpenAI(AsyncOpenAI):
         workspace_client: WorkspaceClient | None = None,
         base_url: str | None = None,
         use_ai_gateway_native_api: bool = False,
-        use_ai_gateway_mlflow_api: bool = False,
+        use_ai_gateway: bool = False,
     ):
         if workspace_client is None:
             workspace_client = WorkspaceClient()
@@ -617,11 +634,7 @@ class AsyncDatabricksOpenAI(AsyncOpenAI):
 
         sync_http_client = _get_authorized_http_client(workspace_client)
         target_base_url = _resolve_base_url(
-            workspace_client,
-            base_url,
-            use_ai_gateway_mlflow_api,
-            sync_http_client,
-            use_ai_gateway_native_api,
+            workspace_client, base_url, use_ai_gateway, sync_http_client, use_ai_gateway_native_api
         )
 
         # Authentication is handled via http_client, not api_key

--- a/integrations/openai/src/databricks_openai/utils/clients.py
+++ b/integrations/openai/src/databricks_openai/utils/clients.py
@@ -113,7 +113,7 @@ def _discover_ai_gateway_host(
     http_client: Client,
     host: str,
 ) -> str | None:
-    """Discover the legacy AI Gateway host URL (scheme + netloc only).
+    """Discover the AI Gateway host URL (scheme + netloc only).
 
     Calls GET /api/ai-gateway/v2/endpoints. If successful and endpoints exist,
     extracts the ai_gateway_url from the first endpoint response and returns
@@ -142,10 +142,13 @@ def _is_workspace_ai_gateway_available(
 ) -> bool:
     """Check whether the workspace supports the /ai-gateway/ URL prefix.
 
-    Makes a lightweight GET to {host}/ai-gateway/mlflow/v1/chat/completions.
-    The proxy returns a bare 404 with no content-type when the route doesn't
-    exist; the backend always returns JSON (even for error responses like
-    400 "Missing required 'model' parameter").
+    Sends a lightweight GET to {host}/ai-gateway/mlflow/v1/chat/completions.
+
+    Two possible outcomes:
+      - Request reaches the AI Gateway backend: the backend responds with JSON
+        which means the route is live → return True.
+      - Proxy blocks the request: returns a bare 404 with no content-type,
+        meaning /ai-gateway/ is not configured on this workspace → return False.
     """
     try:
         response = http_client.get(f"{host}/ai-gateway/mlflow/v1/chat/completions")
@@ -174,11 +177,9 @@ def _get_ai_gateway_base_url(
       2. Legacy *.ai-gateway.* host: {gateway_host}/{api_path}
       3. None (gateway not available)
     """
-    # Step 1: Try the new workspace-based /ai-gateway/ path
     if _is_workspace_ai_gateway_available(http_client, host):
         return f"{host}/ai-gateway/{api_path}"
 
-    # Step 2: Fall back to legacy *.ai-gateway.* hostname
     gateway_host = _discover_ai_gateway_host(http_client, host)
     return f"{gateway_host}/{api_path}" if gateway_host else None
 
@@ -204,12 +205,19 @@ def _resolve_base_url(
     host = workspace_client.config.host
 
     # AI Gateway routing
-    if use_ai_gateway_native_api or use_ai_gateway:
-        api_path = "openai/v1" if use_ai_gateway_native_api else "mlflow/v1"
+    if use_ai_gateway_native_api:
+        api_path = "openai/v1"
+        flag_name = "use_ai_gateway_native_api"
+    elif use_ai_gateway:
+        api_path = "mlflow/v1"
+        flag_name = "use_ai_gateway"
+    else:
+        api_path = None
+
+    if api_path:
         gateway_url = _get_ai_gateway_base_url(http_client, host, api_path)
         if gateway_url:
             return gateway_url
-        flag_name = "use_ai_gateway_native_api" if use_ai_gateway_native_api else "use_ai_gateway"
         raise ValueError(
             "Please ensure AI Gateway V2 is enabled for the workspace "
             f"when {flag_name} is set to True."

--- a/integrations/openai/src/databricks_openai/utils/clients.py
+++ b/integrations/openai/src/databricks_openai/utils/clients.py
@@ -142,14 +142,17 @@ def _is_workspace_ai_gateway_available(
 ) -> bool:
     """Check whether the workspace supports the /ai-gateway/ URL prefix.
 
-    Makes a lightweight GET to {host}/ai-gateway/openai/v1/models.
+    Makes a lightweight GET to {host}/ai-gateway/mlflow/v1/chat/completions.
     The proxy returns a bare 404 with no content-type when the route doesn't
-    exist; the backend always returns JSON (even for error responses).
+    exist; the backend always returns JSON (even for error responses like
+    400 "Missing required 'model' parameter").
     """
     try:
-        response = http_client.get(f"{host}/ai-gateway/openai/v1/models")
+        response = http_client.get(f"{host}/ai-gateway/mlflow/v1/chat/completions")
         content_type = response.headers.get("content-type", "")
-        return response.status_code != 404 or "application/json" in content_type
+        if "application/json" in content_type:
+            return True
+        return response.status_code != 404
     except Exception:
         return False
 

--- a/integrations/openai/src/databricks_openai/utils/clients.py
+++ b/integrations/openai/src/databricks_openai/utils/clients.py
@@ -152,15 +152,17 @@ def _get_ai_gateway_base_url(
 def _resolve_base_url(
     workspace_client: WorkspaceClient,
     base_url: str | None,
-    use_ai_gateway: bool,
+    use_ai_gateway_mlflow_api: bool,
     http_client: Client,
     use_ai_gateway_native_api: bool,
 ) -> str:
     """Resolve the target base URL for the OpenAI client."""
     if use_ai_gateway_native_api and base_url is not None:
         raise ValueError("Cannot specify both 'use_ai_gateway_native_api' and 'base_url'.")
-    if use_ai_gateway_native_api and use_ai_gateway:
-        raise ValueError("Cannot specify both 'use_ai_gateway_native_api' and 'use_ai_gateway'.")
+    if use_ai_gateway_native_api and use_ai_gateway_mlflow_api:
+        raise ValueError(
+            "Cannot specify both 'use_ai_gateway_native_api' and 'use_ai_gateway_mlflow_api'."
+        )
 
     if base_url is not None:
         if _DATABRICKS_APPS_DOMAIN in base_url:
@@ -178,13 +180,13 @@ def _resolve_base_url(
         )
 
     # MLflow-format AI Gateway endpoints
-    if use_ai_gateway:
+    if use_ai_gateway_mlflow_api:
         gateway_url = _get_ai_gateway_base_url(http_client, workspace_client.config.host)
         if gateway_url:
             return gateway_url
         raise ValueError(
             "Please ensure AI Gateway V2 is enabled for the workspace "
-            "when use_ai_gateway is set to True."
+            "when use_ai_gateway_mlflow_api is set to True."
         )
 
     # Fallback to using serving endpoints
@@ -394,9 +396,10 @@ class DatabricksOpenAI(OpenAI):
         use_ai_gateway_native_api: If True, auto-detect AI Gateway V2 and route requests through
             its native OpenAI-compatible API (``<ai_gateway_url>/openai/v1``). This allows use of
             provider-native features not available through the MLflow API. Cannot be combined
-            with ``base_url`` or ``use_ai_gateway``. Defaults to False.
-        use_ai_gateway: If True, auto-detect AI Gateway V2 availability and route
-            requests through it using the MLflow API. Defaults to False.
+            with ``base_url`` or ``use_ai_gateway_mlflow_api``. Defaults to False.
+        use_ai_gateway_mlflow_api: If True, auto-detect AI Gateway V2 availability and route
+            requests through it using the MLflow API (``<ai_gateway_url>/mlflow/v1``).
+            Defaults to False.
 
     Example - Query a serving or AI gateway endpoint:
         >>> client = DatabricksOpenAI()
@@ -438,7 +441,7 @@ class DatabricksOpenAI(OpenAI):
         workspace_client: WorkspaceClient | None = None,
         base_url: str | None = None,
         use_ai_gateway_native_api: bool = False,
-        use_ai_gateway: bool = False,
+        use_ai_gateway_mlflow_api: bool = False,
     ):
         if workspace_client is None:
             workspace_client = WorkspaceClient()
@@ -447,7 +450,11 @@ class DatabricksOpenAI(OpenAI):
 
         http_client = _get_authorized_http_client(workspace_client)
         target_base_url = _resolve_base_url(
-            workspace_client, base_url, use_ai_gateway, http_client, use_ai_gateway_native_api
+            workspace_client,
+            base_url,
+            use_ai_gateway_mlflow_api,
+            http_client,
+            use_ai_gateway_native_api,
         )
 
         # Authentication is handled via http_client, not api_key
@@ -556,9 +563,10 @@ class AsyncDatabricksOpenAI(AsyncOpenAI):
         use_ai_gateway_native_api: If True, auto-detect AI Gateway V2 and route requests through
             its native OpenAI-compatible API (``<ai_gateway_url>/openai/v1``). This allows use of
             provider-native features not available through the MLflow API. Cannot be combined
-            with ``base_url`` or ``use_ai_gateway``. Defaults to False.
-        use_ai_gateway: If True, auto-detect AI Gateway V2 availability and route
-            requests through it using the MLflow API. Defaults to False.
+            with ``base_url`` or ``use_ai_gateway_mlflow_api``. Defaults to False.
+        use_ai_gateway_mlflow_api: If True, auto-detect AI Gateway V2 availability and route
+            requests through it using the MLflow API (``<ai_gateway_url>/mlflow/v1``).
+            Defaults to False.
 
     Example - Query a serving or AI gateway endpoint:
         >>> client = AsyncDatabricksOpenAI()
@@ -600,7 +608,7 @@ class AsyncDatabricksOpenAI(AsyncOpenAI):
         workspace_client: WorkspaceClient | None = None,
         base_url: str | None = None,
         use_ai_gateway_native_api: bool = False,
-        use_ai_gateway: bool = False,
+        use_ai_gateway_mlflow_api: bool = False,
     ):
         if workspace_client is None:
             workspace_client = WorkspaceClient()
@@ -609,7 +617,11 @@ class AsyncDatabricksOpenAI(AsyncOpenAI):
 
         sync_http_client = _get_authorized_http_client(workspace_client)
         target_base_url = _resolve_base_url(
-            workspace_client, base_url, use_ai_gateway, sync_http_client, use_ai_gateway_native_api
+            workspace_client,
+            base_url,
+            use_ai_gateway_mlflow_api,
+            sync_http_client,
+            use_ai_gateway_native_api,
         )
 
         # Authentication is handled via http_client, not api_key

--- a/integrations/openai/src/databricks_openai/utils/clients.py
+++ b/integrations/openai/src/databricks_openai/utils/clients.py
@@ -3,7 +3,7 @@ from typing import Any, Generator
 from urllib.parse import urlparse
 
 from databricks.sdk import WorkspaceClient
-from httpx import AsyncClient, Auth, Client, Request, Response
+from httpx import URL, AsyncClient, Auth, Client, Request, Response
 from openai import APIConnectionError, APIStatusError, AsyncOpenAI, OpenAI
 from openai.resources.chat import AsyncChat, Chat
 from openai.resources.chat.completions import AsyncCompletions, Completions
@@ -363,7 +363,8 @@ def _truncate_input_ids(input_items: Any) -> None:
 
 
 class DatabricksResponses(Responses):
-    """Responses resource that handles apps/ prefix routing and id truncation."""
+    """Responses resource that handles apps/ prefix routing, id truncation,
+    and base URL swapping for AI Gateway mlflow/v1 → openai/v1."""
 
     def __init__(self, client, workspace_client: WorkspaceClient):
         super().__init__(client)
@@ -395,7 +396,17 @@ class DatabricksResponses(Responses):
             except (APIStatusError, APIConnectionError) as e:
                 raise _wrap_app_error(e, app_name) from e
 
-        response = super().create(**kwargs)
+        # When using use_ai_gateway (mlflow/v1), swap to openai/v1 for responses
+        openai_base_url = getattr(self._client, "_openai_base_url", None)
+        if openai_base_url:
+            original_base_url = self._client._base_url
+            self._client._base_url = URL(f"{openai_base_url}/")
+            try:
+                response = super().create(**kwargs)
+            finally:
+                self._client._base_url = original_base_url
+        else:
+            response = super().create(**kwargs)
         _truncate_response_ids(response)
         return response
 
@@ -478,6 +489,13 @@ class DatabricksOpenAI(OpenAI):
             workspace_client, base_url, use_ai_gateway, http_client, use_ai_gateway_native_api
         )
 
+        # When using use_ai_gateway (mlflow/v1), store the gateway root so that
+        # DatabricksResponses can swap to openai/v1 for the responses API.
+        self._openai_base_url: str | None = None
+        if use_ai_gateway and target_base_url.endswith("/mlflow/v1"):
+            gateway_root = target_base_url[: -len("/mlflow/v1")]
+            self._openai_base_url = f"{gateway_root}/openai/v1"
+
         # Authentication is handled via http_client, not api_key
         super().__init__(
             base_url=target_base_url,
@@ -525,7 +543,8 @@ class AsyncDatabricksChat(AsyncChat):
 
 
 class AsyncDatabricksResponses(AsyncResponses):
-    """Async Responses resource that handles apps/ prefix routing and id truncation."""
+    """Async Responses resource that handles apps/ prefix routing, id truncation,
+    and base URL swapping for AI Gateway mlflow/v1 → openai/v1."""
 
     def __init__(self, client, workspace_client: WorkspaceClient):
         super().__init__(client)
@@ -557,7 +576,17 @@ class AsyncDatabricksResponses(AsyncResponses):
             except (APIStatusError, APIConnectionError) as e:
                 raise _wrap_app_error(e, app_name) from e
 
-        response = await super().create(**kwargs)
+        # When using use_ai_gateway (mlflow/v1), swap to openai/v1 for responses
+        openai_base_url = getattr(self._client, "_openai_base_url", None)
+        if openai_base_url:
+            original_base_url = self._client._base_url
+            self._client._base_url = URL(f"{openai_base_url}/")
+            try:
+                response = await super().create(**kwargs)
+            finally:
+                self._client._base_url = original_base_url
+        else:
+            response = await super().create(**kwargs)
         _truncate_response_ids(response)
         return response
 
@@ -639,6 +668,13 @@ class AsyncDatabricksOpenAI(AsyncOpenAI):
         target_base_url = _resolve_base_url(
             workspace_client, base_url, use_ai_gateway, sync_http_client, use_ai_gateway_native_api
         )
+
+        # When using use_ai_gateway (mlflow/v1), store the gateway root so that
+        # AsyncDatabricksResponses can swap to openai/v1 for the responses API.
+        self._openai_base_url: str | None = None
+        if use_ai_gateway and target_base_url.endswith("/mlflow/v1"):
+            gateway_root = target_base_url[: -len("/mlflow/v1")]
+            self._openai_base_url = f"{gateway_root}/openai/v1"
 
         # Authentication is handled via http_client, not api_key
         super().__init__(

--- a/integrations/openai/src/databricks_openai/utils/clients.py
+++ b/integrations/openai/src/databricks_openai/utils/clients.py
@@ -1,7 +1,5 @@
 import os
 from typing import Any, Generator
-from urllib.parse import urlparse
-
 from databricks.sdk import WorkspaceClient
 from httpx import AsyncClient, Auth, Client, Request, Response
 from openai import APIConnectionError, APIStatusError, AsyncOpenAI, OpenAI
@@ -109,86 +107,10 @@ def _fix_empty_assistant_content_in_messages(messages: Any) -> None:
                 message["content"] = " "
 
 
-def _discover_ai_gateway_host(
-    http_client: Client,
-    host: str,
-) -> str | None:
-    """Discover the AI Gateway host URL (scheme + netloc only).
-
-    Calls GET /api/ai-gateway/v2/endpoints. If successful and endpoints exist,
-    extracts the ai_gateway_url from the first endpoint response and returns
-    just the scheme + netloc (no path). Returns None if gateway is not available.
-    """
-    try:
-        response = http_client.get(f"{host}/api/ai-gateway/v2/endpoints")
-        if response.status_code != 200:
-            return None
-        data = response.json()
-        endpoints = data.get("endpoints", [])
-        if not endpoints:
-            return None
-        gateway_url = endpoints[0].get("ai_gateway_url")
-        if not gateway_url:
-            return None
-        parsed = urlparse(gateway_url)
-        return f"{parsed.scheme}://{parsed.netloc}"
-    except Exception:
-        return None
-
-
-def _is_workspace_ai_gateway_available(
-    http_client: Client,
-    host: str,
-) -> bool:
-    """Check whether the workspace supports the /ai-gateway/ URL prefix.
-
-    Sends a lightweight GET to {host}/ai-gateway/mlflow/v1/chat/completions.
-
-    Two possible outcomes:
-      - Request reaches the AI Gateway backend: the backend responds with JSON
-        which means the route is live → return True.
-      - Proxy blocks the request: returns a bare 404 with no content-type,
-        meaning /ai-gateway/ is not configured on this workspace → return False.
-    """
-    try:
-        response = http_client.get(f"{host}/ai-gateway/mlflow/v1/chat/completions")
-        content_type = response.headers.get("content-type", "")
-        if "application/json" in content_type:
-            return True
-        return response.status_code != 404
-    except Exception:
-        return False
-
-
-def _get_ai_gateway_base_url(
-    http_client: Client,
-    host: str,
-    api_path: str,
-) -> str | None:
-    """Return the AI Gateway base URL for the given API path.
-
-    Args:
-        http_client: Authorized HTTP client.
-        host: Workspace host URL.
-        api_path: API path prefix, e.g. "mlflow/v1" or "openai/v1".
-
-    Trickle-down resolution order:
-      1. New workspace URL: {host}/ai-gateway/{api_path}
-      2. Legacy *.ai-gateway.* host: {gateway_host}/{api_path}
-      3. None (gateway not available)
-    """
-    if _is_workspace_ai_gateway_available(http_client, host):
-        return f"{host}/ai-gateway/{api_path}"
-
-    gateway_host = _discover_ai_gateway_host(http_client, host)
-    return f"{gateway_host}/{api_path}" if gateway_host else None
-
-
 def _resolve_base_url(
     workspace_client: WorkspaceClient,
     base_url: str | None,
     use_ai_gateway: bool,
-    http_client: Client,
     use_ai_gateway_native_api: bool,
 ) -> str:
     """Resolve the target base URL for the OpenAI client."""
@@ -204,24 +126,11 @@ def _resolve_base_url(
 
     host = workspace_client.config.host
 
-    # AI Gateway routing
+    # AI Gateway routing: {host}/ai-gateway/{api_path}
     if use_ai_gateway_native_api:
-        api_path = "openai/v1"
-        flag_name = "use_ai_gateway_native_api"
+        return f"{host}/ai-gateway/openai/v1"
     elif use_ai_gateway:
-        api_path = "mlflow/v1"
-        flag_name = "use_ai_gateway"
-    else:
-        api_path = None
-
-    if api_path:
-        gateway_url = _get_ai_gateway_base_url(http_client, host, api_path)
-        if gateway_url:
-            return gateway_url
-        raise ValueError(
-            "Please ensure AI Gateway V2 is enabled for the workspace "
-            f"when {flag_name} is set to True."
-        )
+        return f"{host}/ai-gateway/mlflow/v1"
 
     # Fallback to using serving endpoints
     return f"{host}/serving-endpoints"
@@ -481,16 +390,15 @@ class DatabricksOpenAI(OpenAI):
 
         self._workspace_client = workspace_client
 
-        http_client = _get_authorized_http_client(workspace_client)
         target_base_url = _resolve_base_url(
-            workspace_client, base_url, use_ai_gateway, http_client, use_ai_gateway_native_api
+            workspace_client, base_url, use_ai_gateway, use_ai_gateway_native_api
         )
 
         # Authentication is handled via http_client, not api_key
         super().__init__(
             base_url=target_base_url,
             api_key=_get_openai_api_key(),
-            http_client=http_client,
+            http_client=_get_authorized_http_client(workspace_client),
         )
 
     @override
@@ -643,9 +551,8 @@ class AsyncDatabricksOpenAI(AsyncOpenAI):
 
         self._workspace_client = workspace_client
 
-        sync_http_client = _get_authorized_http_client(workspace_client)
         target_base_url = _resolve_base_url(
-            workspace_client, base_url, use_ai_gateway, sync_http_client, use_ai_gateway_native_api
+            workspace_client, base_url, use_ai_gateway, use_ai_gateway_native_api
         )
 
         # Authentication is handled via http_client, not api_key

--- a/integrations/openai/src/databricks_openai/utils/clients.py
+++ b/integrations/openai/src/databricks_openai/utils/clients.py
@@ -1,5 +1,6 @@
 import os
 from typing import Any, Generator
+
 from databricks.sdk import WorkspaceClient
 from httpx import AsyncClient, Auth, Client, Request, Response
 from openai import APIConnectionError, APIStatusError, AsyncOpenAI, OpenAI

--- a/integrations/openai/tests/unit_tests/test_clients.py
+++ b/integrations/openai/tests/unit_tests/test_clients.py
@@ -783,9 +783,7 @@ class TestDatabricksOpenAIWithGateway:
         client_cls = (
             DatabricksOpenAI if client_cls_name == "DatabricksOpenAI" else AsyncDatabricksOpenAI
         )
-        client = client_cls(
-            workspace_client=mock_workspace_client, use_ai_gateway_native_api=True
-        )
+        client = client_cls(workspace_client=mock_workspace_client, use_ai_gateway_native_api=True)
         assert "/ai-gateway/openai/v1" in str(client.base_url)
         assert "test.databricks.com" in str(client.base_url)
 
@@ -836,4 +834,3 @@ class TestDatabricksOpenAIWithGateway:
                 use_ai_gateway_native_api=True,
                 use_ai_gateway=True,
             )
-

--- a/integrations/openai/tests/unit_tests/test_clients.py
+++ b/integrations/openai/tests/unit_tests/test_clients.py
@@ -784,7 +784,7 @@ class TestWorkspaceAIGatewayDetection:
         mock_client.get.return_value = _mock_httpx_response(200)
         assert _is_workspace_ai_gateway_available(mock_client, "https://test.databricks.com")
         mock_client.get.assert_called_once_with(
-            "https://test.databricks.com/ai-gateway/openai/v1/models"
+            "https://test.databricks.com/ai-gateway/mlflow/v1/chat/completions"
         )
 
     def test_available_on_json_404(self):
@@ -833,7 +833,7 @@ class TestAIGatewayV2Detection:
         mock_client = MagicMock(spec=httpx.Client)
 
         def mock_get(url):
-            if "/ai-gateway/openai/v1/models" in url:
+            if "/ai-gateway/mlflow/v1/chat/completions" in url:
                 return _mock_httpx_response(404, content_type="")
             if "api/ai-gateway/v2/endpoints" in url:
                 return _mock_httpx_response(
@@ -860,7 +860,7 @@ class TestAIGatewayV2Detection:
         mock_client = MagicMock(spec=httpx.Client)
 
         def mock_get(url):
-            if "/ai-gateway/openai/v1/models" in url:
+            if "/ai-gateway/mlflow/v1/chat/completions" in url:
                 return _mock_httpx_response(404, content_type="")
             if "api/ai-gateway/v2/endpoints" in url:
                 return _mock_httpx_response(
@@ -893,7 +893,7 @@ class TestAIGatewayV2Detection:
         mock_client = MagicMock(spec=httpx.Client)
 
         def mock_get(url):
-            if "/ai-gateway/openai/v1/models" in url:
+            if "/ai-gateway/mlflow/v1/chat/completions" in url:
                 return _mock_httpx_response(404, content_type="")
             return _mock_httpx_response(200, {"endpoints": []})
 
@@ -907,7 +907,7 @@ class TestAIGatewayV2Detection:
         mock_client = MagicMock(spec=httpx.Client)
 
         def mock_get(url):
-            if "/ai-gateway/openai/v1/models" in url:
+            if "/ai-gateway/mlflow/v1/chat/completions" in url:
                 return _mock_httpx_response(404, content_type="")
             return _mock_httpx_response(200, {"endpoints": [{"name": "my-endpoint"}]})
 
@@ -921,7 +921,7 @@ class TestAIGatewayV2Detection:
         mock_client = MagicMock(spec=httpx.Client)
 
         def mock_get(url):
-            if "/ai-gateway/openai/v1/models" in url:
+            if "/ai-gateway/mlflow/v1/chat/completions" in url:
                 return _mock_httpx_response(404, content_type="")
             return _mock_httpx_response(
                 200,

--- a/integrations/openai/tests/unit_tests/test_clients.py
+++ b/integrations/openai/tests/unit_tests/test_clients.py
@@ -1037,66 +1037,6 @@ class TestDatabricksOpenAIWithGateway:
             assert "custom.example.com" in str(client.base_url)
 
 
-class TestAIGatewayResponsesRouting:
-    """Tests that responses.create() swaps to openai/v1 when use_ai_gateway=True."""
-
-    @pytest.mark.parametrize("client_cls_name", ["DatabricksOpenAI", "AsyncDatabricksOpenAI"])
-    def test_use_ai_gateway_sets_openai_base_url(self, client_cls_name, mock_workspace_client):
-        """use_ai_gateway stores _openai_base_url for responses routing."""
-        client_cls = (
-            DatabricksOpenAI if client_cls_name == "DatabricksOpenAI" else AsyncDatabricksOpenAI
-        )
-        with patch(
-            "databricks_openai.utils.clients._get_ai_gateway_base_url",
-            return_value="https://12345.ai-gateway.cloud.databricks.com/mlflow/v1",
-        ):
-            client = client_cls(workspace_client=mock_workspace_client, use_ai_gateway=True)
-            assert client._openai_base_url == "https://12345.ai-gateway.cloud.databricks.com/openai/v1"
-
-    @pytest.mark.parametrize("client_cls_name", ["DatabricksOpenAI", "AsyncDatabricksOpenAI"])
-    def test_use_ai_gateway_workspace_url_sets_openai_base_url(
-        self, client_cls_name, mock_workspace_client
-    ):
-        """use_ai_gateway with workspace URL stores correct _openai_base_url."""
-        client_cls = (
-            DatabricksOpenAI if client_cls_name == "DatabricksOpenAI" else AsyncDatabricksOpenAI
-        )
-        with patch(
-            "databricks_openai.utils.clients._get_ai_gateway_base_url",
-            return_value="https://test.databricks.com/ai-gateway/mlflow/v1",
-        ):
-            client = client_cls(workspace_client=mock_workspace_client, use_ai_gateway=True)
-            assert client._openai_base_url == "https://test.databricks.com/ai-gateway/openai/v1"
-
-    @pytest.mark.parametrize("client_cls_name", ["DatabricksOpenAI", "AsyncDatabricksOpenAI"])
-    def test_native_api_does_not_set_openai_base_url(
-        self, client_cls_name, mock_workspace_client
-    ):
-        """use_ai_gateway_native_api already uses openai/v1, no swap needed."""
-        client_cls = (
-            DatabricksOpenAI if client_cls_name == "DatabricksOpenAI" else AsyncDatabricksOpenAI
-        )
-        with patch(
-            "databricks_openai.utils.clients._get_ai_gateway_base_url",
-            return_value="https://12345.ai-gateway.cloud.databricks.com/openai/v1",
-        ):
-            client = client_cls(
-                workspace_client=mock_workspace_client, use_ai_gateway_native_api=True
-            )
-            assert client._openai_base_url is None
-
-    @pytest.mark.parametrize("client_cls_name", ["DatabricksOpenAI", "AsyncDatabricksOpenAI"])
-    def test_no_gateway_does_not_set_openai_base_url(
-        self, client_cls_name, mock_workspace_client
-    ):
-        """No gateway flags → no _openai_base_url."""
-        client_cls = (
-            DatabricksOpenAI if client_cls_name == "DatabricksOpenAI" else AsyncDatabricksOpenAI
-        )
-        client = client_cls(workspace_client=mock_workspace_client)
-        assert client._openai_base_url is None
-
-
 class TestAIGatewayNativeAPI:
     """Tests for use_ai_gateway_native_api parameter in DatabricksOpenAI and AsyncDatabricksOpenAI."""
 

--- a/integrations/openai/tests/unit_tests/test_clients.py
+++ b/integrations/openai/tests/unit_tests/test_clients.py
@@ -1037,6 +1037,66 @@ class TestDatabricksOpenAIWithGateway:
             assert "custom.example.com" in str(client.base_url)
 
 
+class TestAIGatewayResponsesRouting:
+    """Tests that responses.create() swaps to openai/v1 when use_ai_gateway=True."""
+
+    @pytest.mark.parametrize("client_cls_name", ["DatabricksOpenAI", "AsyncDatabricksOpenAI"])
+    def test_use_ai_gateway_sets_openai_base_url(self, client_cls_name, mock_workspace_client):
+        """use_ai_gateway stores _openai_base_url for responses routing."""
+        client_cls = (
+            DatabricksOpenAI if client_cls_name == "DatabricksOpenAI" else AsyncDatabricksOpenAI
+        )
+        with patch(
+            "databricks_openai.utils.clients._get_ai_gateway_base_url",
+            return_value="https://12345.ai-gateway.cloud.databricks.com/mlflow/v1",
+        ):
+            client = client_cls(workspace_client=mock_workspace_client, use_ai_gateway=True)
+            assert client._openai_base_url == "https://12345.ai-gateway.cloud.databricks.com/openai/v1"
+
+    @pytest.mark.parametrize("client_cls_name", ["DatabricksOpenAI", "AsyncDatabricksOpenAI"])
+    def test_use_ai_gateway_workspace_url_sets_openai_base_url(
+        self, client_cls_name, mock_workspace_client
+    ):
+        """use_ai_gateway with workspace URL stores correct _openai_base_url."""
+        client_cls = (
+            DatabricksOpenAI if client_cls_name == "DatabricksOpenAI" else AsyncDatabricksOpenAI
+        )
+        with patch(
+            "databricks_openai.utils.clients._get_ai_gateway_base_url",
+            return_value="https://test.databricks.com/ai-gateway/mlflow/v1",
+        ):
+            client = client_cls(workspace_client=mock_workspace_client, use_ai_gateway=True)
+            assert client._openai_base_url == "https://test.databricks.com/ai-gateway/openai/v1"
+
+    @pytest.mark.parametrize("client_cls_name", ["DatabricksOpenAI", "AsyncDatabricksOpenAI"])
+    def test_native_api_does_not_set_openai_base_url(
+        self, client_cls_name, mock_workspace_client
+    ):
+        """use_ai_gateway_native_api already uses openai/v1, no swap needed."""
+        client_cls = (
+            DatabricksOpenAI if client_cls_name == "DatabricksOpenAI" else AsyncDatabricksOpenAI
+        )
+        with patch(
+            "databricks_openai.utils.clients._get_ai_gateway_base_url",
+            return_value="https://12345.ai-gateway.cloud.databricks.com/openai/v1",
+        ):
+            client = client_cls(
+                workspace_client=mock_workspace_client, use_ai_gateway_native_api=True
+            )
+            assert client._openai_base_url is None
+
+    @pytest.mark.parametrize("client_cls_name", ["DatabricksOpenAI", "AsyncDatabricksOpenAI"])
+    def test_no_gateway_does_not_set_openai_base_url(
+        self, client_cls_name, mock_workspace_client
+    ):
+        """No gateway flags → no _openai_base_url."""
+        client_cls = (
+            DatabricksOpenAI if client_cls_name == "DatabricksOpenAI" else AsyncDatabricksOpenAI
+        )
+        client = client_cls(workspace_client=mock_workspace_client)
+        assert client._openai_base_url is None
+
+
 class TestAIGatewayNativeAPI:
     """Tests for use_ai_gateway_native_api parameter in DatabricksOpenAI and AsyncDatabricksOpenAI."""
 

--- a/integrations/openai/tests/unit_tests/test_clients.py
+++ b/integrations/openai/tests/unit_tests/test_clients.py
@@ -13,11 +13,13 @@ from openai.resources.responses import AsyncResponses, Responses
 
 from databricks_openai import AsyncDatabricksOpenAI, DatabricksOpenAI
 from databricks_openai.utils.clients import (
+    _discover_ai_gateway_host,
     _get_ai_gateway_base_url,
     _get_app_url,
     _get_authorized_async_http_client,
     _get_authorized_http_client,
     _get_openai_api_key,
+    _is_workspace_ai_gateway_available,
     _should_strip_strict,
     _strip_strict_from_kwargs,
     _strip_strict_from_tools,
@@ -763,80 +765,205 @@ class TestOpenAIApiKey:
             assert _get_openai_api_key() == "no-token"
 
 
-def _mock_httpx_response(status_code: int, json_data: Any = None) -> MagicMock:
+def _mock_httpx_response(
+    status_code: int, json_data: Any = None, content_type: str = "application/json"
+) -> MagicMock:
     """Create a mock httpx Response."""
     response = MagicMock()
     response.status_code = status_code
     response.json.return_value = json_data or {}
+    response.headers = {"content-type": content_type}
     return response
 
 
-class TestAIGatewayV2Detection:
-    """Tests for _get_ai_gateway_base_url."""
+class TestWorkspaceAIGatewayDetection:
+    """Tests for _is_workspace_ai_gateway_available."""
 
-    def test_returns_base_url_when_endpoints_exist(self):
+    def test_available_on_200(self):
+        mock_client = MagicMock(spec=httpx.Client)
+        mock_client.get.return_value = _mock_httpx_response(200)
+        assert _is_workspace_ai_gateway_available(mock_client, "https://test.databricks.com")
+        mock_client.get.assert_called_once_with(
+            "https://test.databricks.com/ai-gateway/openai/v1/models"
+        )
+
+    def test_available_on_json_404(self):
+        """A JSON 404 from the backend means the route is live."""
         mock_client = MagicMock(spec=httpx.Client)
         mock_client.get.return_value = _mock_httpx_response(
-            200,
-            {
-                "endpoints": [
-                    {
-                        "name": "databricks-claude-sonnet-4-6",
-                        "id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
-                        "created_by": "Databricks",
-                        "ai_gateway_url": "https://12345.ai-gateway.cloud.databricks.com",
-                    }
-                ]
-            },
+            404, {"error_code": "ENDPOINT_NOT_FOUND"}, content_type="application/json"
         )
-        result = _get_ai_gateway_base_url(mock_client, "https://test.databricks.com")
-        assert result == "https://12345.ai-gateway.cloud.databricks.com/mlflow/v1"
-        mock_client.get.assert_called_once_with(
-            "https://test.databricks.com/api/ai-gateway/v2/endpoints"
-        )
+        assert _is_workspace_ai_gateway_available(mock_client, "https://test.databricks.com")
 
-    def test_returns_none_on_404(self):
+    def test_unavailable_on_bare_404(self):
+        """Bare 404 (no JSON) from proxy means the route doesn't exist."""
         mock_client = MagicMock(spec=httpx.Client)
-        mock_client.get.return_value = _mock_httpx_response(404)
-        result = _get_ai_gateway_base_url(mock_client, "https://test.databricks.com")
+        mock_client.get.return_value = _mock_httpx_response(404, content_type="")
+        assert not _is_workspace_ai_gateway_available(mock_client, "https://test.databricks.com")
+
+    def test_unavailable_on_exception(self):
+        mock_client = MagicMock(spec=httpx.Client)
+        mock_client.get.side_effect = Exception("Connection refused")
+        assert not _is_workspace_ai_gateway_available(mock_client, "https://test.databricks.com")
+
+
+class TestAIGatewayV2Detection:
+    """Tests for _get_ai_gateway_base_url trickle-down resolution."""
+
+    def test_workspace_path_with_mlflow_api(self):
+        """use_ai_gateway → {host}/ai-gateway/mlflow/v1."""
+        mock_client = MagicMock(spec=httpx.Client)
+        mock_client.get.return_value = _mock_httpx_response(200)
+        result = _get_ai_gateway_base_url(
+            mock_client, "https://test.databricks.com", "mlflow/v1"
+        )
+        assert result == "https://test.databricks.com/ai-gateway/mlflow/v1"
+
+    def test_workspace_path_with_openai_api(self):
+        """use_ai_gateway_native_api → {host}/ai-gateway/openai/v1."""
+        mock_client = MagicMock(spec=httpx.Client)
+        mock_client.get.return_value = _mock_httpx_response(200)
+        result = _get_ai_gateway_base_url(
+            mock_client, "https://test.databricks.com", "openai/v1"
+        )
+        assert result == "https://test.databricks.com/ai-gateway/openai/v1"
+
+    def test_falls_back_to_legacy_host_with_mlflow_api(self):
+        """Bare 404 from proxy → legacy host with mlflow/v1."""
+        mock_client = MagicMock(spec=httpx.Client)
+
+        def mock_get(url):
+            if "/ai-gateway/openai/v1/models" in url:
+                return _mock_httpx_response(404, content_type="")
+            if "api/ai-gateway/v2/endpoints" in url:
+                return _mock_httpx_response(
+                    200,
+                    {
+                        "endpoints": [
+                            {
+                                "name": "databricks-claude-sonnet-4-6",
+                                "ai_gateway_url": "https://12345.ai-gateway.cloud.databricks.com",
+                            }
+                        ]
+                    },
+                )
+            return _mock_httpx_response(404, content_type="")
+
+        mock_client.get.side_effect = mock_get
+        result = _get_ai_gateway_base_url(
+            mock_client, "https://test.databricks.com", "mlflow/v1"
+        )
+        assert result == "https://12345.ai-gateway.cloud.databricks.com/mlflow/v1"
+
+    def test_falls_back_to_legacy_host_with_openai_api(self):
+        """Bare 404 from proxy → legacy host with openai/v1."""
+        mock_client = MagicMock(spec=httpx.Client)
+
+        def mock_get(url):
+            if "/ai-gateway/openai/v1/models" in url:
+                return _mock_httpx_response(404, content_type="")
+            if "api/ai-gateway/v2/endpoints" in url:
+                return _mock_httpx_response(
+                    200,
+                    {
+                        "endpoints": [
+                            {
+                                "ai_gateway_url": "https://12345.ai-gateway.cloud.databricks.com",
+                            }
+                        ]
+                    },
+                )
+            return _mock_httpx_response(404, content_type="")
+
+        mock_client.get.side_effect = mock_get
+        result = _get_ai_gateway_base_url(
+            mock_client, "https://test.databricks.com", "openai/v1"
+        )
+        assert result == "https://12345.ai-gateway.cloud.databricks.com/openai/v1"
+
+    def test_returns_none_when_both_unavailable(self):
+        mock_client = MagicMock(spec=httpx.Client)
+        mock_client.get.return_value = _mock_httpx_response(404, content_type="")
+        result = _get_ai_gateway_base_url(
+            mock_client, "https://test.databricks.com", "mlflow/v1"
+        )
         assert result is None
 
     def test_returns_none_on_empty_endpoints(self):
         mock_client = MagicMock(spec=httpx.Client)
-        mock_client.get.return_value = _mock_httpx_response(200, {"endpoints": []})
-        result = _get_ai_gateway_base_url(mock_client, "https://test.databricks.com")
-        assert result is None
 
-    def test_returns_none_on_network_exception(self):
-        mock_client = MagicMock(spec=httpx.Client)
-        mock_client.get.side_effect = Exception("Connection refused")
-        result = _get_ai_gateway_base_url(mock_client, "https://test.databricks.com")
+        def mock_get(url):
+            if "/ai-gateway/openai/v1/models" in url:
+                return _mock_httpx_response(404, content_type="")
+            return _mock_httpx_response(200, {"endpoints": []})
+
+        mock_client.get.side_effect = mock_get
+        result = _get_ai_gateway_base_url(
+            mock_client, "https://test.databricks.com", "mlflow/v1"
+        )
         assert result is None
 
     def test_returns_none_on_missing_ai_gateway_url(self):
         mock_client = MagicMock(spec=httpx.Client)
-        mock_client.get.return_value = _mock_httpx_response(
-            200,
-            {"endpoints": [{"name": "my-endpoint"}]},
+
+        def mock_get(url):
+            if "/ai-gateway/openai/v1/models" in url:
+                return _mock_httpx_response(404, content_type="")
+            return _mock_httpx_response(200, {"endpoints": [{"name": "my-endpoint"}]})
+
+        mock_client.get.side_effect = mock_get
+        result = _get_ai_gateway_base_url(
+            mock_client, "https://test.databricks.com", "mlflow/v1"
         )
-        result = _get_ai_gateway_base_url(mock_client, "https://test.databricks.com")
         assert result is None
 
-    def test_parses_base_url_from_different_workspace(self):
+    def test_legacy_parses_base_url_from_different_workspace(self):
         mock_client = MagicMock(spec=httpx.Client)
-        mock_client.get.return_value = _mock_httpx_response(
-            200,
-            {
-                "endpoints": [
-                    {
-                        "name": "databricks-gpt-5-2",
-                        "ai_gateway_url": "https://ws-123.ai-gateway.us-east-1.cloud.databricks.com",
-                    }
-                ]
-            },
+
+        def mock_get(url):
+            if "/ai-gateway/openai/v1/models" in url:
+                return _mock_httpx_response(404, content_type="")
+            return _mock_httpx_response(
+                200,
+                {
+                    "endpoints": [
+                        {
+                            "name": "databricks-gpt-5-2",
+                            "ai_gateway_url": "https://ws-123.ai-gateway.us-east-1.cloud.databricks.com",
+                        }
+                    ]
+                },
+            )
+
+        mock_client.get.side_effect = mock_get
+        result = _get_ai_gateway_base_url(
+            mock_client, "https://test.databricks.com", "mlflow/v1"
         )
-        result = _get_ai_gateway_base_url(mock_client, "https://test.databricks.com")
         assert result == "https://ws-123.ai-gateway.us-east-1.cloud.databricks.com/mlflow/v1"
+
+    def test_workspace_exception_falls_back_to_legacy(self):
+        """If the workspace probe throws, still try legacy."""
+        mock_client = MagicMock(spec=httpx.Client)
+        call_count = [0]
+
+        def mock_get(url):
+            call_count[0] += 1
+            if call_count[0] == 1:
+                raise Exception("Connection reset")
+            return _mock_httpx_response(
+                200,
+                {
+                    "endpoints": [
+                        {"ai_gateway_url": "https://12345.ai-gateway.cloud.databricks.com"}
+                    ]
+                },
+            )
+
+        mock_client.get.side_effect = mock_get
+        result = _get_ai_gateway_base_url(
+            mock_client, "https://test.databricks.com", "mlflow/v1"
+        )
+        assert result == "https://12345.ai-gateway.cloud.databricks.com/mlflow/v1"
 
 
 class TestDatabricksOpenAIWithGateway:
@@ -851,11 +978,24 @@ class TestDatabricksOpenAIWithGateway:
             "databricks_openai.utils.clients._get_ai_gateway_base_url",
             return_value="https://12345.ai-gateway.cloud.databricks.com/mlflow/v1",
         ):
-            client = client_cls(
-                workspace_client=mock_workspace_client, use_ai_gateway_mlflow_api=True
-            )
+            client = client_cls(workspace_client=mock_workspace_client, use_ai_gateway=True)
             assert "ai-gateway" in str(client.base_url)
             assert "12345.ai-gateway.cloud.databricks.com" in str(client.base_url)
+
+    @pytest.mark.parametrize("client_cls_name", ["DatabricksOpenAI", "AsyncDatabricksOpenAI"])
+    def test_gateway_uses_workspace_url_when_available(
+        self, client_cls_name, mock_workspace_client
+    ):
+        client_cls = (
+            DatabricksOpenAI if client_cls_name == "DatabricksOpenAI" else AsyncDatabricksOpenAI
+        )
+        with patch(
+            "databricks_openai.utils.clients._get_ai_gateway_base_url",
+            return_value="https://test.databricks.com/ai-gateway/mlflow/v1",
+        ):
+            client = client_cls(workspace_client=mock_workspace_client, use_ai_gateway=True)
+            assert "/ai-gateway/mlflow/v1" in str(client.base_url)
+            assert "test.databricks.com" in str(client.base_url)
 
     @pytest.mark.parametrize("client_cls_name", ["DatabricksOpenAI", "AsyncDatabricksOpenAI"])
     def test_gateway_unavailable_raises_error(self, client_cls_name, mock_workspace_client):
@@ -867,7 +1007,7 @@ class TestDatabricksOpenAIWithGateway:
             return_value=None,
         ):
             with pytest.raises(ValueError, match="Please ensure AI Gateway V2 is enabled"):
-                client_cls(workspace_client=mock_workspace_client, use_ai_gateway_mlflow_api=True)
+                client_cls(workspace_client=mock_workspace_client, use_ai_gateway=True)
 
     @pytest.mark.parametrize("client_cls_name", ["DatabricksOpenAI", "AsyncDatabricksOpenAI"])
     def test_gateway_disabled_no_api_call(self, client_cls_name, mock_workspace_client):
@@ -877,9 +1017,7 @@ class TestDatabricksOpenAIWithGateway:
         with patch(
             "databricks_openai.utils.clients._get_ai_gateway_base_url",
         ) as mock_gateway:
-            client = client_cls(
-                workspace_client=mock_workspace_client, use_ai_gateway_mlflow_api=False
-            )
+            client = client_cls(workspace_client=mock_workspace_client, use_ai_gateway=False)
             mock_gateway.assert_not_called()
             assert "/serving-endpoints/" in str(client.base_url)
 
@@ -903,13 +1041,13 @@ class TestAIGatewayNativeAPI:
     """Tests for use_ai_gateway_native_api parameter in DatabricksOpenAI and AsyncDatabricksOpenAI."""
 
     @pytest.mark.parametrize("client_cls_name", ["DatabricksOpenAI", "AsyncDatabricksOpenAI"])
-    def test_native_api_uses_openai_base_path(self, client_cls_name, mock_workspace_client):
+    def test_native_api_uses_openai_base_path_legacy(self, client_cls_name, mock_workspace_client):
         client_cls = (
             DatabricksOpenAI if client_cls_name == "DatabricksOpenAI" else AsyncDatabricksOpenAI
         )
         with patch(
-            "databricks_openai.utils.clients._discover_ai_gateway_host",
-            return_value="https://12345.ai-gateway.cloud.databricks.com",
+            "databricks_openai.utils.clients._get_ai_gateway_base_url",
+            return_value="https://12345.ai-gateway.cloud.databricks.com/openai/v1",
         ):
             client = client_cls(
                 workspace_client=mock_workspace_client,
@@ -919,12 +1057,30 @@ class TestAIGatewayNativeAPI:
             assert "/openai/v1" in str(client.base_url)
 
     @pytest.mark.parametrize("client_cls_name", ["DatabricksOpenAI", "AsyncDatabricksOpenAI"])
+    def test_native_api_uses_workspace_path_when_available(
+        self, client_cls_name, mock_workspace_client
+    ):
+        client_cls = (
+            DatabricksOpenAI if client_cls_name == "DatabricksOpenAI" else AsyncDatabricksOpenAI
+        )
+        with patch(
+            "databricks_openai.utils.clients._get_ai_gateway_base_url",
+            return_value="https://test.databricks.com/ai-gateway/openai/v1",
+        ):
+            client = client_cls(
+                workspace_client=mock_workspace_client,
+                use_ai_gateway_native_api=True,
+            )
+            assert "/ai-gateway/openai/v1" in str(client.base_url)
+            assert "test.databricks.com" in str(client.base_url)
+
+    @pytest.mark.parametrize("client_cls_name", ["DatabricksOpenAI", "AsyncDatabricksOpenAI"])
     def test_native_api_unavailable_raises_error(self, client_cls_name, mock_workspace_client):
         client_cls = (
             DatabricksOpenAI if client_cls_name == "DatabricksOpenAI" else AsyncDatabricksOpenAI
         )
         with patch(
-            "databricks_openai.utils.clients._discover_ai_gateway_host",
+            "databricks_openai.utils.clients._get_ai_gateway_base_url",
             return_value=None,
         ):
             with pytest.raises(ValueError, match="Please ensure AI Gateway V2 is enabled"):
@@ -948,28 +1104,22 @@ class TestAIGatewayNativeAPI:
             )
 
     @pytest.mark.parametrize("client_cls_name", ["DatabricksOpenAI", "AsyncDatabricksOpenAI"])
-    def test_native_api_and_use_ai_gateway_mlflow_api_raises(
-        self, client_cls_name, mock_workspace_client
-    ):
+    def test_native_api_and_use_ai_gateway_raises(self, client_cls_name, mock_workspace_client):
         client_cls = (
             DatabricksOpenAI if client_cls_name == "DatabricksOpenAI" else AsyncDatabricksOpenAI
         )
         with pytest.raises(
             ValueError,
-            match="Cannot specify both 'use_ai_gateway_native_api' and 'use_ai_gateway_mlflow_api'",
+            match="Cannot specify both 'use_ai_gateway_native_api' and 'use_ai_gateway'",
         ):
             client_cls(
                 workspace_client=mock_workspace_client,
                 use_ai_gateway_native_api=True,
-                use_ai_gateway_mlflow_api=True,
+                use_ai_gateway=True,
             )
 
     def test_discover_ai_gateway_host_strips_path(self):
         """_discover_ai_gateway_host returns only scheme+netloc, stripping any path."""
-        from unittest.mock import MagicMock
-
-        from databricks_openai.utils.clients import _discover_ai_gateway_host
-
         mock_http = MagicMock()
         mock_http.get.return_value.status_code = 200
         mock_http.get.return_value.json.return_value = {

--- a/integrations/openai/tests/unit_tests/test_clients.py
+++ b/integrations/openai/tests/unit_tests/test_clients.py
@@ -13,13 +13,10 @@ from openai.resources.responses import AsyncResponses, Responses
 
 from databricks_openai import AsyncDatabricksOpenAI, DatabricksOpenAI
 from databricks_openai.utils.clients import (
-    _discover_ai_gateway_host,
-    _get_ai_gateway_base_url,
     _get_app_url,
     _get_authorized_async_http_client,
     _get_authorized_http_client,
     _get_openai_api_key,
-    _is_workspace_ai_gateway_available,
     _should_strip_strict,
     _strip_strict_from_kwargs,
     _strip_strict_from_tools,
@@ -765,329 +762,51 @@ class TestOpenAIApiKey:
             assert _get_openai_api_key() == "no-token"
 
 
-def _mock_httpx_response(
-    status_code: int, json_data: Any = None, content_type: str = "application/json"
-) -> MagicMock:
-    """Create a mock httpx Response."""
-    response = MagicMock()
-    response.status_code = status_code
-    response.json.return_value = json_data or {}
-    response.headers = {"content-type": content_type}
-    return response
-
-
-class TestWorkspaceAIGatewayDetection:
-    """Tests for _is_workspace_ai_gateway_available."""
-
-    def test_available_on_200(self):
-        mock_client = MagicMock(spec=httpx.Client)
-        mock_client.get.return_value = _mock_httpx_response(200)
-        assert _is_workspace_ai_gateway_available(mock_client, "https://test.databricks.com")
-        mock_client.get.assert_called_once_with(
-            "https://test.databricks.com/ai-gateway/mlflow/v1/chat/completions"
-        )
-
-    def test_available_on_json_404(self):
-        """A JSON 404 means the request reached the backend (route is wired up)."""
-        mock_client = MagicMock(spec=httpx.Client)
-        mock_client.get.return_value = _mock_httpx_response(
-            404, {"error_code": "ENDPOINT_NOT_FOUND"}, content_type="application/json"
-        )
-        assert _is_workspace_ai_gateway_available(mock_client, "https://test.databricks.com")
-
-    def test_unavailable_on_bare_404(self):
-        """Bare 404 (no JSON) from proxy means the route doesn't exist."""
-        mock_client = MagicMock(spec=httpx.Client)
-        mock_client.get.return_value = _mock_httpx_response(404, content_type="")
-        assert not _is_workspace_ai_gateway_available(mock_client, "https://test.databricks.com")
-
-    def test_unavailable_on_exception(self):
-        mock_client = MagicMock(spec=httpx.Client)
-        mock_client.get.side_effect = Exception("Connection refused")
-        assert not _is_workspace_ai_gateway_available(mock_client, "https://test.databricks.com")
-
-
-class TestAIGatewayV2Detection:
-    """Tests for _get_ai_gateway_base_url trickle-down resolution."""
-
-    def test_workspace_path_with_mlflow_api(self):
-        """use_ai_gateway → {host}/ai-gateway/mlflow/v1."""
-        mock_client = MagicMock(spec=httpx.Client)
-        mock_client.get.return_value = _mock_httpx_response(200)
-        result = _get_ai_gateway_base_url(
-            mock_client, "https://test.databricks.com", "mlflow/v1"
-        )
-        assert result == "https://test.databricks.com/ai-gateway/mlflow/v1"
-
-    def test_workspace_path_with_openai_api(self):
-        """use_ai_gateway_native_api → {host}/ai-gateway/openai/v1."""
-        mock_client = MagicMock(spec=httpx.Client)
-        mock_client.get.return_value = _mock_httpx_response(200)
-        result = _get_ai_gateway_base_url(
-            mock_client, "https://test.databricks.com", "openai/v1"
-        )
-        assert result == "https://test.databricks.com/ai-gateway/openai/v1"
-
-    def test_falls_back_to_legacy_host_with_mlflow_api(self):
-        """Bare 404 from proxy → legacy host with mlflow/v1."""
-        mock_client = MagicMock(spec=httpx.Client)
-
-        def mock_get(url):
-            if "/ai-gateway/mlflow/v1/chat/completions" in url:
-                return _mock_httpx_response(404, content_type="")
-            if "api/ai-gateway/v2/endpoints" in url:
-                return _mock_httpx_response(
-                    200,
-                    {
-                        "endpoints": [
-                            {
-                                "name": "databricks-claude-sonnet-4-6",
-                                "ai_gateway_url": "https://12345.ai-gateway.cloud.databricks.com",
-                            }
-                        ]
-                    },
-                )
-            return _mock_httpx_response(404, content_type="")
-
-        mock_client.get.side_effect = mock_get
-        result = _get_ai_gateway_base_url(
-            mock_client, "https://test.databricks.com", "mlflow/v1"
-        )
-        assert result == "https://12345.ai-gateway.cloud.databricks.com/mlflow/v1"
-
-    def test_falls_back_to_legacy_host_with_openai_api(self):
-        """Bare 404 from proxy → legacy host with openai/v1."""
-        mock_client = MagicMock(spec=httpx.Client)
-
-        def mock_get(url):
-            if "/ai-gateway/mlflow/v1/chat/completions" in url:
-                return _mock_httpx_response(404, content_type="")
-            if "api/ai-gateway/v2/endpoints" in url:
-                return _mock_httpx_response(
-                    200,
-                    {
-                        "endpoints": [
-                            {
-                                "ai_gateway_url": "https://12345.ai-gateway.cloud.databricks.com",
-                            }
-                        ]
-                    },
-                )
-            return _mock_httpx_response(404, content_type="")
-
-        mock_client.get.side_effect = mock_get
-        result = _get_ai_gateway_base_url(
-            mock_client, "https://test.databricks.com", "openai/v1"
-        )
-        assert result == "https://12345.ai-gateway.cloud.databricks.com/openai/v1"
-
-    def test_returns_none_when_both_unavailable(self):
-        mock_client = MagicMock(spec=httpx.Client)
-        mock_client.get.return_value = _mock_httpx_response(404, content_type="")
-        result = _get_ai_gateway_base_url(
-            mock_client, "https://test.databricks.com", "mlflow/v1"
-        )
-        assert result is None
-
-    def test_returns_none_on_empty_endpoints(self):
-        mock_client = MagicMock(spec=httpx.Client)
-
-        def mock_get(url):
-            if "/ai-gateway/mlflow/v1/chat/completions" in url:
-                return _mock_httpx_response(404, content_type="")
-            return _mock_httpx_response(200, {"endpoints": []})
-
-        mock_client.get.side_effect = mock_get
-        result = _get_ai_gateway_base_url(
-            mock_client, "https://test.databricks.com", "mlflow/v1"
-        )
-        assert result is None
-
-    def test_returns_none_on_missing_ai_gateway_url(self):
-        mock_client = MagicMock(spec=httpx.Client)
-
-        def mock_get(url):
-            if "/ai-gateway/mlflow/v1/chat/completions" in url:
-                return _mock_httpx_response(404, content_type="")
-            return _mock_httpx_response(200, {"endpoints": [{"name": "my-endpoint"}]})
-
-        mock_client.get.side_effect = mock_get
-        result = _get_ai_gateway_base_url(
-            mock_client, "https://test.databricks.com", "mlflow/v1"
-        )
-        assert result is None
-
-    def test_legacy_parses_base_url_from_different_workspace(self):
-        mock_client = MagicMock(spec=httpx.Client)
-
-        def mock_get(url):
-            if "/ai-gateway/mlflow/v1/chat/completions" in url:
-                return _mock_httpx_response(404, content_type="")
-            return _mock_httpx_response(
-                200,
-                {
-                    "endpoints": [
-                        {
-                            "name": "databricks-gpt-5-2",
-                            "ai_gateway_url": "https://ws-123.ai-gateway.us-east-1.cloud.databricks.com",
-                        }
-                    ]
-                },
-            )
-
-        mock_client.get.side_effect = mock_get
-        result = _get_ai_gateway_base_url(
-            mock_client, "https://test.databricks.com", "mlflow/v1"
-        )
-        assert result == "https://ws-123.ai-gateway.us-east-1.cloud.databricks.com/mlflow/v1"
-
-    def test_workspace_exception_falls_back_to_legacy(self):
-        """If the workspace probe throws, still try legacy."""
-        mock_client = MagicMock(spec=httpx.Client)
-        call_count = [0]
-
-        def mock_get(url):
-            call_count[0] += 1
-            if call_count[0] == 1:
-                raise Exception("Connection reset")
-            return _mock_httpx_response(
-                200,
-                {
-                    "endpoints": [
-                        {"ai_gateway_url": "https://12345.ai-gateway.cloud.databricks.com"}
-                    ]
-                },
-            )
-
-        mock_client.get.side_effect = mock_get
-        result = _get_ai_gateway_base_url(
-            mock_client, "https://test.databricks.com", "mlflow/v1"
-        )
-        assert result == "https://12345.ai-gateway.cloud.databricks.com/mlflow/v1"
-
-
 class TestDatabricksOpenAIWithGateway:
-    """Tests for AI Gateway V2 integration in DatabricksOpenAI and AsyncDatabricksOpenAI."""
+    """Tests for AI Gateway routing in DatabricksOpenAI and AsyncDatabricksOpenAI."""
 
     @pytest.mark.parametrize("client_cls_name", ["DatabricksOpenAI", "AsyncDatabricksOpenAI"])
-    def test_gateway_available_uses_gateway_url(self, client_cls_name, mock_workspace_client):
+    def test_use_ai_gateway_routes_to_mlflow(self, client_cls_name, mock_workspace_client):
+        """use_ai_gateway=True → {host}/ai-gateway/mlflow/v1."""
         client_cls = (
             DatabricksOpenAI if client_cls_name == "DatabricksOpenAI" else AsyncDatabricksOpenAI
         )
-        with patch(
-            "databricks_openai.utils.clients._get_ai_gateway_base_url",
-            return_value="https://12345.ai-gateway.cloud.databricks.com/mlflow/v1",
-        ):
-            client = client_cls(workspace_client=mock_workspace_client, use_ai_gateway=True)
-            assert "ai-gateway" in str(client.base_url)
-            assert "12345.ai-gateway.cloud.databricks.com" in str(client.base_url)
+        client = client_cls(workspace_client=mock_workspace_client, use_ai_gateway=True)
+        assert "/ai-gateway/mlflow/v1" in str(client.base_url)
+        assert "test.databricks.com" in str(client.base_url)
 
     @pytest.mark.parametrize("client_cls_name", ["DatabricksOpenAI", "AsyncDatabricksOpenAI"])
-    def test_gateway_uses_workspace_url_when_available(
+    def test_use_ai_gateway_native_api_routes_to_openai(
         self, client_cls_name, mock_workspace_client
     ):
+        """use_ai_gateway_native_api=True → {host}/ai-gateway/openai/v1."""
         client_cls = (
             DatabricksOpenAI if client_cls_name == "DatabricksOpenAI" else AsyncDatabricksOpenAI
         )
-        with patch(
-            "databricks_openai.utils.clients._get_ai_gateway_base_url",
-            return_value="https://test.databricks.com/ai-gateway/mlflow/v1",
-        ):
-            client = client_cls(workspace_client=mock_workspace_client, use_ai_gateway=True)
-            assert "/ai-gateway/mlflow/v1" in str(client.base_url)
-            assert "test.databricks.com" in str(client.base_url)
+        client = client_cls(
+            workspace_client=mock_workspace_client, use_ai_gateway_native_api=True
+        )
+        assert "/ai-gateway/openai/v1" in str(client.base_url)
+        assert "test.databricks.com" in str(client.base_url)
 
     @pytest.mark.parametrize("client_cls_name", ["DatabricksOpenAI", "AsyncDatabricksOpenAI"])
-    def test_gateway_unavailable_raises_error(self, client_cls_name, mock_workspace_client):
+    def test_no_gateway_flag_uses_serving_endpoints(self, client_cls_name, mock_workspace_client):
         client_cls = (
             DatabricksOpenAI if client_cls_name == "DatabricksOpenAI" else AsyncDatabricksOpenAI
         )
-        with patch(
-            "databricks_openai.utils.clients._get_ai_gateway_base_url",
-            return_value=None,
-        ):
-            with pytest.raises(ValueError, match="Please ensure AI Gateway V2 is enabled"):
-                client_cls(workspace_client=mock_workspace_client, use_ai_gateway=True)
+        client = client_cls(workspace_client=mock_workspace_client)
+        assert "/serving-endpoints/" in str(client.base_url)
 
     @pytest.mark.parametrize("client_cls_name", ["DatabricksOpenAI", "AsyncDatabricksOpenAI"])
-    def test_gateway_disabled_no_api_call(self, client_cls_name, mock_workspace_client):
+    def test_explicit_base_url_overrides_gateway(self, client_cls_name, mock_workspace_client):
         client_cls = (
             DatabricksOpenAI if client_cls_name == "DatabricksOpenAI" else AsyncDatabricksOpenAI
         )
-        with patch(
-            "databricks_openai.utils.clients._get_ai_gateway_base_url",
-        ) as mock_gateway:
-            client = client_cls(workspace_client=mock_workspace_client, use_ai_gateway=False)
-            mock_gateway.assert_not_called()
-            assert "/serving-endpoints/" in str(client.base_url)
-
-    @pytest.mark.parametrize("client_cls_name", ["DatabricksOpenAI", "AsyncDatabricksOpenAI"])
-    def test_explicit_base_url_skips_gateway_check(self, client_cls_name, mock_workspace_client):
-        client_cls = (
-            DatabricksOpenAI if client_cls_name == "DatabricksOpenAI" else AsyncDatabricksOpenAI
+        client = client_cls(
+            workspace_client=mock_workspace_client,
+            base_url="https://custom.example.com/v1",
         )
-        with patch(
-            "databricks_openai.utils.clients._get_ai_gateway_base_url",
-        ) as mock_gateway:
-            client = client_cls(
-                workspace_client=mock_workspace_client,
-                base_url="https://custom.example.com/v1",
-            )
-            mock_gateway.assert_not_called()
-            assert "custom.example.com" in str(client.base_url)
-
-
-class TestAIGatewayNativeAPI:
-    """Tests for use_ai_gateway_native_api parameter in DatabricksOpenAI and AsyncDatabricksOpenAI."""
-
-    @pytest.mark.parametrize("client_cls_name", ["DatabricksOpenAI", "AsyncDatabricksOpenAI"])
-    def test_native_api_uses_openai_base_path_legacy(self, client_cls_name, mock_workspace_client):
-        client_cls = (
-            DatabricksOpenAI if client_cls_name == "DatabricksOpenAI" else AsyncDatabricksOpenAI
-        )
-        with patch(
-            "databricks_openai.utils.clients._get_ai_gateway_base_url",
-            return_value="https://12345.ai-gateway.cloud.databricks.com/openai/v1",
-        ):
-            client = client_cls(
-                workspace_client=mock_workspace_client,
-                use_ai_gateway_native_api=True,
-            )
-            assert "12345.ai-gateway.cloud.databricks.com" in str(client.base_url)
-            assert "/openai/v1" in str(client.base_url)
-
-    @pytest.mark.parametrize("client_cls_name", ["DatabricksOpenAI", "AsyncDatabricksOpenAI"])
-    def test_native_api_uses_workspace_path_when_available(
-        self, client_cls_name, mock_workspace_client
-    ):
-        client_cls = (
-            DatabricksOpenAI if client_cls_name == "DatabricksOpenAI" else AsyncDatabricksOpenAI
-        )
-        with patch(
-            "databricks_openai.utils.clients._get_ai_gateway_base_url",
-            return_value="https://test.databricks.com/ai-gateway/openai/v1",
-        ):
-            client = client_cls(
-                workspace_client=mock_workspace_client,
-                use_ai_gateway_native_api=True,
-            )
-            assert "/ai-gateway/openai/v1" in str(client.base_url)
-            assert "test.databricks.com" in str(client.base_url)
-
-    @pytest.mark.parametrize("client_cls_name", ["DatabricksOpenAI", "AsyncDatabricksOpenAI"])
-    def test_native_api_unavailable_raises_error(self, client_cls_name, mock_workspace_client):
-        client_cls = (
-            DatabricksOpenAI if client_cls_name == "DatabricksOpenAI" else AsyncDatabricksOpenAI
-        )
-        with patch(
-            "databricks_openai.utils.clients._get_ai_gateway_base_url",
-            return_value=None,
-        ):
-            with pytest.raises(ValueError, match="Please ensure AI Gateway V2 is enabled"):
-                client_cls(
-                    workspace_client=mock_workspace_client,
-                    use_ai_gateway_native_api=True,
-                )
+        assert "custom.example.com" in str(client.base_url)
 
     @pytest.mark.parametrize("client_cls_name", ["DatabricksOpenAI", "AsyncDatabricksOpenAI"])
     def test_native_api_and_base_url_raises(self, client_cls_name, mock_workspace_client):
@@ -1118,14 +837,3 @@ class TestAIGatewayNativeAPI:
                 use_ai_gateway=True,
             )
 
-    def test_discover_ai_gateway_host_strips_path(self):
-        """_discover_ai_gateway_host returns only scheme+netloc, stripping any path."""
-        mock_http = MagicMock()
-        mock_http.get.return_value.status_code = 200
-        mock_http.get.return_value.json.return_value = {
-            "endpoints": [
-                {"ai_gateway_url": "https://12345.ai-gateway.cloud.databricks.com/some/path"}
-            ]
-        }
-        result = _discover_ai_gateway_host(mock_http, "https://test.databricks.com")
-        assert result == "https://12345.ai-gateway.cloud.databricks.com"

--- a/integrations/openai/tests/unit_tests/test_clients.py
+++ b/integrations/openai/tests/unit_tests/test_clients.py
@@ -788,7 +788,7 @@ class TestWorkspaceAIGatewayDetection:
         )
 
     def test_available_on_json_404(self):
-        """A JSON 404 from the backend means the route is live."""
+        """A JSON 404 means the request reached the backend (route is wired up)."""
         mock_client = MagicMock(spec=httpx.Client)
         mock_client.get.return_value = _mock_httpx_response(
             404, {"error_code": "ENDPOINT_NOT_FOUND"}, content_type="application/json"

--- a/integrations/openai/tests/unit_tests/test_clients.py
+++ b/integrations/openai/tests/unit_tests/test_clients.py
@@ -851,7 +851,9 @@ class TestDatabricksOpenAIWithGateway:
             "databricks_openai.utils.clients._get_ai_gateway_base_url",
             return_value="https://12345.ai-gateway.cloud.databricks.com/mlflow/v1",
         ):
-            client = client_cls(workspace_client=mock_workspace_client, use_ai_gateway=True)
+            client = client_cls(
+                workspace_client=mock_workspace_client, use_ai_gateway_mlflow_api=True
+            )
             assert "ai-gateway" in str(client.base_url)
             assert "12345.ai-gateway.cloud.databricks.com" in str(client.base_url)
 
@@ -865,7 +867,7 @@ class TestDatabricksOpenAIWithGateway:
             return_value=None,
         ):
             with pytest.raises(ValueError, match="Please ensure AI Gateway V2 is enabled"):
-                client_cls(workspace_client=mock_workspace_client, use_ai_gateway=True)
+                client_cls(workspace_client=mock_workspace_client, use_ai_gateway_mlflow_api=True)
 
     @pytest.mark.parametrize("client_cls_name", ["DatabricksOpenAI", "AsyncDatabricksOpenAI"])
     def test_gateway_disabled_no_api_call(self, client_cls_name, mock_workspace_client):
@@ -875,7 +877,9 @@ class TestDatabricksOpenAIWithGateway:
         with patch(
             "databricks_openai.utils.clients._get_ai_gateway_base_url",
         ) as mock_gateway:
-            client = client_cls(workspace_client=mock_workspace_client, use_ai_gateway=False)
+            client = client_cls(
+                workspace_client=mock_workspace_client, use_ai_gateway_mlflow_api=False
+            )
             mock_gateway.assert_not_called()
             assert "/serving-endpoints/" in str(client.base_url)
 
@@ -944,18 +948,20 @@ class TestAIGatewayNativeAPI:
             )
 
     @pytest.mark.parametrize("client_cls_name", ["DatabricksOpenAI", "AsyncDatabricksOpenAI"])
-    def test_native_api_and_use_ai_gateway_raises(self, client_cls_name, mock_workspace_client):
+    def test_native_api_and_use_ai_gateway_mlflow_api_raises(
+        self, client_cls_name, mock_workspace_client
+    ):
         client_cls = (
             DatabricksOpenAI if client_cls_name == "DatabricksOpenAI" else AsyncDatabricksOpenAI
         )
         with pytest.raises(
             ValueError,
-            match="Cannot specify both 'use_ai_gateway_native_api' and 'use_ai_gateway'",
+            match="Cannot specify both 'use_ai_gateway_native_api' and 'use_ai_gateway_mlflow_api'",
         ):
             client_cls(
                 workspace_client=mock_workspace_client,
                 use_ai_gateway_native_api=True,
-                use_ai_gateway=True,
+                use_ai_gateway_mlflow_api=True,
             )
 
     def test_discover_ai_gateway_host_strips_path(self):


### PR DESCRIPTION
Support Heilmeier: AI Gateway Token Scope - Unique Paths and Workspace URL as they plan to deprecate old URLs at end of may:
https://docs.google.com/document/d/17_Hdi27Ecjl8Ys9ZCvoOeC3L3AEZEOtNLh3FuiRIGGE/edit?tab=t.0

STAGING Testing notebook with updated workspace-based ai-gateway url path: https://dbc-fb904e0e-bca7.staging.cloud.databricks.com/editor/notebooks/2573471477383128?o=4146361371977516#command/4780814485864147

PROD Testing notebook in workspace without the new URL supported will use the ai gateway host url: https://eng-ml-inference-team-eu-central-1.cloud.databricks.com/editor/notebooks/421682237852321?o=5763476629593792#command/6870101689879415

- Adds support for the new workspace-based AI Gateway URL pattern `({host}/ai-gateway/{api_path})` where AI Gateway endpoints are accessed via a path prefix on the workspace host, instead of requiring a separate
  *.ai-gateway.* hostname
  - tries the new workspace /ai-gateway/ prefix first, falls back to the legacy *.ai-gateway.* hostname discovery via
  /api/ai-gateway/v2/endpoints
  - use_ai_gateway=True routes to mlflow/v1 (chat completions API)
  - use_ai_gateway_native_api=True routes to openai/v1 (responses API)

route not enabled yet:
<img width="1056" height="533" alt="image" src="https://github.com/user-attachments/assets/bb4a6f8a-b4d7-4972-b540-d52373a96ca8" />

  How detection works

  The SDK sends a lightweight GET {host}/ai-gateway/mlflow/v1/chat/completions
  to check if the workspace has the /ai-gateway/ prefix wired up at the proxy
  layer:
  - JSON response (any status code) → request reached the AI Gateway backend →
  workspace prefix is available
  - Bare 404 with no content-type → proxy doesn't recognize the route → fall
  back to legacy hostname
