### PR TITLE
Agent Memory SDKs: allow for custom schemas

### DIFF
--- a/integrations/langchain/src/databricks_langchain/checkpoint.py
+++ b/integrations/langchain/src/databricks_langchain/checkpoint.py
@@ -57,13 +57,7 @@ class CheckpointSaver(PostgresSaver):
 
     def setup(self) -> None:
         """Set up the checkpoint database, creating the schema if specified."""
-        if self._schema:
-            from psycopg import sql
-
-            with self._lakebase.connection() as conn:
-                conn.execute(
-                    sql.SQL("CREATE SCHEMA IF NOT EXISTS {}").format(sql.Identifier(self._schema))
-                )
+        self._lakebase.create_schema()
         super().setup()
 
     def __enter__(self):
@@ -118,13 +112,7 @@ class AsyncCheckpointSaver(AsyncPostgresSaver):
 
     async def setup(self) -> None:
         """Set up the checkpoint database asynchronously, creating the schema if specified."""
-        if self._schema:
-            from psycopg import sql
-
-            async with self._lakebase.connection() as conn:
-                await conn.execute(
-                    sql.SQL("CREATE SCHEMA IF NOT EXISTS {}").format(sql.Identifier(self._schema))
-                )
+        await self._lakebase.create_schema()
         await super().setup()
 
     async def __aenter__(self):

--- a/integrations/langchain/src/databricks_langchain/checkpoint.py
+++ b/integrations/langchain/src/databricks_langchain/checkpoint.py
@@ -33,6 +33,7 @@ class CheckpointSaver(PostgresSaver):
         project: str | None = None,
         branch: str | None = None,
         workspace_client: WorkspaceClient | None = None,
+        schema: str | None = None,
         **pool_kwargs: Any,
     ) -> None:
         # Lazy imports
@@ -48,9 +49,24 @@ class CheckpointSaver(PostgresSaver):
             project=project,
             branch=branch,
             workspace_client=workspace_client,
+            schema=schema,
             **dict(pool_kwargs),
         )
+        self._schema = schema
         super().__init__(self._lakebase.pool)
+
+    def setup(self) -> None:
+        """Set up the checkpoint database, creating the schema if specified."""
+        if self._schema:
+            from psycopg import sql
+
+            with self._lakebase.connection() as conn:
+                conn.execute(
+                    sql.SQL("CREATE SCHEMA IF NOT EXISTS {}").format(
+                        sql.Identifier(self._schema)
+                    )
+                )
+        super().setup()
 
     def __enter__(self):
         """Enter context manager."""
@@ -80,6 +96,7 @@ class AsyncCheckpointSaver(AsyncPostgresSaver):
         project: str | None = None,
         branch: str | None = None,
         workspace_client: WorkspaceClient | None = None,
+        schema: str | None = None,
         **pool_kwargs: Any,
     ) -> None:
         # Lazy imports
@@ -95,9 +112,24 @@ class AsyncCheckpointSaver(AsyncPostgresSaver):
             project=project,
             branch=branch,
             workspace_client=workspace_client,
+            schema=schema,
             **dict(pool_kwargs),
         )
+        self._schema = schema
         super().__init__(self._lakebase.pool)
+
+    async def setup(self) -> None:
+        """Set up the checkpoint database asynchronously, creating the schema if specified."""
+        if self._schema:
+            from psycopg import sql
+
+            async with self._lakebase.connection() as conn:
+                await conn.execute(
+                    sql.SQL("CREATE SCHEMA IF NOT EXISTS {}").format(
+                        sql.Identifier(self._schema)
+                    )
+                )
+        await super().setup()
 
     async def __aenter__(self):
         """Enter async context manager and open the connection pool."""

--- a/integrations/langchain/src/databricks_langchain/checkpoint.py
+++ b/integrations/langchain/src/databricks_langchain/checkpoint.py
@@ -62,9 +62,7 @@ class CheckpointSaver(PostgresSaver):
 
             with self._lakebase.connection() as conn:
                 conn.execute(
-                    sql.SQL("CREATE SCHEMA IF NOT EXISTS {}").format(
-                        sql.Identifier(self._schema)
-                    )
+                    sql.SQL("CREATE SCHEMA IF NOT EXISTS {}").format(sql.Identifier(self._schema))
                 )
         super().setup()
 
@@ -125,9 +123,7 @@ class AsyncCheckpointSaver(AsyncPostgresSaver):
 
             async with self._lakebase.connection() as conn:
                 await conn.execute(
-                    sql.SQL("CREATE SCHEMA IF NOT EXISTS {}").format(
-                        sql.Identifier(self._schema)
-                    )
+                    sql.SQL("CREATE SCHEMA IF NOT EXISTS {}").format(sql.Identifier(self._schema))
                 )
         await super().setup()
 

--- a/integrations/langchain/src/databricks_langchain/store.py
+++ b/integrations/langchain/src/databricks_langchain/store.py
@@ -42,6 +42,7 @@ class DatabricksStore(BaseStore):
         embedding_dims: int | None = None,
         embedding_fields: list[str] | None = None,
         embeddings: DatabricksEmbeddings | None = None,
+        schema: str | None = None,
         **pool_kwargs: Any,
     ) -> None:
         """Initialize DatabricksStore with embedding support.
@@ -61,6 +62,8 @@ class DatabricksStore(BaseStore):
                 vectorizes the entire JSON value.
             embeddings: Optional pre-configured DatabricksEmbeddings instance. If provided,
                 takes precedence over embedding_endpoint.
+            schema: Optional PostgreSQL schema name. When provided, all tables
+                are created in and queried from this schema instead of ``public``.
             **pool_kwargs: Additional keyword arguments passed to LakebasePool.
         """
         if not _store_imports_available:
@@ -69,12 +72,14 @@ class DatabricksStore(BaseStore):
                 "Install with: pip install 'databricks-langchain[memory]'"
             )
 
+        self._schema = schema
         self._lakebase: LakebasePool = LakebasePool(
             instance_name=instance_name,
             autoscaling_endpoint=autoscaling_endpoint,
             project=project,
             branch=branch,
             workspace_client=workspace_client,
+            schema=schema,
             **pool_kwargs,
         )
 
@@ -124,6 +129,15 @@ class DatabricksStore(BaseStore):
 
     def setup(self) -> None:
         """Instantiate the store, setting up necessary persistent storage."""
+        if self._schema:
+            from psycopg import sql
+
+            with self._lakebase.connection() as conn:
+                conn.execute(
+                    sql.SQL("CREATE SCHEMA IF NOT EXISTS {}").format(
+                        sql.Identifier(self._schema)
+                    )
+                )
         return self._with_store(lambda s: s.setup())
 
     def batch(self, ops: Iterable[Op]) -> list[Result]:
@@ -167,6 +181,7 @@ class AsyncDatabricksStore(AsyncBatchedBaseStore):
         embedding_dims: int | None = None,
         embedding_fields: list[str] | None = None,
         embeddings: DatabricksEmbeddings | None = None,
+        schema: str | None = None,
         **pool_kwargs: Any,
     ) -> None:
         """Initialize AsyncDatabricksStore with embedding support.
@@ -186,6 +201,8 @@ class AsyncDatabricksStore(AsyncBatchedBaseStore):
                 vectorizes the entire JSON value.
             embeddings: Optional pre-configured DatabricksEmbeddings instance. If provided,
                 takes precedence over embedding_endpoint.
+            schema: Optional PostgreSQL schema name. When provided, all tables
+                are created in and queried from this schema instead of ``public``.
             **pool_kwargs: Additional keyword arguments passed to AsyncLakebasePool.
         """
         if not _store_imports_available:
@@ -196,12 +213,14 @@ class AsyncDatabricksStore(AsyncBatchedBaseStore):
 
         super().__init__()
 
+        self._schema = schema
         self._lakebase: AsyncLakebasePool = AsyncLakebasePool(
             instance_name=instance_name,
             autoscaling_endpoint=autoscaling_endpoint,
             project=project,
             branch=branch,
             workspace_client=workspace_client,
+            schema=schema,
             **pool_kwargs,
         )
 
@@ -251,6 +270,15 @@ class AsyncDatabricksStore(AsyncBatchedBaseStore):
 
     async def setup(self) -> None:
         """Instantiate the store, setting up necessary persistent storage."""
+        if self._schema:
+            from psycopg import sql
+
+            async with self._lakebase.connection() as conn:
+                await conn.execute(
+                    sql.SQL("CREATE SCHEMA IF NOT EXISTS {}").format(
+                        sql.Identifier(self._schema)
+                    )
+                )
         return await self._with_store(lambda s: s.setup())
 
     async def abatch(self, ops: Iterable[Op]) -> list[Result]:

--- a/integrations/langchain/src/databricks_langchain/store.py
+++ b/integrations/langchain/src/databricks_langchain/store.py
@@ -129,13 +129,7 @@ class DatabricksStore(BaseStore):
 
     def setup(self) -> None:
         """Instantiate the store, setting up necessary persistent storage."""
-        if self._schema:
-            from psycopg import sql
-
-            with self._lakebase.connection() as conn:
-                conn.execute(
-                    sql.SQL("CREATE SCHEMA IF NOT EXISTS {}").format(sql.Identifier(self._schema))
-                )
+        self._lakebase.create_schema()
         return self._with_store(lambda s: s.setup())
 
     def batch(self, ops: Iterable[Op]) -> list[Result]:
@@ -268,13 +262,7 @@ class AsyncDatabricksStore(AsyncBatchedBaseStore):
 
     async def setup(self) -> None:
         """Instantiate the store, setting up necessary persistent storage."""
-        if self._schema:
-            from psycopg import sql
-
-            async with self._lakebase.connection() as conn:
-                await conn.execute(
-                    sql.SQL("CREATE SCHEMA IF NOT EXISTS {}").format(sql.Identifier(self._schema))
-                )
+        await self._lakebase.create_schema()
         return await self._with_store(lambda s: s.setup())
 
     async def abatch(self, ops: Iterable[Op]) -> list[Result]:

--- a/integrations/langchain/src/databricks_langchain/store.py
+++ b/integrations/langchain/src/databricks_langchain/store.py
@@ -134,9 +134,7 @@ class DatabricksStore(BaseStore):
 
             with self._lakebase.connection() as conn:
                 conn.execute(
-                    sql.SQL("CREATE SCHEMA IF NOT EXISTS {}").format(
-                        sql.Identifier(self._schema)
-                    )
+                    sql.SQL("CREATE SCHEMA IF NOT EXISTS {}").format(sql.Identifier(self._schema))
                 )
         return self._with_store(lambda s: s.setup())
 
@@ -275,9 +273,7 @@ class AsyncDatabricksStore(AsyncBatchedBaseStore):
 
             async with self._lakebase.connection() as conn:
                 await conn.execute(
-                    sql.SQL("CREATE SCHEMA IF NOT EXISTS {}").format(
-                        sql.Identifier(self._schema)
-                    )
+                    sql.SQL("CREATE SCHEMA IF NOT EXISTS {}").format(sql.Identifier(self._schema))
                 )
         return await self._with_store(lambda s: s.setup())
 

--- a/integrations/langchain/tests/unit_tests/test_checkpoint.py
+++ b/integrations/langchain/tests/unit_tests/test_checkpoint.py
@@ -256,10 +256,10 @@ def test_checkpoint_saver_setup_calls_create_schema(monkeypatch):
         workspace_client=workspace,
         schema="my_schema",
     )
-    saver._lakebase.create_schema = MagicMock()
+    saver._lakebase.create_schema = MagicMock()  # type: ignore[assignment]
     saver.setup()
 
-    saver._lakebase.create_schema.assert_called_once()
+    saver._lakebase.create_schema.assert_called_once()  # type: ignore[union-attr]
 
 
 @pytest.mark.asyncio
@@ -281,10 +281,10 @@ async def test_async_checkpoint_saver_setup_calls_create_schema(monkeypatch):
         workspace_client=workspace,
         schema="my_schema",
     )
-    saver._lakebase.create_schema = AsyncMock()
+    saver._lakebase.create_schema = AsyncMock()  # type: ignore[assignment]
     await saver.setup()
 
-    saver._lakebase.create_schema.assert_called_once()
+    saver._lakebase.create_schema.assert_called_once()  # type: ignore[union-attr]
 
 
 @pytest.mark.asyncio

