### PR TITLE
Release Databricks AI Bridge 0.18.0

### DIFF
--- a/databricks_mcp/pyproject.toml
+++ b/databricks_mcp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "databricks-mcp"
-version = "0.10.0"
+version = "0.9.0"
 description = "MCP helpers for Databricks"
 authors = [
     { name="Databricks", email="agent-feedback@databricks.com" },

--- a/databricks_mcp/pyproject.toml
+++ b/databricks_mcp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "databricks-mcp"
-version = "0.9.0"
+version = "0.10.0"
 description = "MCP helpers for Databricks"
 authors = [
     { name="Databricks", email="agent-feedback@databricks.com" },

--- a/integrations/langchain/pyproject.toml
+++ b/integrations/langchain/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "databricks-langchain"
-version = "0.17.0"
+version = "0.18.0"
 description = "Support for Databricks AI support in LangChain"
 authors = [
     { name="Databricks", email="agent-feedback@databricks.com" },
@@ -11,7 +11,7 @@ requires-python = ">=3.10"
 dependencies = [
     "langchain>=1.0.0",
     "databricks-vectorsearch>=0.50",
-    "databricks-ai-bridge>=0.17.0",
+    "databricks-ai-bridge>=0.18.0",
     "mlflow>=3.0.0",
     "pydantic>2.10.0",
     "unitycatalog-langchain[databricks]>=0.3.0",

--- a/integrations/openai/pyproject.toml
+++ b/integrations/openai/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "databricks-openai"
-version = "0.13.0"
+version = "0.14.0"
 description = "Support for Databricks AI support with OpenAI"
 authors = [
     { name="Databricks", email="agent-feedback@databricks.com" },
@@ -10,7 +10,7 @@ license = { text="Apache-2.0" }
 requires-python = ">=3.10"
 dependencies = [
     "databricks-vectorsearch>=0.50",
-    "databricks-ai-bridge>=0.17.0",
+    "databricks-ai-bridge>=0.18.0",
     "openai>=1.99.9",
     "pydantic>2.10.0",
     "mlflow>=3.10.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "databricks-ai-bridge"
-version = "0.17.0"
+version = "0.18.0"
 description = "Official Python library for Databricks AI support"
 authors = [
     { name="Databricks", email="agent-feedback@databricks.com" },


### PR DESCRIPTION
Change Log:

databricks-ai-bridge (core)

  - [#397] Experimental long-running agent server — Adds a new long_running module with an AgentServer for persistent, long-running agent sessions. Includes a DB layer, repository, models, and a full server implementation.

  ---
  databricks-openai

  - [#412] Support updated Workspace URL Path for AI Gateway — Adds support for the new {host}/ai-gateway/{api_path} URL pattern. Tries new workspace /ai-gateway/ prefix first, falls back to legacy *.ai-gateway.* hostname. Affects
  both use_ai_gateway=True (mlflow/v1) and use_ai_gateway_native_api=True (openai/v1) paths.
  - [#390] AI Gateway native provider endpoint support — Adds support for AI Gateway native provider endpoints in databricks_openai.
  - [#372] Remove strict kwarg injection in create_agent — Stops injecting the strict kwarg from LangChain's create_agent, fixing compatibility issues.

  ---
  databricks-langchain

  - [#396] Checkpointer fix — Bug fix for the LangGraph checkpointer (checkpoint.py), simplifying implementation and removing flawed unit tests.