### PR TITLE
Update ChatDatabricks to use DatabricksOpenAI

### DIFF
--- a/integrations/langchain/pyproject.toml
+++ b/integrations/langchain/pyproject.toml
@@ -17,7 +17,7 @@ dependencies = [
     "unitycatalog-langchain[databricks]>=0.3.0",
     "databricks-sdk>=0.65.0",
     "openai>=1.99.9",
-    "databricks-openai>=0.9.0",
+    "databricks-openai>=0.14.0",
     "langchain-mcp-adapters>=0.1.13",
     "databricks_mcp>=0.5.1",
 ]

--- a/integrations/langchain/src/databricks_langchain/chat_models.py
+++ b/integrations/langchain/src/databricks_langchain/chat_models.py
@@ -299,7 +299,7 @@ class ChatDatabricks(BaseChatModel):
     max_retries: Optional[int] = None
     """Maximum number of retries for failed requests. If None, uses the default retry count."""
     use_ai_gateway: bool = False
-    """If True, route requests through AI Gateway using the MLflow API."""
+    """If True, route requests through AI Gateway using the Supervisor API."""
     use_ai_gateway_native_api: bool = False
     """If True, route requests through AI Gateway using the native OpenAI-compatible API."""
 

--- a/integrations/langchain/src/databricks_langchain/chat_models.py
+++ b/integrations/langchain/src/databricks_langchain/chat_models.py
@@ -298,6 +298,10 @@ class ChatDatabricks(BaseChatModel):
     """Timeout in seconds for the HTTP request. If None, uses the default timeout."""
     max_retries: Optional[int] = None
     """Maximum number of retries for failed requests. If None, uses the default retry count."""
+    use_ai_gateway: bool = False
+    """If True, route requests through AI Gateway using the MLflow API."""
+    use_ai_gateway_native_api: bool = False
+    """If True, route requests through AI Gateway using the native OpenAI-compatible API."""
 
     @property
     def endpoint(self) -> str:
@@ -326,6 +330,10 @@ class ChatDatabricks(BaseChatModel):
             openai_kwargs["timeout"] = self.timeout
         if self.max_retries is not None:
             openai_kwargs["max_retries"] = self.max_retries
+        if self.use_ai_gateway:
+            openai_kwargs["use_ai_gateway"] = True
+        if self.use_ai_gateway_native_api:
+            openai_kwargs["use_ai_gateway_native_api"] = True
         return openai_kwargs
 
     @cached_property

--- a/integrations/langchain/src/databricks_langchain/chat_models.py
+++ b/integrations/langchain/src/databricks_langchain/chat_models.py
@@ -66,7 +66,7 @@ from openai import AsyncOpenAI, AsyncStream, OpenAI, Stream
 from openai.types.chat import ChatCompletion, ChatCompletionChunk
 from openai.types.completion_usage import CompletionUsage
 from openai.types.responses import Response, ResponseStreamEvent, ResponseUsage
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 from typing_extensions import override
 
 from databricks_langchain.utils import get_async_openai_client, get_openai_client
@@ -299,9 +299,22 @@ class ChatDatabricks(BaseChatModel):
     max_retries: Optional[int] = None
     """Maximum number of retries for failed requests. If None, uses the default retry count."""
     use_ai_gateway: bool = False
-    """If True, route requests through AI Gateway using the Supervisor API."""
+    """If True, auto-detect AI Gateway V2 availability and route requests through it using the
+    MLflow API. Defaults to False."""
     use_ai_gateway_native_api: bool = False
-    """If True, route requests through AI Gateway using the native OpenAI-compatible API."""
+    """If True, auto-detect AI Gateway V2 and route requests through its native
+    OpenAI-compatible API (``<ai_gateway_url>/openai/v1``). This allows use of provider-native
+    features not available through the MLflow API. Cannot be combined with ``base_url`` or
+    ``use_ai_gateway``. Defaults to False."""
+
+    @model_validator(mode="after")
+    def _validate_ai_gateway_flags(self) -> "ChatDatabricks":
+        if self.use_ai_gateway and self.use_ai_gateway_native_api:
+            raise ValueError(
+                "Cannot set both `use_ai_gateway` and `use_ai_gateway_native_api` to True. "
+                "Please set only one of them."
+            )
+        return self
 
     @property
     def endpoint(self) -> str:

--- a/integrations/langchain/src/databricks_langchain/utils.py
+++ b/integrations/langchain/src/databricks_langchain/utils.py
@@ -2,7 +2,7 @@ from typing import Any, List, Union
 from urllib.parse import urlparse
 
 import numpy as np
-from databricks_openai import AsyncDatabricksOpenAI
+from databricks_openai import AsyncDatabricksOpenAI, DatabricksOpenAI
 from openai import AsyncOpenAI, OpenAI
 
 
@@ -28,26 +28,14 @@ def get_openai_client(workspace_client: Any = None, **kwargs) -> OpenAI:
     Args:
         workspace_client: Optional WorkspaceClient instance to use for authentication.
             If not provided, creates a default WorkspaceClient.
-        **kwargs: Additional keyword arguments to pass to get_open_ai_client(),
-            such as timeout and max_retries.
+        **kwargs: Additional keyword arguments to pass to DatabricksOpenAI(),
+            such as timeout, max_retries, use_ai_gateway, and use_ai_gateway_native_api.
     """
-    try:
-        from databricks.sdk import WorkspaceClient
+    from databricks.sdk import WorkspaceClient
 
-        # If workspace_client is provided, use it directly
-        if workspace_client is not None:
-            return workspace_client.serving_endpoints.get_open_ai_client(**kwargs)
-        else:
-            # Otherwise, create default workspace client
-            workspace_client = WorkspaceClient()
-            return workspace_client.serving_endpoints.get_open_ai_client(**kwargs)
-
-    except ImportError as e:
-        raise ImportError(
-            "Failed to create the OpenAI client. "
-            "Please run `pip install databricks-sdk` to install "
-            "required dependencies."
-        ) from e
+    if workspace_client is None:
+        workspace_client = WorkspaceClient()
+    return DatabricksOpenAI(workspace_client=workspace_client, **kwargs)
 
 
 def get_async_openai_client(workspace_client: Any = None, **kwargs) -> AsyncOpenAI:

--- a/integrations/langchain/tests/unit_tests/test_utils.py
+++ b/integrations/langchain/tests/unit_tests/test_utils.py
@@ -1,62 +1,24 @@
 """Test utilities module."""
 
+import pytest
 from unittest.mock import Mock, patch
 
 from databricks_langchain.utils import get_openai_client
 
 
-def test_get_openai_client_with_timeout_and_max_retries() -> None:
-    """Test that get_openai_client properly passes timeout and max_retries as kwargs to the SDK."""
-
-    mock_openai_client = Mock()
-
+@pytest.mark.parametrize("kwargs,with_workspace_client", [
+    ({"timeout": 45.0, "max_retries": 3}, True),
+    ({"timeout": 30.0, "max_retries": 2}, False),
+    ({}, True),
+])
+def test_get_openai_client(kwargs, with_workspace_client):
+    mock_client = Mock()
     mock_workspace_client = Mock()
-    mock_workspace_client.serving_endpoints.get_open_ai_client.return_value = mock_openai_client
 
-    # Test with workspace_client, timeout, and max_retries
-    client = get_openai_client(workspace_client=mock_workspace_client, timeout=45.0, max_retries=3)
+    with patch("databricks_langchain.utils.DatabricksOpenAI", return_value=mock_client) as mock_cls:
+        with patch("databricks.sdk.WorkspaceClient", return_value=mock_workspace_client):
+            wc = mock_workspace_client if with_workspace_client else None
+            result = get_openai_client(workspace_client=wc, **kwargs)
 
-    # Verify the OpenAI client was obtained with the correct kwargs
-    mock_workspace_client.serving_endpoints.get_open_ai_client.assert_called_once_with(
-        timeout=45.0, max_retries=3
-    )
-
-    # Verify the client is returned
-    assert client == mock_openai_client
-
-
-def test_get_openai_client_with_default_workspace_client() -> None:
-    """Test get_openai_client creates default WorkspaceClient when none provided."""
-
-    mock_openai_client = Mock()
-
-    mock_workspace_client = Mock()
-    mock_workspace_client.serving_endpoints.get_open_ai_client.return_value = mock_openai_client
-
-    with patch("databricks.sdk.WorkspaceClient", return_value=mock_workspace_client):
-        client = get_openai_client(timeout=30.0, max_retries=2)
-
-    # Verify default WorkspaceClient was created and kwargs were passed
-    mock_workspace_client.serving_endpoints.get_open_ai_client.assert_called_once_with(
-        timeout=30.0, max_retries=2
-    )
-
-    # Verify the client is returned
-    assert client == mock_openai_client
-
-
-def test_get_openai_client_without_timeout_and_retries() -> None:
-    """Test get_openai_client doesn't pass kwargs when not provided."""
-
-    mock_openai_client = Mock()
-
-    mock_workspace_client = Mock()
-    mock_workspace_client.serving_endpoints.get_open_ai_client.return_value = mock_openai_client
-
-    client = get_openai_client(workspace_client=mock_workspace_client)
-
-    # Verify the OpenAI client was obtained without kwargs
-    mock_workspace_client.serving_endpoints.get_open_ai_client.assert_called_once_with()
-
-    # Verify the client is returned
-    assert client == mock_openai_client
+    mock_cls.assert_called_once_with(workspace_client=mock_workspace_client, **kwargs)
+    assert result == mock_client