--- a/integrations/langchain/tests/unit_tests/test_checkpoint.py
+++ b/integrations/langchain/tests/unit_tests/test_checkpoint.py
@@ -226,6 +226,143 @@ async def test_async_checkpoint_saver_autoscaling_configures_lakebase(monkeypatc
     assert saver._lakebase._is_autoscaling is True
 
 
+# =============================================================================
+# Schema Tests
+# =============================================================================
+
+
+def test_checkpoint_saver_stores_schema(monkeypatch):
+    """CheckpointSaver with schema stores it as _schema."""
+    test_pool = TestConnectionPool(connection_value="lake-conn")
+    monkeypatch.setattr(lakebase, "ConnectionPool", test_pool)
+
+    workspace = MagicMock()
+    workspace.database.generate_database_credential.return_value = MagicMock(token="stub-token")
+    workspace.database.get_database_instance.return_value.read_write_dns = "db-host"
+    workspace.current_service_principal.me.side_effect = RuntimeError("no sp")
+    workspace.current_user.me.return_value = MagicMock(user_name="test@databricks.com")
+
+    saver = CheckpointSaver(
+        instance_name="lakebase-instance",
+        workspace_client=workspace,
+        schema="my_schema",
+    )
+
+    assert saver._schema == "my_schema"
+
+
+def test_checkpoint_saver_setup_creates_schema(monkeypatch):
+    """CheckpointSaver.setup() should CREATE SCHEMA IF NOT EXISTS when schema is set."""
+    mock_conn = MagicMock()
+    test_pool = TestConnectionPool(connection_value=mock_conn)
+    monkeypatch.setattr(lakebase, "ConnectionPool", test_pool)
+
+    workspace = MagicMock()
+    workspace.database.generate_database_credential.return_value = MagicMock(token="stub-token")
+    workspace.database.get_database_instance.return_value.read_write_dns = "db-host"
+    workspace.current_service_principal.me.side_effect = RuntimeError("no sp")
+    workspace.current_user.me.return_value = MagicMock(user_name="test@databricks.com")
+
+    from langgraph.checkpoint.postgres import PostgresSaver
+
+    monkeypatch.setattr(PostgresSaver, "setup", MagicMock())
+
+    saver = CheckpointSaver(
+        instance_name="lakebase-instance",
+        workspace_client=workspace,
+        schema="my_schema",
+    )
+
+    saver.setup()
+
+    # Verify CREATE SCHEMA was executed on the connection
+    mock_conn.execute.assert_called_once()
+    executed_sql = str(mock_conn.execute.call_args[0][0])
+    assert "my_schema" in executed_sql
+
+
+def test_checkpoint_saver_setup_skips_schema_when_none(monkeypatch):
+    """CheckpointSaver.setup() should not create schema when schema is None."""
+    mock_conn = MagicMock()
+    test_pool = TestConnectionPool(connection_value=mock_conn)
+    monkeypatch.setattr(lakebase, "ConnectionPool", test_pool)
+
+    workspace = MagicMock()
+    workspace.database.generate_database_credential.return_value = MagicMock(token="stub-token")
+    workspace.database.get_database_instance.return_value.read_write_dns = "db-host"
+    workspace.current_service_principal.me.side_effect = RuntimeError("no sp")
+    workspace.current_user.me.return_value = MagicMock(user_name="test@databricks.com")
+
+    from langgraph.checkpoint.postgres import PostgresSaver
+
+    monkeypatch.setattr(PostgresSaver, "setup", MagicMock())
+
+    saver = CheckpointSaver(
+        instance_name="lakebase-instance",
+        workspace_client=workspace,
+    )
+
+    saver.setup()
+
+    # No schema creation should have happened
+    mock_conn.execute.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_async_checkpoint_saver_stores_schema(monkeypatch):
+    """AsyncCheckpointSaver with schema stores it as _schema."""
+    test_pool = TestAsyncConnectionPool(connection_value="async-lake-conn")
+    monkeypatch.setattr(lakebase, "AsyncConnectionPool", test_pool)
+
+    workspace = MagicMock()
+    workspace.database.generate_database_credential.return_value = MagicMock(token="stub-token")
+    workspace.database.get_database_instance.return_value.read_write_dns = "db-host"
+    workspace.current_service_principal.me.side_effect = RuntimeError("no sp")
+    workspace.current_user.me.return_value = MagicMock(user_name="test@databricks.com")
+
+    saver = AsyncCheckpointSaver(
+        instance_name="lakebase-instance",
+        workspace_client=workspace,
+        schema="my_schema",
+    )
+
+    assert saver._schema == "my_schema"
+
+
+@pytest.mark.asyncio
+async def test_async_checkpoint_saver_setup_creates_schema(monkeypatch):
+    """AsyncCheckpointSaver.setup() should CREATE SCHEMA IF NOT EXISTS when schema is set."""
+    from unittest.mock import AsyncMock
+
+    mock_conn = MagicMock()
+    mock_conn.execute = AsyncMock(return_value=MagicMock())
+    test_pool = TestAsyncConnectionPool(connection_value=mock_conn)
+    monkeypatch.setattr(lakebase, "AsyncConnectionPool", test_pool)
+
+    workspace = MagicMock()
+    workspace.database.generate_database_credential.return_value = MagicMock(token="stub-token")
+    workspace.database.get_database_instance.return_value.read_write_dns = "db-host"
+    workspace.current_service_principal.me.side_effect = RuntimeError("no sp")
+    workspace.current_user.me.return_value = MagicMock(user_name="test@databricks.com")
+
+    from langgraph.checkpoint.postgres.aio import AsyncPostgresSaver
+
+    monkeypatch.setattr(AsyncPostgresSaver, "setup", AsyncMock())
+
+    saver = AsyncCheckpointSaver(
+        instance_name="lakebase-instance",
+        workspace_client=workspace,
+        schema="my_schema",
+    )
+
+    await saver.setup()
+
+    # Verify CREATE SCHEMA was executed
+    mock_conn.execute.assert_called_once()
+    executed_sql = str(mock_conn.execute.call_args[0][0])
+    assert "my_schema" in executed_sql
+
+
 @pytest.mark.asyncio
 async def test_async_checkpoint_saver_autoscaling_context_manager(monkeypatch):
     test_pool = TestAsyncConnectionPool(connection_value="async-lake-conn")

--- a/integrations/langchain/tests/unit_tests/test_checkpoint.py
+++ b/integrations/langchain/tests/unit_tests/test_checkpoint.py
@@ -231,26 +231,6 @@ async def test_async_checkpoint_saver_autoscaling_configures_lakebase(monkeypatc
 # =============================================================================
 
 
-def test_checkpoint_saver_stores_schema(monkeypatch):
-    """CheckpointSaver with schema stores it as _schema."""
-    test_pool = TestConnectionPool(connection_value="lake-conn")
-    monkeypatch.setattr(lakebase, "ConnectionPool", test_pool)
-
-    workspace = MagicMock()
-    workspace.database.generate_database_credential.return_value = MagicMock(token="stub-token")
-    workspace.database.get_database_instance.return_value.read_write_dns = "db-host"
-    workspace.current_service_principal.me.side_effect = RuntimeError("no sp")
-    workspace.current_user.me.return_value = MagicMock(user_name="test@databricks.com")
-
-    saver = CheckpointSaver(
-        instance_name="lakebase-instance",
-        workspace_client=workspace,
-        schema="my_schema",
-    )
-
-    assert saver._schema == "my_schema"
-
-
 def test_checkpoint_saver_setup_creates_schema(monkeypatch):
     """CheckpointSaver.setup() should CREATE SCHEMA IF NOT EXISTS when schema is set."""
     mock_conn = MagicMock()
@@ -306,27 +286,6 @@ def test_checkpoint_saver_setup_skips_schema_when_none(monkeypatch):
 
     # No schema creation should have happened
     mock_conn.execute.assert_not_called()
-
-
-@pytest.mark.asyncio
-async def test_async_checkpoint_saver_stores_schema(monkeypatch):
-    """AsyncCheckpointSaver with schema stores it as _schema."""
-    test_pool = TestAsyncConnectionPool(connection_value="async-lake-conn")
-    monkeypatch.setattr(lakebase, "AsyncConnectionPool", test_pool)
-
-    workspace = MagicMock()
-    workspace.database.generate_database_credential.return_value = MagicMock(token="stub-token")
-    workspace.database.get_database_instance.return_value.read_write_dns = "db-host"
-    workspace.current_service_principal.me.side_effect = RuntimeError("no sp")
-    workspace.current_user.me.return_value = MagicMock(user_name="test@databricks.com")
-
-    saver = AsyncCheckpointSaver(
-        instance_name="lakebase-instance",
-        workspace_client=workspace,
-        schema="my_schema",
-    )
-
-    assert saver._schema == "my_schema"
 
 
 @pytest.mark.asyncio

--- a/integrations/langchain/tests/unit_tests/test_checkpoint.py
+++ b/integrations/langchain/tests/unit_tests/test_checkpoint.py
@@ -106,6 +106,15 @@ class TestAsyncConnectionPool:
         self._closed = True
 
 
+def _make_workspace():
+    workspace = MagicMock()
+    workspace.database.generate_database_credential.return_value = MagicMock(token="stub-token")
+    workspace.database.get_database_instance.return_value.read_write_dns = "db-host"
+    workspace.current_service_principal.me.side_effect = RuntimeError("no sp")
+    workspace.current_user.me.return_value = MagicMock(user_name="test@databricks.com")
+    return workspace
+
+
 @pytest.mark.asyncio
 async def test_async_checkpoint_saver_configures_lakebase(monkeypatch):
     test_pool = TestAsyncConnectionPool(connection_value="async-lake-conn")
@@ -231,17 +240,12 @@ async def test_async_checkpoint_saver_autoscaling_configures_lakebase(monkeypatc
 # =============================================================================
 
 
-def test_checkpoint_saver_setup_creates_schema(monkeypatch):
-    """CheckpointSaver.setup() should CREATE SCHEMA IF NOT EXISTS when schema is set."""
-    mock_conn = MagicMock()
-    test_pool = TestConnectionPool(connection_value=mock_conn)
+def test_checkpoint_saver_setup_calls_create_schema(monkeypatch):
+    """CheckpointSaver.setup() delegates schema creation to LakebasePool.create_schema()."""
+    test_pool = TestConnectionPool()
     monkeypatch.setattr(lakebase, "ConnectionPool", test_pool)
 
-    workspace = MagicMock()
-    workspace.database.generate_database_credential.return_value = MagicMock(token="stub-token")
-    workspace.database.get_database_instance.return_value.read_write_dns = "db-host"
-    workspace.current_service_principal.me.side_effect = RuntimeError("no sp")
-    workspace.current_user.me.return_value = MagicMock(user_name="test@databricks.com")
+    workspace = _make_workspace()
 
     from langgraph.checkpoint.postgres import PostgresSaver
 
@@ -252,57 +256,21 @@ def test_checkpoint_saver_setup_creates_schema(monkeypatch):
         workspace_client=workspace,
         schema="my_schema",
     )
-
+    saver._lakebase.create_schema = MagicMock()
     saver.setup()
 
-    # Verify CREATE SCHEMA was executed on the connection
-    mock_conn.execute.assert_called_once()
-    executed_sql = str(mock_conn.execute.call_args[0][0])
-    assert "my_schema" in executed_sql
-
-
-def test_checkpoint_saver_setup_skips_schema_when_none(monkeypatch):
-    """CheckpointSaver.setup() should not create schema when schema is None."""
-    mock_conn = MagicMock()
-    test_pool = TestConnectionPool(connection_value=mock_conn)
-    monkeypatch.setattr(lakebase, "ConnectionPool", test_pool)
-
-    workspace = MagicMock()
-    workspace.database.generate_database_credential.return_value = MagicMock(token="stub-token")
-    workspace.database.get_database_instance.return_value.read_write_dns = "db-host"
-    workspace.current_service_principal.me.side_effect = RuntimeError("no sp")
-    workspace.current_user.me.return_value = MagicMock(user_name="test@databricks.com")
-
-    from langgraph.checkpoint.postgres import PostgresSaver
-
-    monkeypatch.setattr(PostgresSaver, "setup", MagicMock())
-
-    saver = CheckpointSaver(
-        instance_name="lakebase-instance",
-        workspace_client=workspace,
-    )
-
-    saver.setup()
-
-    # No schema creation should have happened
-    mock_conn.execute.assert_not_called()
+    saver._lakebase.create_schema.assert_called_once()
 
 
 @pytest.mark.asyncio
-async def test_async_checkpoint_saver_setup_creates_schema(monkeypatch):
-    """AsyncCheckpointSaver.setup() should CREATE SCHEMA IF NOT EXISTS when schema is set."""
+async def test_async_checkpoint_saver_setup_calls_create_schema(monkeypatch):
+    """AsyncCheckpointSaver.setup() delegates schema creation to AsyncLakebasePool.create_schema()."""
     from unittest.mock import AsyncMock
 
-    mock_conn = MagicMock()
-    mock_conn.execute = AsyncMock(return_value=MagicMock())
-    test_pool = TestAsyncConnectionPool(connection_value=mock_conn)
+    test_pool = TestAsyncConnectionPool()
     monkeypatch.setattr(lakebase, "AsyncConnectionPool", test_pool)
 
-    workspace = MagicMock()
-    workspace.database.generate_database_credential.return_value = MagicMock(token="stub-token")
-    workspace.database.get_database_instance.return_value.read_write_dns = "db-host"
-    workspace.current_service_principal.me.side_effect = RuntimeError("no sp")
-    workspace.current_user.me.return_value = MagicMock(user_name="test@databricks.com")
+    workspace = _make_workspace()
 
     from langgraph.checkpoint.postgres.aio import AsyncPostgresSaver
 
@@ -313,13 +281,10 @@ async def test_async_checkpoint_saver_setup_creates_schema(monkeypatch):
         workspace_client=workspace,
         schema="my_schema",
     )
-
+    saver._lakebase.create_schema = AsyncMock()
     await saver.setup()
 
-    # Verify CREATE SCHEMA was executed
-    mock_conn.execute.assert_called_once()
-    executed_sql = str(mock_conn.execute.call_args[0][0])
-    assert "my_schema" in executed_sql
+    saver._lakebase.create_schema.assert_called_once()
 
 
 @pytest.mark.asyncio

--- a/integrations/langchain/tests/unit_tests/test_store.py
+++ b/integrations/langchain/tests/unit_tests/test_store.py
@@ -667,23 +667,6 @@ async def test_async_databricks_store_branch_resource_path(monkeypatch):
 # =============================================================================
 
 
-def test_databricks_store_stores_schema(monkeypatch):
-    """DatabricksStore with schema stores it as _schema."""
-    mock_conn = MagicMock()
-    test_pool = TestConnectionPool(connection_value=mock_conn)
-    monkeypatch.setattr(lakebase, "ConnectionPool", test_pool)
-
-    workspace = _create_mock_workspace()
-
-    store = DatabricksStore(
-        instance_name="lakebase-instance",
-        workspace_client=workspace,
-        schema="my_schema",
-    )
-
-    assert store._schema == "my_schema"
-
-
 def test_databricks_store_setup_creates_schema(monkeypatch):
     """DatabricksStore.setup() should CREATE SCHEMA IF NOT EXISTS when schema is set."""
     mock_conn = MagicMock()
@@ -731,24 +714,6 @@ def test_databricks_store_setup_skips_schema_when_none(monkeypatch):
 
     # No schema creation should have happened
     mock_conn.execute.assert_not_called()
-
-
-@pytest.mark.asyncio
-async def test_async_databricks_store_stores_schema(monkeypatch):
-    """AsyncDatabricksStore with schema stores it as _schema."""
-    mock_conn = MagicMock()
-    test_pool = TestAsyncConnectionPool(connection_value=mock_conn)
-    monkeypatch.setattr(lakebase, "AsyncConnectionPool", test_pool)
-
-    workspace = _create_mock_workspace()
-
-    store = AsyncDatabricksStore(
-        instance_name="lakebase-instance",
-        workspace_client=workspace,
-        schema="my_schema",
-    )
-
-    assert store._schema == "my_schema"
 
 
 @pytest.mark.asyncio

--- a/integrations/langchain/tests/unit_tests/test_store.py
+++ b/integrations/langchain/tests/unit_tests/test_store.py
@@ -683,10 +683,10 @@ def test_databricks_store_setup_calls_create_schema(monkeypatch):
         workspace_client=workspace,
         schema="my_schema",
     )
-    store._lakebase.create_schema = MagicMock()
+    store._lakebase.create_schema = MagicMock()  # type: ignore[assignment]
     store.setup()
 
-    store._lakebase.create_schema.assert_called_once()
+    store._lakebase.create_schema.assert_called_once()  # type: ignore[union-attr]
 
 
 @pytest.mark.asyncio
@@ -708,7 +708,7 @@ async def test_async_databricks_store_setup_calls_create_schema(monkeypatch):
         workspace_client=workspace,
         schema="my_schema",
     )
-    store._lakebase.create_schema = AsyncMock()
+    store._lakebase.create_schema = AsyncMock()  # type: ignore[assignment]
     await store.setup()
 
-    store._lakebase.create_schema.assert_called_once()
+    store._lakebase.create_schema.assert_called_once()  # type: ignore[union-attr]

--- a/integrations/langchain/tests/unit_tests/test_store.py
+++ b/integrations/langchain/tests/unit_tests/test_store.py
@@ -667,10 +667,9 @@ async def test_async_databricks_store_branch_resource_path(monkeypatch):
 # =============================================================================
 
 
-def test_databricks_store_setup_creates_schema(monkeypatch):
-    """DatabricksStore.setup() should CREATE SCHEMA IF NOT EXISTS when schema is set."""
-    mock_conn = MagicMock()
-    test_pool = TestConnectionPool(connection_value=mock_conn)
+def test_databricks_store_setup_calls_create_schema(monkeypatch):
+    """DatabricksStore.setup() delegates schema creation to LakebasePool.create_schema()."""
+    test_pool = TestConnectionPool()
     monkeypatch.setattr(lakebase, "ConnectionPool", test_pool)
 
     from langgraph.store.postgres import PostgresStore
@@ -684,51 +683,22 @@ def test_databricks_store_setup_creates_schema(monkeypatch):
         workspace_client=workspace,
         schema="my_schema",
     )
-
+    store._lakebase.create_schema = MagicMock()
     store.setup()
 
-    # Verify CREATE SCHEMA was executed on the connection
-    mock_conn.execute.assert_called_once()
-    executed_sql = str(mock_conn.execute.call_args[0][0])
-    assert "my_schema" in executed_sql
-
-
-def test_databricks_store_setup_skips_schema_when_none(monkeypatch):
-    """DatabricksStore.setup() should not create schema when schema is None."""
-    mock_conn = MagicMock()
-    test_pool = TestConnectionPool(connection_value=mock_conn)
-    monkeypatch.setattr(lakebase, "ConnectionPool", test_pool)
-
-    from langgraph.store.postgres import PostgresStore
-
-    monkeypatch.setattr(PostgresStore, "setup", MagicMock())
-
-    workspace = _create_mock_workspace()
-
-    store = DatabricksStore(
-        instance_name="lakebase-instance",
-        workspace_client=workspace,
-    )
-
-    store.setup()
-
-    # No schema creation should have happened
-    mock_conn.execute.assert_not_called()
+    store._lakebase.create_schema.assert_called_once()
 
 
 @pytest.mark.asyncio
-async def test_async_databricks_store_setup_creates_schema(monkeypatch):
-    """AsyncDatabricksStore.setup() should CREATE SCHEMA IF NOT EXISTS when schema is set."""
+async def test_async_databricks_store_setup_calls_create_schema(monkeypatch):
+    """AsyncDatabricksStore.setup() delegates schema creation to AsyncLakebasePool.create_schema()."""
     from unittest.mock import AsyncMock
 
-    mock_conn = MagicMock()
-    mock_conn.execute = AsyncMock(return_value=MagicMock())
-    test_pool = TestAsyncConnectionPool(connection_value=mock_conn)
+    test_pool = TestAsyncConnectionPool()
     monkeypatch.setattr(lakebase, "AsyncConnectionPool", test_pool)
 
     from langgraph.store.postgres import AsyncPostgresStore
 
-    # setup() is called via _with_store which awaits it, so must be AsyncMock
     monkeypatch.setattr(AsyncPostgresStore, "setup", AsyncMock())
 
     workspace = _create_mock_workspace()
@@ -738,10 +708,7 @@ async def test_async_databricks_store_setup_creates_schema(monkeypatch):
         workspace_client=workspace,
         schema="my_schema",
     )
-
+    store._lakebase.create_schema = AsyncMock()
     await store.setup()
 
-    # Verify CREATE SCHEMA was executed
-    mock_conn.execute.assert_called_once()
-    executed_sql = str(mock_conn.execute.call_args[0][0])
-    assert "my_schema" in executed_sql
+    store._lakebase.create_schema.assert_called_once()

--- a/integrations/langchain/tests/unit_tests/test_store.py
+++ b/integrations/langchain/tests/unit_tests/test_store.py
@@ -660,3 +660,123 @@ async def test_async_databricks_store_branch_resource_path(monkeypatch):
 
     assert "host=auto-db-host" in test_pool.conninfo
     assert store._lakebase._is_autoscaling is True
+
+
+# =============================================================================
+# Schema Tests
+# =============================================================================
+
+
+def test_databricks_store_stores_schema(monkeypatch):
+    """DatabricksStore with schema stores it as _schema."""
+    mock_conn = MagicMock()
+    test_pool = TestConnectionPool(connection_value=mock_conn)
+    monkeypatch.setattr(lakebase, "ConnectionPool", test_pool)
+
+    workspace = _create_mock_workspace()
+
+    store = DatabricksStore(
+        instance_name="lakebase-instance",
+        workspace_client=workspace,
+        schema="my_schema",
+    )
+
+    assert store._schema == "my_schema"
+
+
+def test_databricks_store_setup_creates_schema(monkeypatch):
+    """DatabricksStore.setup() should CREATE SCHEMA IF NOT EXISTS when schema is set."""
+    mock_conn = MagicMock()
+    test_pool = TestConnectionPool(connection_value=mock_conn)
+    monkeypatch.setattr(lakebase, "ConnectionPool", test_pool)
+
+    from langgraph.store.postgres import PostgresStore
+
+    monkeypatch.setattr(PostgresStore, "setup", MagicMock())
+
+    workspace = _create_mock_workspace()
+
+    store = DatabricksStore(
+        instance_name="lakebase-instance",
+        workspace_client=workspace,
+        schema="my_schema",
+    )
+
+    store.setup()
+
+    # Verify CREATE SCHEMA was executed on the connection
+    mock_conn.execute.assert_called_once()
+    executed_sql = str(mock_conn.execute.call_args[0][0])
+    assert "my_schema" in executed_sql
+
+
+def test_databricks_store_setup_skips_schema_when_none(monkeypatch):
+    """DatabricksStore.setup() should not create schema when schema is None."""
+    mock_conn = MagicMock()
+    test_pool = TestConnectionPool(connection_value=mock_conn)
+    monkeypatch.setattr(lakebase, "ConnectionPool", test_pool)
+
+    from langgraph.store.postgres import PostgresStore
+
+    monkeypatch.setattr(PostgresStore, "setup", MagicMock())
+
+    workspace = _create_mock_workspace()
+
+    store = DatabricksStore(
+        instance_name="lakebase-instance",
+        workspace_client=workspace,
+    )
+
+    store.setup()
+
+    # No schema creation should have happened
+    mock_conn.execute.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_async_databricks_store_stores_schema(monkeypatch):
+    """AsyncDatabricksStore with schema stores it as _schema."""
+    mock_conn = MagicMock()
+    test_pool = TestAsyncConnectionPool(connection_value=mock_conn)
+    monkeypatch.setattr(lakebase, "AsyncConnectionPool", test_pool)
+
+    workspace = _create_mock_workspace()
+
+    store = AsyncDatabricksStore(
+        instance_name="lakebase-instance",
+        workspace_client=workspace,
+        schema="my_schema",
+    )
+
+    assert store._schema == "my_schema"
+
+
+@pytest.mark.asyncio
+async def test_async_databricks_store_setup_creates_schema(monkeypatch):
+    """AsyncDatabricksStore.setup() should CREATE SCHEMA IF NOT EXISTS when schema is set."""
+    from unittest.mock import AsyncMock
+
+    mock_conn = MagicMock()
+    mock_conn.execute = AsyncMock(return_value=MagicMock())
+    test_pool = TestAsyncConnectionPool(connection_value=mock_conn)
+    monkeypatch.setattr(lakebase, "AsyncConnectionPool", test_pool)
+
+    from langgraph.store.postgres import AsyncPostgresStore
+
+    # setup() is called via _with_store which awaits it, so must be AsyncMock
+    monkeypatch.setattr(AsyncPostgresStore, "setup", AsyncMock())
+
+    workspace = _create_mock_workspace()
+
+    store = AsyncDatabricksStore(
+        instance_name="lakebase-instance",
+        workspace_client=workspace,
+        schema="my_schema",
+    )
+
+    await store.setup()
+
+    # Verify CREATE SCHEMA was executed
+    mock_conn.execute.assert_called_once()
+    executed_sql = str(mock_conn.execute.call_args[0][0])
+    assert "my_schema" in executed_sql