--- a/integrations/langchain/tests/unit_tests/test_utils.py
+++ b/integrations/langchain/tests/unit_tests/test_utils.py
@@ -1,16 +1,20 @@
 """Test utilities module."""
 
-import pytest
 from unittest.mock import Mock, patch
+
+import pytest
 
 from databricks_langchain.utils import get_openai_client
 
 
-@pytest.mark.parametrize("kwargs,with_workspace_client", [
-    ({"timeout": 45.0, "max_retries": 3}, True),
-    ({"timeout": 30.0, "max_retries": 2}, False),
-    ({}, True),
-])
+@pytest.mark.parametrize(
+    "kwargs,with_workspace_client",
+    [
+        ({"timeout": 45.0, "max_retries": 3}, True),
+        ({"timeout": 30.0, "max_retries": 2}, False),
+        ({}, True),
+    ],
+)
 def test_get_openai_client(kwargs, with_workspace_client):
     mock_client = Mock()
     mock_workspace_client = Mock()

--- a/integrations/langchain/tests/unit_tests/test_utils.py
+++ b/integrations/langchain/tests/unit_tests/test_utils.py
@@ -4,7 +4,7 @@ from unittest.mock import Mock, patch
 
 import pytest
 
-from databricks_langchain.utils import get_openai_client
+from databricks_langchain.utils import get_async_openai_client, get_openai_client
 
 
 @pytest.mark.parametrize(
@@ -23,6 +23,30 @@ def test_get_openai_client(kwargs, with_workspace_client):
         with patch("databricks.sdk.WorkspaceClient", return_value=mock_workspace_client):
             wc = mock_workspace_client if with_workspace_client else None
             result = get_openai_client(workspace_client=wc, **kwargs)
+
+    mock_cls.assert_called_once_with(workspace_client=mock_workspace_client, **kwargs)
+    assert result == mock_client
+
+
+@pytest.mark.parametrize(
+    "kwargs,with_workspace_client",
+    [
+        ({"timeout": 45.0, "max_retries": 3}, True),
+        ({"use_ai_gateway": True}, False),
+        ({"use_ai_gateway_native_api": True}, True),
+        ({}, True),
+    ],
+)
+def test_get_async_openai_client(kwargs, with_workspace_client):
+    mock_client = Mock()
+    mock_workspace_client = Mock()
+
+    with patch(
+        "databricks_langchain.utils.AsyncDatabricksOpenAI", return_value=mock_client
+    ) as mock_cls:
+        with patch("databricks.sdk.WorkspaceClient", return_value=mock_workspace_client):
+            wc = mock_workspace_client if with_workspace_client else None
+            result = get_async_openai_client(workspace_client=wc, **kwargs)
 
     mock_cls.assert_called_once_with(workspace_client=mock_workspace_client, **kwargs)
     assert result == mock_client


### PR DESCRIPTION
Update ChatDatabricks to use DatabricksOpenAI package. Additionally adds the ability to use the use_ai_gateway=True parameter

## Tests

Unit tests and integration tests

Notebook: https://dogfood.staging.databricks.com/editor/notebooks/667884564555753?o=6051921418418893