--- a/integrations/openai/src/databricks_openai/agents/session.py
+++ b/integrations/openai/src/databricks_openai/agents/session.py
@@ -176,10 +176,16 @@ class AsyncDatabricksSession(SQLAlchemySession):
     async def _ensure_tables(self) -> None:
         """Ensure schema and tables are created before any database operations."""
         if self._schema and self._create_tables:
+            import re
+
             from sqlalchemy import text
 
+            if not re.match(r"^[A-Za-z_][A-Za-z0-9_]*$", self._schema):
+                raise ValueError(f"Invalid schema name: {self._schema!r}")
             async with self._engine.begin() as conn:
-                await conn.execute(text(f'CREATE SCHEMA IF NOT EXISTS "{self._schema}"'))
+                await conn.execute(
+                    text(f'CREATE SCHEMA IF NOT EXISTS "{self._schema}"')
+                )
         await super()._ensure_tables()
 
     @classmethod

--- a/integrations/openai/src/databricks_openai/agents/session.py
+++ b/integrations/openai/src/databricks_openai/agents/session.py
@@ -108,6 +108,7 @@ class AsyncDatabricksSession(SQLAlchemySession):
         sessions_table: str = "agent_sessions",
         messages_table: str = "agent_messages",
         use_cached_engine: bool = True,
+        schema: Optional[str] = None,
         **engine_kwargs,
     ) -> None:
         """
@@ -133,6 +134,8 @@ class AsyncDatabricksSession(SQLAlchemySession):
             use_cached_engine: Whether to reuse a cached engine for the same
                 connection parameters and engine_kwargs combination. Set to False
                 to always create a new engine. Defaults to True.
+            schema: Optional PostgreSQL schema name. When provided, all tables
+                are created in and queried from this schema instead of ``public``.
             **engine_kwargs: Additional keyword arguments passed to
                 SQLAlchemy's create_async_engine().
         """
@@ -142,6 +145,7 @@ class AsyncDatabricksSession(SQLAlchemySession):
                 "Please install with: pip install databricks-openai[memory]"
             )
 
+        self._schema = schema
         self._lakebase = self._get_or_create_lakebase(
             instance_name=instance_name,
             autoscaling_endpoint=autoscaling_endpoint,
@@ -151,6 +155,7 @@ class AsyncDatabricksSession(SQLAlchemySession):
             token_cache_duration_seconds=token_cache_duration_seconds,
             pool_recycle=engine_kwargs.pop("pool_recycle", DEFAULT_POOL_RECYCLE_SECONDS),
             use_cached_engine=use_cached_engine,
+            schema=schema,
             **engine_kwargs,
         )
 
@@ -168,6 +173,17 @@ class AsyncDatabricksSession(SQLAlchemySession):
             session_id,
         )
 
+    async def _ensure_tables(self) -> None:
+        """Ensure schema and tables are created before any database operations."""
+        if self._schema and self._create_tables:
+            from sqlalchemy import text
+
+            async with self._engine.begin() as conn:
+                await conn.execute(
+                    text(f'CREATE SCHEMA IF NOT EXISTS "{self._schema}"')
+                )
+        await super()._ensure_tables()
+
     @classmethod
     def _build_cache_key(
         cls,
@@ -175,18 +191,20 @@ class AsyncDatabricksSession(SQLAlchemySession):
         autoscaling_endpoint: Optional[str] = None,
         project: Optional[str] = None,
         branch: Optional[str] = None,
+        schema: Optional[str] = None,
         **engine_kwargs: Any,
     ) -> str:
         """Build a cache key from connection parameters and engine_kwargs."""
         # Sort kwargs for deterministic key; use JSON for serializable values
         kwargs_key = json.dumps(engine_kwargs, sort_keys=True, default=str)
+        schema_suffix = f"::schema={schema}" if schema else ""
         if autoscaling_endpoint:
-            return f"endpoint::{autoscaling_endpoint}::{kwargs_key}"
+            return f"endpoint::{autoscaling_endpoint}::{kwargs_key}{schema_suffix}"
         if project and branch:
-            return f"autoscaling::{project}::{branch}::{kwargs_key}"
+            return f"autoscaling::{project}::{branch}::{kwargs_key}{schema_suffix}"
         if branch:
-            return f"autoscaling::{branch}::{kwargs_key}"
-        return f"provisioned::{instance_name}::{kwargs_key}"
+            return f"autoscaling::{branch}::{kwargs_key}{schema_suffix}"
+        return f"provisioned::{instance_name}::{kwargs_key}{schema_suffix}"
 
     @classmethod
     def _get_or_create_lakebase(
@@ -200,6 +218,7 @@ class AsyncDatabricksSession(SQLAlchemySession):
         token_cache_duration_seconds: int,
         pool_recycle: int,
         use_cached_engine: bool = True,
+        schema: Optional[str] = None,
         **engine_kwargs,
     ) -> AsyncLakebaseSQLAlchemy:
         """Get cached AsyncLakebaseSQLAlchemy or create a new one.
@@ -210,6 +229,7 @@ class AsyncDatabricksSession(SQLAlchemySession):
             autoscaling_endpoint=autoscaling_endpoint,
             project=project,
             branch=branch,
+            schema=schema,
             pool_recycle=pool_recycle,
             **engine_kwargs,
         )
@@ -228,6 +248,7 @@ class AsyncDatabricksSession(SQLAlchemySession):
             workspace_client=workspace_client,
             token_cache_duration_seconds=token_cache_duration_seconds,
             pool_recycle=pool_recycle,
+            schema=schema,
             **engine_kwargs,
         )
 

--- a/integrations/openai/src/databricks_openai/agents/session.py
+++ b/integrations/openai/src/databricks_openai/agents/session.py
@@ -183,9 +183,7 @@ class AsyncDatabricksSession(SQLAlchemySession):
             if not re.match(r"^[A-Za-z_][A-Za-z0-9_]*$", self._schema):
                 raise ValueError(f"Invalid schema name: {self._schema!r}")
             async with self._engine.begin() as conn:
-                await conn.execute(
-                    text(f'CREATE SCHEMA IF NOT EXISTS "{self._schema}"')
-                )
+                await conn.execute(text(f'CREATE SCHEMA IF NOT EXISTS "{self._schema}"'))
         await super()._ensure_tables()
 
     @classmethod

--- a/integrations/openai/src/databricks_openai/agents/session.py
+++ b/integrations/openai/src/databricks_openai/agents/session.py
@@ -176,14 +176,7 @@ class AsyncDatabricksSession(SQLAlchemySession):
     async def _ensure_tables(self) -> None:
         """Ensure schema and tables are created before any database operations."""
         if self._schema and self._create_tables:
-            import re
-
-            from sqlalchemy import text
-
-            if not re.match(r"^[A-Za-z_][A-Za-z0-9_]*$", self._schema):
-                raise ValueError(f"Invalid schema name: {self._schema!r}")
-            async with self._engine.begin() as conn:
-                await conn.execute(text(f'CREATE SCHEMA IF NOT EXISTS "{self._schema}"'))
+            await self._lakebase.create_schema()
         await super()._ensure_tables()
 
     @classmethod

--- a/integrations/openai/src/databricks_openai/agents/session.py
+++ b/integrations/openai/src/databricks_openai/agents/session.py
@@ -179,9 +179,7 @@ class AsyncDatabricksSession(SQLAlchemySession):
             from sqlalchemy import text
 
             async with self._engine.begin() as conn:
-                await conn.execute(
-                    text(f'CREATE SCHEMA IF NOT EXISTS "{self._schema}"')
-                )
+                await conn.execute(text(f'CREATE SCHEMA IF NOT EXISTS "{self._schema}"'))
         await super()._ensure_tables()
 
     @classmethod

--- a/integrations/openai/tests/unit_tests/test_session.py
+++ b/integrations/openai/tests/unit_tests/test_session.py
@@ -1297,63 +1297,6 @@ class TestAsyncDatabricksSessionBranchResourcePath:
 class TestAsyncDatabricksSessionSchema:
     """Tests for schema parameter behavior in AsyncDatabricksSession."""
 
-    def test_schema_stored_on_session(
-        self, mock_workspace_client, mock_engine, mock_event_listens_for
-    ):
-        """Session stores the schema parameter as _schema."""
-        with (
-            patch(
-                "databricks_ai_bridge.lakebase.WorkspaceClient",
-                return_value=mock_workspace_client,
-            ),
-            patch(
-                "sqlalchemy.ext.asyncio.create_async_engine",
-                return_value=mock_engine,
-            ),
-            patch(
-                "sqlalchemy.event.listens_for",
-                side_effect=mock_event_listens_for,
-            ),
-        ):
-            from databricks_openai.agents.session import AsyncDatabricksSession
-
-            session = AsyncDatabricksSession(
-                session_id="test-session",
-                instance_name="test-instance",
-                workspace_client=mock_workspace_client,
-                schema="my_schema",
-            )
-
-            assert session._schema == "my_schema"
-
-    def test_schema_none_by_default(
-        self, mock_workspace_client, mock_engine, mock_event_listens_for
-    ):
-        """Session _schema is None when not provided."""
-        with (
-            patch(
-                "databricks_ai_bridge.lakebase.WorkspaceClient",
-                return_value=mock_workspace_client,
-            ),
-            patch(
-                "sqlalchemy.ext.asyncio.create_async_engine",
-                return_value=mock_engine,
-            ),
-            patch(
-                "sqlalchemy.event.listens_for",
-                side_effect=mock_event_listens_for,
-            ),
-        ):
-            from databricks_openai.agents.session import AsyncDatabricksSession
-
-            session = AsyncDatabricksSession(
-                session_id="test-session",
-                instance_name="test-instance",
-                workspace_client=mock_workspace_client,
-            )
-
-            assert session._schema is None
-
     def test_different_schemas_get_different_engines(
         self, mock_workspace_client, mock_event_listens_for
     ):

--- a/integrations/openai/tests/unit_tests/test_session.py
+++ b/integrations/openai/tests/unit_tests/test_session.py
@@ -1377,68 +1377,16 @@ class TestAsyncDatabricksSessionSchema:
             assert mock_create_engine.call_count == 1
             assert session1._engine is session2._engine
 
-    def test_schema_vs_no_schema_get_different_engines(
-        self, mock_workspace_client, mock_event_listens_for
-    ):
-        """A session with schema and one without should get different engines."""
-        engine1 = MagicMock()
-        engine1.sync_engine = MagicMock()
-        engine2 = MagicMock()
-        engine2.sync_engine = MagicMock()
-
-        engines = [engine1, engine2]
-        engine_iter = iter(engines)
-
-        with (
-            patch(
-                "databricks_ai_bridge.lakebase.WorkspaceClient",
-                return_value=mock_workspace_client,
-            ),
-            patch(
-                "sqlalchemy.ext.asyncio.create_async_engine",
-                side_effect=lambda *args, **kwargs: next(engine_iter),
-            ) as mock_create_engine,
-            patch(
-                "sqlalchemy.event.listens_for",
-                side_effect=mock_event_listens_for,
-            ),
-        ):
-            from databricks_openai.agents.session import AsyncDatabricksSession
-
-            session_no_schema = AsyncDatabricksSession(
-                session_id="session-1",
-                instance_name="test-instance",
-                workspace_client=mock_workspace_client,
-            )
-            session_with_schema = AsyncDatabricksSession(
-                session_id="session-2",
-                instance_name="test-instance",
-                workspace_client=mock_workspace_client,
-                schema="my_schema",
-            )
-
-            assert mock_create_engine.call_count == 2
-            assert session_no_schema._engine is not session_with_schema._engine
-
 
 class TestAsyncDatabricksSessionEnsureTables:
     """Tests for _ensure_tables with schema support."""
 
     @pytest.mark.asyncio
-    async def test_ensure_tables_creates_schema_when_specified(
+    async def test_ensure_tables_calls_create_schema_when_specified(
         self, mock_workspace_client, mock_engine, mock_event_listens_for
     ):
-        """_ensure_tables should CREATE SCHEMA IF NOT EXISTS when schema is set."""
-        from contextlib import asynccontextmanager
+        """_ensure_tables delegates schema creation to lakebase.create_schema()."""
         from unittest.mock import AsyncMock
-
-        mock_conn = AsyncMock()
-
-        @asynccontextmanager
-        async def mock_begin():
-            yield mock_conn
-
-        mock_engine.begin = mock_begin
 
         with (
             patch(
@@ -1467,20 +1415,19 @@ class TestAsyncDatabricksSessionEnsureTables:
                 schema="my_schema",
                 create_tables=True,
             )
+            session._lakebase.create_schema = AsyncMock()
 
             await session._ensure_tables()
 
-            # Verify CREATE SCHEMA was executed
-            mock_conn.execute.assert_called_once()
-            executed_sql = str(mock_conn.execute.call_args[0][0])
-            assert "CREATE SCHEMA" in executed_sql
-            assert "my_schema" in executed_sql
+            session._lakebase.create_schema.assert_called_once()
 
     @pytest.mark.asyncio
     async def test_ensure_tables_skips_schema_creation_when_no_schema(
         self, mock_workspace_client, mock_engine, mock_event_listens_for
     ):
         """_ensure_tables should not create schema when schema is None."""
+        from unittest.mock import AsyncMock
+
         with (
             patch(
                 "databricks_ai_bridge.lakebase.WorkspaceClient",
@@ -1507,46 +1454,8 @@ class TestAsyncDatabricksSessionEnsureTables:
                 workspace_client=mock_workspace_client,
                 create_tables=True,
             )
+            session._lakebase.create_schema = AsyncMock()
 
             await session._ensure_tables()
 
-            # engine.begin() should NOT have been called (no schema to create)
-            mock_engine.begin.assert_not_called()
-
-    @pytest.mark.asyncio
-    async def test_ensure_tables_skips_schema_when_create_tables_false(
-        self, mock_workspace_client, mock_engine, mock_event_listens_for
-    ):
-        """_ensure_tables should not create schema when create_tables=False."""
-        with (
-            patch(
-                "databricks_ai_bridge.lakebase.WorkspaceClient",
-                return_value=mock_workspace_client,
-            ),
-            patch(
-                "sqlalchemy.ext.asyncio.create_async_engine",
-                return_value=mock_engine,
-            ),
-            patch(
-                "sqlalchemy.event.listens_for",
-                side_effect=mock_event_listens_for,
-            ),
-            patch(
-                "agents.extensions.memory.SQLAlchemySession._ensure_tables",
-                return_value=None,
-            ),
-        ):
-            from databricks_openai.agents.session import AsyncDatabricksSession
-
-            session = AsyncDatabricksSession(
-                session_id="test-session",
-                instance_name="test-instance",
-                workspace_client=mock_workspace_client,
-                schema="my_schema",
-                create_tables=False,
-            )
-
-            await session._ensure_tables()
-
-            # engine.begin() should NOT have been called
-            mock_engine.begin.assert_not_called()
+            session._lakebase.create_schema.assert_not_called()

--- a/integrations/openai/tests/unit_tests/test_session.py
+++ b/integrations/openai/tests/unit_tests/test_session.py
@@ -1287,3 +1287,323 @@ class TestAsyncDatabricksSessionBranchResourcePath:
             mock_autoscaling_workspace_client.postgres.list_endpoints.assert_called_once_with(
                 parent="projects/my-project/branches/my-branch"
             )
+
+
+# =============================================================================
+# Schema Tests
+# =============================================================================
+
+
+class TestAsyncDatabricksSessionSchema:
+    """Tests for schema parameter behavior in AsyncDatabricksSession."""
+
+    def test_schema_stored_on_session(
+        self, mock_workspace_client, mock_engine, mock_event_listens_for
+    ):
+        """Session stores the schema parameter as _schema."""
+        with (
+            patch(
+                "databricks_ai_bridge.lakebase.WorkspaceClient",
+                return_value=mock_workspace_client,
+            ),
+            patch(
+                "sqlalchemy.ext.asyncio.create_async_engine",
+                return_value=mock_engine,
+            ),
+            patch(
+                "sqlalchemy.event.listens_for",
+                side_effect=mock_event_listens_for,
+            ),
+        ):
+            from databricks_openai.agents.session import AsyncDatabricksSession
+
+            session = AsyncDatabricksSession(
+                session_id="test-session",
+                instance_name="test-instance",
+                workspace_client=mock_workspace_client,
+                schema="my_schema",
+            )
+
+            assert session._schema == "my_schema"
+
+    def test_schema_none_by_default(
+        self, mock_workspace_client, mock_engine, mock_event_listens_for
+    ):
+        """Session _schema is None when not provided."""
+        with (
+            patch(
+                "databricks_ai_bridge.lakebase.WorkspaceClient",
+                return_value=mock_workspace_client,
+            ),
+            patch(
+                "sqlalchemy.ext.asyncio.create_async_engine",
+                return_value=mock_engine,
+            ),
+            patch(
+                "sqlalchemy.event.listens_for",
+                side_effect=mock_event_listens_for,
+            ),
+        ):
+            from databricks_openai.agents.session import AsyncDatabricksSession
+
+            session = AsyncDatabricksSession(
+                session_id="test-session",
+                instance_name="test-instance",
+                workspace_client=mock_workspace_client,
+            )
+
+            assert session._schema is None
+
+    def test_different_schemas_get_different_engines(
+        self, mock_workspace_client, mock_event_listens_for
+    ):
+        """Sessions with different schemas should get different cached engines."""
+        engine1 = MagicMock()
+        engine1.sync_engine = MagicMock()
+        engine2 = MagicMock()
+        engine2.sync_engine = MagicMock()
+
+        engines = [engine1, engine2]
+        engine_iter = iter(engines)
+
+        with (
+            patch(
+                "databricks_ai_bridge.lakebase.WorkspaceClient",
+                return_value=mock_workspace_client,
+            ),
+            patch(
+                "sqlalchemy.ext.asyncio.create_async_engine",
+                side_effect=lambda *args, **kwargs: next(engine_iter),
+            ) as mock_create_engine,
+            patch(
+                "sqlalchemy.event.listens_for",
+                side_effect=mock_event_listens_for,
+            ),
+        ):
+            from databricks_openai.agents.session import AsyncDatabricksSession
+
+            session1 = AsyncDatabricksSession(
+                session_id="session-1",
+                instance_name="test-instance",
+                workspace_client=mock_workspace_client,
+                schema="schema_a",
+            )
+            session2 = AsyncDatabricksSession(
+                session_id="session-2",
+                instance_name="test-instance",
+                workspace_client=mock_workspace_client,
+                schema="schema_b",
+            )
+
+            assert mock_create_engine.call_count == 2
+            assert session1._engine is not session2._engine
+
+    def test_same_schema_shares_engine(
+        self, mock_workspace_client, mock_engine, mock_event_listens_for
+    ):
+        """Sessions with the same schema should share the cached engine."""
+        with (
+            patch(
+                "databricks_ai_bridge.lakebase.WorkspaceClient",
+                return_value=mock_workspace_client,
+            ),
+            patch(
+                "sqlalchemy.ext.asyncio.create_async_engine",
+                return_value=mock_engine,
+            ) as mock_create_engine,
+            patch(
+                "sqlalchemy.event.listens_for",
+                side_effect=mock_event_listens_for,
+            ),
+        ):
+            from databricks_openai.agents.session import AsyncDatabricksSession
+
+            session1 = AsyncDatabricksSession(
+                session_id="session-1",
+                instance_name="test-instance",
+                workspace_client=mock_workspace_client,
+                schema="my_schema",
+            )
+            session2 = AsyncDatabricksSession(
+                session_id="session-2",
+                instance_name="test-instance",
+                workspace_client=mock_workspace_client,
+                schema="my_schema",
+            )
+
+            assert mock_create_engine.call_count == 1
+            assert session1._engine is session2._engine
+
+    def test_schema_vs_no_schema_get_different_engines(
+        self, mock_workspace_client, mock_event_listens_for
+    ):
+        """A session with schema and one without should get different engines."""
+        engine1 = MagicMock()
+        engine1.sync_engine = MagicMock()
+        engine2 = MagicMock()
+        engine2.sync_engine = MagicMock()
+
+        engines = [engine1, engine2]
+        engine_iter = iter(engines)
+
+        with (
+            patch(
+                "databricks_ai_bridge.lakebase.WorkspaceClient",
+                return_value=mock_workspace_client,
+            ),
+            patch(
+                "sqlalchemy.ext.asyncio.create_async_engine",
+                side_effect=lambda *args, **kwargs: next(engine_iter),
+            ) as mock_create_engine,
+            patch(
+                "sqlalchemy.event.listens_for",
+                side_effect=mock_event_listens_for,
+            ),
+        ):
+            from databricks_openai.agents.session import AsyncDatabricksSession
+
+            session_no_schema = AsyncDatabricksSession(
+                session_id="session-1",
+                instance_name="test-instance",
+                workspace_client=mock_workspace_client,
+            )
+            session_with_schema = AsyncDatabricksSession(
+                session_id="session-2",
+                instance_name="test-instance",
+                workspace_client=mock_workspace_client,
+                schema="my_schema",
+            )
+
+            assert mock_create_engine.call_count == 2
+            assert session_no_schema._engine is not session_with_schema._engine
+
+
+class TestAsyncDatabricksSessionEnsureTables:
+    """Tests for _ensure_tables with schema support."""
+
+    @pytest.mark.asyncio
+    async def test_ensure_tables_creates_schema_when_specified(
+        self, mock_workspace_client, mock_engine, mock_event_listens_for
+    ):
+        """_ensure_tables should CREATE SCHEMA IF NOT EXISTS when schema is set."""
+        from contextlib import asynccontextmanager
+        from unittest.mock import AsyncMock
+
+        mock_conn = AsyncMock()
+
+        @asynccontextmanager
+        async def mock_begin():
+            yield mock_conn
+
+        mock_engine.begin = mock_begin
+
+        with (
+            patch(
+                "databricks_ai_bridge.lakebase.WorkspaceClient",
+                return_value=mock_workspace_client,
+            ),
+            patch(
+                "sqlalchemy.ext.asyncio.create_async_engine",
+                return_value=mock_engine,
+            ),
+            patch(
+                "sqlalchemy.event.listens_for",
+                side_effect=mock_event_listens_for,
+            ),
+            patch(
+                "agents.extensions.memory.SQLAlchemySession._ensure_tables",
+                return_value=None,
+            ),
+        ):
+            from databricks_openai.agents.session import AsyncDatabricksSession
+
+            session = AsyncDatabricksSession(
+                session_id="test-session",
+                instance_name="test-instance",
+                workspace_client=mock_workspace_client,
+                schema="my_schema",
+                create_tables=True,
+            )
+
+            await session._ensure_tables()
+
+            # Verify CREATE SCHEMA was executed
+            mock_conn.execute.assert_called_once()
+            executed_sql = str(mock_conn.execute.call_args[0][0])
+            assert "CREATE SCHEMA" in executed_sql
+            assert "my_schema" in executed_sql
+
+    @pytest.mark.asyncio
+    async def test_ensure_tables_skips_schema_creation_when_no_schema(
+        self, mock_workspace_client, mock_engine, mock_event_listens_for
+    ):
+        """_ensure_tables should not create schema when schema is None."""
+        with (
+            patch(
+                "databricks_ai_bridge.lakebase.WorkspaceClient",
+                return_value=mock_workspace_client,
+            ),
+            patch(
+                "sqlalchemy.ext.asyncio.create_async_engine",
+                return_value=mock_engine,
+            ),
+            patch(
+                "sqlalchemy.event.listens_for",
+                side_effect=mock_event_listens_for,
+            ),
+            patch(
+                "agents.extensions.memory.SQLAlchemySession._ensure_tables",
+                return_value=None,
+            ),
+        ):
+            from databricks_openai.agents.session import AsyncDatabricksSession
+
+            session = AsyncDatabricksSession(
+                session_id="test-session",
+                instance_name="test-instance",
+                workspace_client=mock_workspace_client,
+                create_tables=True,
+            )
+
+            await session._ensure_tables()
+
+            # engine.begin() should NOT have been called (no schema to create)
+            mock_engine.begin.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_ensure_tables_skips_schema_when_create_tables_false(
+        self, mock_workspace_client, mock_engine, mock_event_listens_for
+    ):
+        """_ensure_tables should not create schema when create_tables=False."""
+        with (
+            patch(
+                "databricks_ai_bridge.lakebase.WorkspaceClient",
+                return_value=mock_workspace_client,
+            ),
+            patch(
+                "sqlalchemy.ext.asyncio.create_async_engine",
+                return_value=mock_engine,
+            ),
+            patch(
+                "sqlalchemy.event.listens_for",
+                side_effect=mock_event_listens_for,
+            ),
+            patch(
+                "agents.extensions.memory.SQLAlchemySession._ensure_tables",
+                return_value=None,
+            ),
+        ):
+            from databricks_openai.agents.session import AsyncDatabricksSession
+
+            session = AsyncDatabricksSession(
+                session_id="test-session",
+                instance_name="test-instance",
+                workspace_client=mock_workspace_client,
+                schema="my_schema",
+                create_tables=False,
+            )
+
+            await session._ensure_tables()
+
+            # engine.begin() should NOT have been called
+            mock_engine.begin.assert_not_called()

--- a/integrations/openai/tests/unit_tests/test_session.py
+++ b/integrations/openai/tests/unit_tests/test_session.py
@@ -1415,11 +1415,11 @@ class TestAsyncDatabricksSessionEnsureTables:
                 schema="my_schema",
                 create_tables=True,
             )
-            session._lakebase.create_schema = AsyncMock()
+            session._lakebase.create_schema = AsyncMock()  # type: ignore[assignment]
 
             await session._ensure_tables()
 
-            session._lakebase.create_schema.assert_called_once()
+            session._lakebase.create_schema.assert_called_once()  # type: ignore[union-attr]
 
     @pytest.mark.asyncio
     async def test_ensure_tables_skips_schema_creation_when_no_schema(
@@ -1454,8 +1454,8 @@ class TestAsyncDatabricksSessionEnsureTables:
                 workspace_client=mock_workspace_client,
                 create_tables=True,
             )
-            session._lakebase.create_schema = AsyncMock()
+            session._lakebase.create_schema = AsyncMock()  # type: ignore[assignment]
 
             await session._ensure_tables()
 
-            session._lakebase.create_schema.assert_not_called()
+            session._lakebase.create_schema.assert_not_called()  # type: ignore[union-attr]

--- a/src/databricks_ai_bridge/lakebase.py
+++ b/src/databricks_ai_bridge/lakebase.py
@@ -118,9 +118,11 @@ class _LakebaseBase:
         branch: str | None = None,
         workspace_client: WorkspaceClient | None = None,
         token_cache_duration_seconds: int = DEFAULT_TOKEN_CACHE_DURATION_SECONDS,
+        schema: str | None = None,
     ) -> None:
         self.workspace_client: WorkspaceClient = workspace_client or WorkspaceClient()
         self.token_cache_duration_seconds: int = token_cache_duration_seconds
+        self.schema: str | None = schema
 
         # --- Parameter validation ---
         is_autoscaling = (
@@ -393,6 +395,7 @@ class LakebasePool(_LakebaseBase):
         branch: str | None = None,
         workspace_client: WorkspaceClient | None = None,
         token_cache_duration_seconds: int = DEFAULT_TOKEN_CACHE_DURATION_SECONDS,
+        schema: str | None = None,
         **pool_kwargs: dict[str, Any],
     ) -> None:
         super().__init__(
@@ -402,6 +405,7 @@ class LakebasePool(_LakebaseBase):
             branch=branch,
             workspace_client=workspace_client,
             token_cache_duration_seconds=token_cache_duration_seconds,
+            schema=schema,
         )
 
         # Sync lock for thread-safe token caching
@@ -441,6 +445,22 @@ class LakebasePool(_LakebaseBase):
         max_size = pool_kwargs.pop("max_size", DEFAULT_MAX_SIZE)
         timeout = pool_kwargs.pop("timeout", DEFAULT_TIMEOUT)
 
+        # Set search_path on each connection when a schema is specified
+        user_configure = pool_kwargs.pop("configure", None)
+        if self.schema:
+            _schema = self.schema
+
+            def configure(conn):
+                conn.execute(
+                    sql.SQL("SET search_path TO {}, public").format(
+                        sql.Identifier(_schema)
+                    )
+                )
+                if user_configure:
+                    user_configure(conn)
+        else:
+            configure = user_configure
+
         self._pool: ConnectionPool[psycopg.Connection[DictRow]] = ConnectionPool(  # type: ignore[invalid-assignment]
             conninfo=self._conninfo(),
             kwargs=default_kwargs,
@@ -449,6 +469,7 @@ class LakebasePool(_LakebaseBase):
             timeout=timeout,  # type: ignore[invalid-argument-type]
             open=True,
             connection_class=RotatingConnection,
+            configure=configure,
             **pool_kwargs,  # type: ignore[invalid-argument-type]
         )
 
@@ -506,6 +527,7 @@ class AsyncLakebasePool(_LakebaseBase):
         branch: str | None = None,
         workspace_client: WorkspaceClient | None = None,
         token_cache_duration_seconds: int = DEFAULT_TOKEN_CACHE_DURATION_SECONDS,
+        schema: str | None = None,
         **pool_kwargs: object,
     ) -> None:
         super().__init__(
@@ -515,6 +537,7 @@ class AsyncLakebasePool(_LakebaseBase):
             branch=branch,
             workspace_client=workspace_client,
             token_cache_duration_seconds=token_cache_duration_seconds,
+            schema=schema,
         )
 
         # Async lock for coroutine-safe token caching
@@ -553,6 +576,22 @@ class AsyncLakebasePool(_LakebaseBase):
         max_size = pool_kwargs.pop("max_size", DEFAULT_MAX_SIZE)
         timeout = pool_kwargs.pop("timeout", DEFAULT_TIMEOUT)
 
+        # Set search_path on each connection when a schema is specified
+        user_configure = pool_kwargs.pop("configure", None)
+        if self.schema:
+            _schema = self.schema
+
+            async def configure(conn):
+                await conn.execute(
+                    sql.SQL("SET search_path TO {}, public").format(
+                        sql.Identifier(_schema)
+                    )
+                )
+                if user_configure:
+                    await user_configure(conn)
+        else:
+            configure = user_configure
+
         self._pool: AsyncConnectionPool[psycopg.AsyncConnection[DictRow]] = AsyncConnectionPool(  # type: ignore[invalid-assignment]
             conninfo=self._conninfo(),
             kwargs=default_kwargs,
@@ -561,6 +600,7 @@ class AsyncLakebasePool(_LakebaseBase):
             timeout=timeout,  # type: ignore[invalid-argument-type]
             open=False,  # Don't open yet, must be opened with await
             connection_class=AsyncRotatingConnection,
+            configure=configure,
             **pool_kwargs,  # type: ignore[invalid-argument-type]
         )
 
@@ -1182,6 +1222,7 @@ class AsyncLakebaseSQLAlchemy(_LakebaseBase):
         workspace_client: WorkspaceClient | None = None,
         token_cache_duration_seconds: int = DEFAULT_TOKEN_CACHE_DURATION_SECONDS,
         pool_recycle: int = DEFAULT_POOL_RECYCLE_SECONDS,
+        schema: str | None = None,
         **engine_kwargs,
     ) -> None:
         """
@@ -1199,6 +1240,8 @@ class AsyncLakebaseSQLAlchemy(_LakebaseBase):
                 Defaults to 15 minutes.
             pool_recycle: Connection pool recycle time in seconds.
                 Defaults to 14 minutes (before token cache expires).
+            schema: Optional PostgreSQL schema name. When provided, all tables
+                are created in and queried from this schema instead of ``public``.
             **engine_kwargs: Additional keyword arguments passed to
                 SQLAlchemy's create_async_engine().
         """
@@ -1209,6 +1252,7 @@ class AsyncLakebaseSQLAlchemy(_LakebaseBase):
             branch=branch,
             workspace_client=workspace_client,
             token_cache_duration_seconds=token_cache_duration_seconds,
+            schema=schema,
         )
 
         # Thread-safe lock for token caching (do_connect is sync context)
@@ -1280,5 +1324,17 @@ class AsyncLakebaseSQLAlchemy(_LakebaseBase):
                 token[-5:],
                 len(token),
             )
+
+        if self.schema:
+
+            @event.listens_for(engine.sync_engine, "connect")
+            def set_search_path(dbapi_conn, connection_record):
+                cursor = dbapi_conn.cursor()
+                cursor.execute(
+                    sql.SQL("SET search_path TO {}, public").format(
+                        sql.Identifier(self.schema)
+                    )
+                )
+                cursor.close()
 
         return engine

--- a/src/databricks_ai_bridge/lakebase.py
+++ b/src/databricks_ai_bridge/lakebase.py
@@ -195,6 +195,7 @@ class _LakebaseBase:
 
     def _search_path_sql(self) -> sql.Composed:
         """Return ``SET search_path TO <schema>, public`` as a psycopg sql.Composed."""
+        assert self.schema is not None, "_search_path_sql called without a schema"
         return sql.SQL("SET search_path TO {}, public").format(sql.Identifier(self.schema))
 
     # --- Host resolution ---

--- a/src/databricks_ai_bridge/lakebase.py
+++ b/src/databricks_ai_bridge/lakebase.py
@@ -1324,12 +1324,10 @@ class AsyncLakebaseSQLAlchemy(_LakebaseBase):
         if self.schema:
             _schema = self.schema
 
-            @event.listens_for(engine.sync_engine, "connect")
-            def set_search_path(dbapi_conn, connection_record):
+            @event.listens_for(engine.sync_engine, "checkout")
+            def set_search_path(dbapi_conn, connection_record, connection_proxy):
                 cursor = dbapi_conn.cursor()
-                cursor.execute(
-                    sql.SQL("SET search_path TO {}, public").format(sql.Identifier(_schema))
-                )
+                cursor.execute(sql.SQL("SET search_path TO {}, public").format(sql.Identifier(_schema)))
                 cursor.close()
 
         return engine

--- a/src/databricks_ai_bridge/lakebase.py
+++ b/src/databricks_ai_bridge/lakebase.py
@@ -445,9 +445,10 @@ class LakebasePool(_LakebaseBase):
         max_size = pool_kwargs.pop("max_size", DEFAULT_MAX_SIZE)
         timeout = pool_kwargs.pop("timeout", DEFAULT_TIMEOUT)
 
-        # Set search_path on each connection when a schema is specified
+        # Build configure callback: set search_path when schema is specified,
+        # and always preserve any user-provided configure callback.
         user_configure = pool_kwargs.pop("configure", None)
-        _configure_fn = None
+        _configure_fn = user_configure
         if self.schema:
             _schema = self.schema
             _user_configure = user_configure
@@ -500,6 +501,15 @@ class LakebasePool(_LakebaseBase):
     def connection(self):
         """Get a connection from the pool."""
         return self._pool.connection()
+
+    def create_schema(self) -> None:
+        """Create the schema if one was specified at init time. No-op otherwise."""
+        if not self.schema:
+            return
+        with self.connection() as conn:
+            conn.execute(
+                sql.SQL("CREATE SCHEMA IF NOT EXISTS {}").format(sql.Identifier(self.schema))
+            )
 
     def close(self) -> None:
         """Close the connection pool."""
@@ -574,9 +584,10 @@ class AsyncLakebasePool(_LakebaseBase):
         max_size = pool_kwargs.pop("max_size", DEFAULT_MAX_SIZE)
         timeout = pool_kwargs.pop("timeout", DEFAULT_TIMEOUT)
 
-        # Set search_path on each connection when a schema is specified
+        # Build configure callback: set search_path when schema is specified,
+        # and always preserve any user-provided configure callback.
         user_configure = pool_kwargs.pop("configure", None)
-        _configure_fn = None
+        _configure_fn = user_configure
         if self.schema:
             _schema = self.schema
             _user_configure = user_configure
@@ -639,6 +650,15 @@ class AsyncLakebasePool(_LakebaseBase):
     async def open(self) -> None:
         """Open the connection pool."""
         await self._pool.open()
+
+    async def create_schema(self) -> None:
+        """Create the schema if one was specified at init time. No-op otherwise."""
+        if not self.schema:
+            return
+        async with self.connection() as conn:
+            await conn.execute(
+                sql.SQL("CREATE SCHEMA IF NOT EXISTS {}").format(sql.Identifier(self.schema))
+            )
 
     async def close(self) -> None:
         """Close the connection pool."""
@@ -1265,6 +1285,22 @@ class AsyncLakebaseSQLAlchemy(_LakebaseBase):
     def engine(self) -> "AsyncEngine":
         """The SQLAlchemy AsyncEngine."""
         return self._engine
+
+    async def create_schema(self) -> None:
+        """Create the schema if one was specified at init time. No-op otherwise."""
+        if not self.schema:
+            return
+        from sqlalchemy import text
+
+        # Use psycopg sql.Identifier for safe quoting, render without a connection
+        # (uses standard SQL quoting which is safe for PostgreSQL identifiers)
+        rendered = (
+            sql.SQL("CREATE SCHEMA IF NOT EXISTS {}")
+            .format(sql.Identifier(self.schema))
+            .as_string(None)
+        )
+        async with self._engine.begin() as conn:
+            await conn.execute(text(rendered))
 
     def get_token(self) -> str:
         """Get cached token or mint a new one (thread-safe)."""

--- a/src/databricks_ai_bridge/lakebase.py
+++ b/src/databricks_ai_bridge/lakebase.py
@@ -447,19 +447,17 @@ class LakebasePool(_LakebaseBase):
 
         # Set search_path on each connection when a schema is specified
         user_configure = pool_kwargs.pop("configure", None)
+        _configure_fn = None
         if self.schema:
             _schema = self.schema
+            _user_configure = user_configure
 
-            def configure(conn):
+            def _configure_fn(conn):  # type: ignore[misc]  # noqa: F811
                 conn.execute(
-                    sql.SQL("SET search_path TO {}, public").format(
-                        sql.Identifier(_schema)
-                    )
+                    sql.SQL("SET search_path TO {}, public").format(sql.Identifier(_schema))
                 )
-                if user_configure:
-                    user_configure(conn)
-        else:
-            configure = user_configure
+                if _user_configure:
+                    _user_configure(conn)  # type: ignore[call-non-callable]
 
         self._pool: ConnectionPool[psycopg.Connection[DictRow]] = ConnectionPool(  # type: ignore[invalid-assignment]
             conninfo=self._conninfo(),
@@ -469,7 +467,7 @@ class LakebasePool(_LakebaseBase):
             timeout=timeout,  # type: ignore[invalid-argument-type]
             open=True,
             connection_class=RotatingConnection,
-            configure=configure,
+            configure=_configure_fn,  # type: ignore[invalid-argument-type]
             **pool_kwargs,  # type: ignore[invalid-argument-type]
         )
 
@@ -578,19 +576,17 @@ class AsyncLakebasePool(_LakebaseBase):
 
         # Set search_path on each connection when a schema is specified
         user_configure = pool_kwargs.pop("configure", None)
+        _configure_fn = None
         if self.schema:
             _schema = self.schema
+            _user_configure = user_configure
 
-            async def configure(conn):
+            async def _configure_fn(conn):  # type: ignore[misc]  # noqa: F811
                 await conn.execute(
-                    sql.SQL("SET search_path TO {}, public").format(
-                        sql.Identifier(_schema)
-                    )
+                    sql.SQL("SET search_path TO {}, public").format(sql.Identifier(_schema))
                 )
-                if user_configure:
-                    await user_configure(conn)
-        else:
-            configure = user_configure
+                if _user_configure:
+                    await _user_configure(conn)  # type: ignore[call-non-callable]
 
         self._pool: AsyncConnectionPool[psycopg.AsyncConnection[DictRow]] = AsyncConnectionPool(  # type: ignore[invalid-assignment]
             conninfo=self._conninfo(),
@@ -600,7 +596,7 @@ class AsyncLakebasePool(_LakebaseBase):
             timeout=timeout,  # type: ignore[invalid-argument-type]
             open=False,  # Don't open yet, must be opened with await
             connection_class=AsyncRotatingConnection,
-            configure=configure,
+            configure=_configure_fn,  # type: ignore[invalid-argument-type]
             **pool_kwargs,  # type: ignore[invalid-argument-type]
         )
 
@@ -1326,14 +1322,13 @@ class AsyncLakebaseSQLAlchemy(_LakebaseBase):
             )
 
         if self.schema:
+            _schema = self.schema
 
             @event.listens_for(engine.sync_engine, "connect")
             def set_search_path(dbapi_conn, connection_record):
                 cursor = dbapi_conn.cursor()
                 cursor.execute(
-                    sql.SQL("SET search_path TO {}, public").format(
-                        sql.Identifier(self.schema)
-                    )
+                    sql.SQL("SET search_path TO {}, public").format(sql.Identifier(_schema))
                 )
                 cursor.close()
 

--- a/src/databricks_ai_bridge/lakebase.py
+++ b/src/databricks_ai_bridge/lakebase.py
@@ -1327,7 +1327,9 @@ class AsyncLakebaseSQLAlchemy(_LakebaseBase):
             @event.listens_for(engine.sync_engine, "checkout")
             def set_search_path(dbapi_conn, connection_record, connection_proxy):
                 cursor = dbapi_conn.cursor()
-                cursor.execute(sql.SQL("SET search_path TO {}, public").format(sql.Identifier(_schema)))
+                cursor.execute(
+                    sql.SQL("SET search_path TO {}, public").format(sql.Identifier(_schema))
+                )
                 cursor.close()
 
         return engine

--- a/src/databricks_ai_bridge/lakebase.py
+++ b/src/databricks_ai_bridge/lakebase.py
@@ -193,6 +193,10 @@ class _LakebaseBase:
         self._cached_token: str | None = None
         self._cache_ts: float | None = None
 
+    def _search_path_sql(self) -> sql.Composed:
+        """Return ``SET search_path TO <schema>, public`` as a psycopg sql.Composed."""
+        return sql.SQL("SET search_path TO {}, public").format(sql.Identifier(self.schema))
+
     # --- Host resolution ---
 
     def _resolve_provisioned_host(self) -> str:
@@ -450,13 +454,11 @@ class LakebasePool(_LakebaseBase):
         user_configure = pool_kwargs.pop("configure", None)
         _configure_fn = user_configure
         if self.schema:
-            _schema = self.schema
+            _set_path = self._search_path_sql()
             _user_configure = user_configure
 
             def _configure_fn(conn):  # type: ignore[misc]  # noqa: F811
-                conn.execute(
-                    sql.SQL("SET search_path TO {}, public").format(sql.Identifier(_schema))
-                )
+                conn.execute(_set_path)
                 if _user_configure:
                     _user_configure(conn)  # type: ignore[call-non-callable]
 
@@ -589,13 +591,11 @@ class AsyncLakebasePool(_LakebaseBase):
         user_configure = pool_kwargs.pop("configure", None)
         _configure_fn = user_configure
         if self.schema:
-            _schema = self.schema
+            _set_path = self._search_path_sql()
             _user_configure = user_configure
 
             async def _configure_fn(conn):  # type: ignore[misc]  # noqa: F811
-                await conn.execute(
-                    sql.SQL("SET search_path TO {}, public").format(sql.Identifier(_schema))
-                )
+                await conn.execute(_set_path)
                 if _user_configure:
                     await _user_configure(conn)  # type: ignore[call-non-callable]
 
@@ -1358,14 +1358,12 @@ class AsyncLakebaseSQLAlchemy(_LakebaseBase):
             )
 
         if self.schema:
-            _schema = self.schema
+            _set_path = self._search_path_sql()
 
             @event.listens_for(engine.sync_engine, "checkout")
             def set_search_path(dbapi_conn, connection_record, connection_proxy):
                 cursor = dbapi_conn.cursor()
-                cursor.execute(
-                    sql.SQL("SET search_path TO {}, public").format(sql.Identifier(_schema))
-                )
+                cursor.execute(_set_path)
                 cursor.close()
 
         return engine

--- a/tests/databricks_ai_bridge/test_lakebase.py
+++ b/tests/databricks_ai_bridge/test_lakebase.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import logging
 import re
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
@@ -18,6 +18,28 @@ from databricks_ai_bridge.lakebase import (
     SequencePrivilege,
     TablePrivilege,
 )
+
+
+class _ContextManager:
+    def __init__(self, value):
+        self._value = value
+
+    def __enter__(self):
+        return self._value
+
+    def __exit__(self, *args):
+        return False
+
+
+class _AsyncContextManager:
+    def __init__(self, value):
+        self._value = value
+
+    async def __aenter__(self):
+        return self._value
+
+    async def __aexit__(self, *args):
+        return False
 
 
 def _make_workspace(
@@ -1948,26 +1970,6 @@ def test_lakebase_pool_configure_sets_search_path_when_schema_specified(monkeypa
     assert "my_schema" in str(executed_sql) or "search_path" in str(executed_sql)
 
 
-def test_lakebase_pool_no_configure_when_no_schema(monkeypatch):
-    """LakebasePool without schema passes no configure callback."""
-    captured_configure = [None]
-
-    class TestPool:
-        def __init__(self, *, conninfo, connection_class, configure=None, **kwargs):
-            self.conninfo = conninfo
-            captured_configure[0] = configure
-
-    monkeypatch.setattr("databricks_ai_bridge.lakebase.ConnectionPool", TestPool)
-    workspace = _make_workspace()
-
-    LakebasePool(
-        instance_name="lake-instance",
-        workspace_client=workspace,
-    )
-
-    assert captured_configure[0] is None, "configure callback should be None when no schema"
-
-
 @pytest.mark.asyncio
 async def test_async_lakebase_pool_configure_sets_search_path_when_schema_specified(monkeypatch):
     """AsyncLakebasePool with schema passes a configure callback that sets search_path."""
@@ -2077,3 +2079,118 @@ def test_sqlalchemy_checkout_handler_sets_search_path(monkeypatch):
     executed_sql = mock_cursor.execute.call_args[0][0]
     assert "search_path" in str(executed_sql).lower()
     assert "my_schema" in str(executed_sql)
+
+
+def test_lakebase_pool_preserves_user_configure_when_no_schema(monkeypatch):
+    """LakebasePool without schema should still pass a user-provided configure callback."""
+    captured_configure = [None]
+
+    class TestPool:
+        def __init__(self, *, conninfo, connection_class, configure=None, **kwargs):
+            self.conninfo = conninfo
+            captured_configure[0] = configure
+
+    monkeypatch.setattr("databricks_ai_bridge.lakebase.ConnectionPool", TestPool)
+    workspace = _make_workspace()
+
+    user_fn = MagicMock()
+    LakebasePool(
+        instance_name="lake-instance",
+        workspace_client=workspace,
+        configure=user_fn,
+    )
+
+    assert captured_configure[0] is user_fn, (
+        "user-provided configure should be passed through when no schema is set"
+    )
+
+
+def test_lakebase_pool_create_schema(monkeypatch):
+    """LakebasePool.create_schema() executes CREATE SCHEMA when schema is set."""
+    mock_conn = MagicMock()
+
+    class TestPool:
+        def __init__(self, **kwargs):
+            pass
+
+        def connection(self):
+            return _ContextManager(mock_conn)
+
+    monkeypatch.setattr("databricks_ai_bridge.lakebase.ConnectionPool", TestPool)
+    workspace = _make_workspace()
+
+    pool = LakebasePool(
+        instance_name="lake-instance",
+        workspace_client=workspace,
+        schema="my_schema",
+    )
+    pool.create_schema()
+
+    mock_conn.execute.assert_called_once()
+    executed_sql = str(mock_conn.execute.call_args[0][0])
+    assert "my_schema" in executed_sql
+
+
+@pytest.mark.asyncio
+async def test_async_lakebase_pool_create_schema(monkeypatch):
+    """AsyncLakebasePool.create_schema() executes CREATE SCHEMA when schema is set."""
+    mock_conn = MagicMock()
+    mock_conn.execute = AsyncMock()
+
+    class TestPool:
+        def __init__(self, **kwargs):
+            pass
+
+        def connection(self):
+            return _AsyncContextManager(mock_conn)
+
+        async def open(self):
+            pass
+
+        async def close(self):
+            pass
+
+    monkeypatch.setattr("databricks_ai_bridge.lakebase.AsyncConnectionPool", TestPool)
+    workspace = _make_workspace()
+
+    pool = AsyncLakebasePool(
+        instance_name="lake-instance",
+        workspace_client=workspace,
+        schema="my_schema",
+    )
+    await pool.create_schema()
+
+    mock_conn.execute.assert_called_once()
+    executed_sql = str(mock_conn.execute.call_args[0][0])
+    assert "my_schema" in executed_sql
+
+
+@pytest.mark.asyncio
+async def test_async_lakebase_pool_preserves_user_configure_when_no_schema(monkeypatch):
+    """AsyncLakebasePool without schema should still pass a user-provided configure callback."""
+    captured_configure = [None]
+
+    class TestPool:
+        def __init__(self, *, conninfo, connection_class, configure=None, **kwargs):
+            self.conninfo = conninfo
+            captured_configure[0] = configure
+
+        async def open(self):
+            pass
+
+        async def close(self):
+            pass
+
+    monkeypatch.setattr("databricks_ai_bridge.lakebase.AsyncConnectionPool", TestPool)
+    workspace = _make_workspace()
+
+    user_fn = AsyncMock()
+    AsyncLakebasePool(
+        instance_name="lake-instance",
+        workspace_client=workspace,
+        configure=user_fn,
+    )
+
+    assert captured_configure[0] is user_fn, (
+        "user-provided configure should be passed through when no schema is set"
+    )

--- a/tests/databricks_ai_bridge/test_lakebase.py
+++ b/tests/databricks_ai_bridge/test_lakebase.py
@@ -1996,40 +1996,6 @@ async def test_async_lakebase_pool_configure_sets_search_path_when_schema_specif
     assert captured_configure[0] is not None, "configure callback should be set when schema is provided"
 
 
-def test_sqlalchemy_registers_checkout_event_when_schema_specified(monkeypatch):
-    """AsyncLakebaseSQLAlchemy registers a 'checkout' event (not 'connect') when schema is set."""
-    captured_events = []
-
-    def mock_listens_for(engine, event_name):
-        def decorator(fn):
-            captured_events.append((event_name, fn))
-            return fn
-
-        return decorator
-
-    workspace = _make_workspace()
-
-    with (
-        monkeypatch.context() as m,
-    ):
-        m.setattr("sqlalchemy.event.listens_for", mock_listens_for)
-        m.setattr(
-            "sqlalchemy.ext.asyncio.create_async_engine",
-            lambda *args, **kwargs: MagicMock(sync_engine=MagicMock()),
-        )
-
-        AsyncLakebaseSQLAlchemy(
-            instance_name="lake-instance",
-            workspace_client=workspace,
-            schema="my_schema",
-        )
-
-    event_names = [name for name, _ in captured_events]
-    assert "do_connect" in event_names, "do_connect event should always be registered"
-    assert "checkout" in event_names, "checkout event should be registered when schema is specified"
-    assert "connect" not in event_names, "connect event should NOT be used (checkout is correct)"
-
-
 def test_sqlalchemy_no_checkout_event_when_no_schema(monkeypatch):
     """AsyncLakebaseSQLAlchemy does not register a checkout event when no schema is set."""
     captured_events = []

--- a/tests/databricks_ai_bridge/test_lakebase.py
+++ b/tests/databricks_ai_bridge/test_lakebase.py
@@ -1935,7 +1935,9 @@ def test_lakebase_pool_configure_sets_search_path_when_schema_specified(monkeypa
         schema="my_schema",
     )
 
-    assert captured_configure[0] is not None, "configure callback should be set when schema is provided"
+    assert captured_configure[0] is not None, (
+        "configure callback should be set when schema is provided"
+    )
 
     # Simulate calling the configure callback
     mock_conn = MagicMock()
@@ -1993,7 +1995,9 @@ async def test_async_lakebase_pool_configure_sets_search_path_when_schema_specif
         schema="my_schema",
     )
 
-    assert captured_configure[0] is not None, "configure callback should be set when schema is provided"
+    assert captured_configure[0] is not None, (
+        "configure callback should be set when schema is provided"
+    )
 
 
 def test_sqlalchemy_no_checkout_event_when_no_schema(monkeypatch):

--- a/tests/databricks_ai_bridge/test_lakebase.py
+++ b/tests/databricks_ai_bridge/test_lakebase.py
@@ -1910,3 +1910,200 @@ def test_branch_plain_name_without_project_raises_error():
             branch="my-branch",
             workspace_client=workspace,
         )
+
+
+# =============================================================================
+# Schema (search_path) Tests
+# =============================================================================
+
+
+def test_lakebase_pool_configure_sets_search_path_when_schema_specified(monkeypatch):
+    """LakebasePool with schema passes a configure callback that sets search_path."""
+    captured_configure = [None]
+
+    class TestPool:
+        def __init__(self, *, conninfo, connection_class, configure=None, **kwargs):
+            self.conninfo = conninfo
+            captured_configure[0] = configure
+
+    monkeypatch.setattr("databricks_ai_bridge.lakebase.ConnectionPool", TestPool)
+    workspace = _make_workspace()
+
+    LakebasePool(
+        instance_name="lake-instance",
+        workspace_client=workspace,
+        schema="my_schema",
+    )
+
+    assert captured_configure[0] is not None, "configure callback should be set when schema is provided"
+
+    # Simulate calling the configure callback
+    mock_conn = MagicMock()
+    captured_configure[0](mock_conn)
+    mock_conn.execute.assert_called_once()
+    executed_sql = mock_conn.execute.call_args[0][0]
+    # The SQL should reference the schema name
+    assert "my_schema" in str(executed_sql) or "search_path" in str(executed_sql)
+
+
+def test_lakebase_pool_no_configure_when_no_schema(monkeypatch):
+    """LakebasePool without schema passes no configure callback."""
+    captured_configure = [None]
+
+    class TestPool:
+        def __init__(self, *, conninfo, connection_class, configure=None, **kwargs):
+            self.conninfo = conninfo
+            captured_configure[0] = configure
+
+    monkeypatch.setattr("databricks_ai_bridge.lakebase.ConnectionPool", TestPool)
+    workspace = _make_workspace()
+
+    LakebasePool(
+        instance_name="lake-instance",
+        workspace_client=workspace,
+    )
+
+    assert captured_configure[0] is None, "configure callback should be None when no schema"
+
+
+@pytest.mark.asyncio
+async def test_async_lakebase_pool_configure_sets_search_path_when_schema_specified(monkeypatch):
+    """AsyncLakebasePool with schema passes a configure callback that sets search_path."""
+    captured_configure = [None]
+
+    class TestPool:
+        def __init__(self, *, conninfo, connection_class, configure=None, **kwargs):
+            self.conninfo = conninfo
+            captured_configure[0] = configure
+            self._opened = False
+            self._closed = False
+
+        async def open(self):
+            self._opened = True
+
+        async def close(self):
+            self._closed = True
+
+    monkeypatch.setattr("databricks_ai_bridge.lakebase.AsyncConnectionPool", TestPool)
+    workspace = _make_workspace()
+
+    AsyncLakebasePool(
+        instance_name="lake-instance",
+        workspace_client=workspace,
+        schema="my_schema",
+    )
+
+    assert captured_configure[0] is not None, "configure callback should be set when schema is provided"
+
+
+def test_sqlalchemy_registers_checkout_event_when_schema_specified(monkeypatch):
+    """AsyncLakebaseSQLAlchemy registers a 'checkout' event (not 'connect') when schema is set."""
+    captured_events = []
+
+    def mock_listens_for(engine, event_name):
+        def decorator(fn):
+            captured_events.append((event_name, fn))
+            return fn
+
+        return decorator
+
+    workspace = _make_workspace()
+
+    with (
+        monkeypatch.context() as m,
+    ):
+        m.setattr("sqlalchemy.event.listens_for", mock_listens_for)
+        m.setattr(
+            "sqlalchemy.ext.asyncio.create_async_engine",
+            lambda *args, **kwargs: MagicMock(sync_engine=MagicMock()),
+        )
+
+        AsyncLakebaseSQLAlchemy(
+            instance_name="lake-instance",
+            workspace_client=workspace,
+            schema="my_schema",
+        )
+
+    event_names = [name for name, _ in captured_events]
+    assert "do_connect" in event_names, "do_connect event should always be registered"
+    assert "checkout" in event_names, "checkout event should be registered when schema is specified"
+    assert "connect" not in event_names, "connect event should NOT be used (checkout is correct)"
+
+
+def test_sqlalchemy_no_checkout_event_when_no_schema(monkeypatch):
+    """AsyncLakebaseSQLAlchemy does not register a checkout event when no schema is set."""
+    captured_events = []
+
+    def mock_listens_for(engine, event_name):
+        def decorator(fn):
+            captured_events.append((event_name, fn))
+            return fn
+
+        return decorator
+
+    workspace = _make_workspace()
+
+    with (
+        monkeypatch.context() as m,
+    ):
+        m.setattr("sqlalchemy.event.listens_for", mock_listens_for)
+        m.setattr(
+            "sqlalchemy.ext.asyncio.create_async_engine",
+            lambda *args, **kwargs: MagicMock(sync_engine=MagicMock()),
+        )
+
+        AsyncLakebaseSQLAlchemy(
+            instance_name="lake-instance",
+            workspace_client=workspace,
+        )
+
+    event_names = [name for name, _ in captured_events]
+    assert "do_connect" in event_names
+    assert "checkout" not in event_names, "checkout event should not be registered without schema"
+
+
+def test_sqlalchemy_checkout_handler_sets_search_path(monkeypatch):
+    """The checkout event handler should execute SET search_path with the schema name."""
+    captured_events = []
+
+    def mock_listens_for(engine, event_name):
+        def decorator(fn):
+            captured_events.append((event_name, fn))
+            return fn
+
+        return decorator
+
+    workspace = _make_workspace()
+
+    with (
+        monkeypatch.context() as m,
+    ):
+        m.setattr("sqlalchemy.event.listens_for", mock_listens_for)
+        m.setattr(
+            "sqlalchemy.ext.asyncio.create_async_engine",
+            lambda *args, **kwargs: MagicMock(sync_engine=MagicMock()),
+        )
+
+        AsyncLakebaseSQLAlchemy(
+            instance_name="lake-instance",
+            workspace_client=workspace,
+            schema="my_schema",
+        )
+
+    checkout_handlers = [(name, fn) for name, fn in captured_events if name == "checkout"]
+    assert len(checkout_handlers) == 1
+
+    handler = checkout_handlers[0][1]
+
+    # Simulate checkout event: handler(dbapi_conn, connection_record, connection_proxy)
+    mock_cursor = MagicMock()
+    mock_dbapi_conn = MagicMock()
+    mock_dbapi_conn.cursor.return_value = mock_cursor
+
+    handler(mock_dbapi_conn, MagicMock(), MagicMock())
+
+    mock_cursor.execute.assert_called_once()
+    mock_cursor.close.assert_called_once()
+    executed_sql = mock_cursor.execute.call_args[0][0]
+    assert "search_path" in str(executed_sql).lower()
+    assert "my_schema" in str(executed_sql)


### PR DESCRIPTION
## Problem

When using the `public` schema, SPs need to be granted postgres permissions explicitly. this means that when creating a template through the UI (without any manual permission grants in the UI / through a script), the SP will not have permission to write/create on it.

## Solution
Adds a `schema` param to CheckpointSaver, AsyncCheckpointSaver, DatabricksStore, AsyncDatabricksStore, and AsyncDatabricksSession. Since it'll be a new creation from the UI (given a fresh db), this will hopefully bypass permission issues.

The implementation uses two layers:
- Pool/engine level: SET search_path on each connection
- Class level: CREATE SCHEMA IF NOT EXISTS in setup()/ensure_tables()

## Rollout 
For current users of this SDK, nothing changes since this param defaults to None.

For new users of the SDK (like the updated templates) that provide a schema, this will create tables in the specified schema instead of `public`

## Testing
unit tests
manually tested with templates