### PR TITLE
Use last query attachment in _parse_attachments

### DIFF
--- a/src/databricks_ai_bridge/genie.py
+++ b/src/databricks_ai_bridge/genie.py
@@ -199,15 +199,21 @@ def _parse_attachments(resp: Dict[str, Any]) -> Dict[str, Any]:
     if not isinstance(attachments, list):
         return result
 
+    # Genie may self-correct, producing multiple query+text pairs. We want
+    # the final query and its paired text (the first text attachment following
+    # the final query).
+    want_new_text = True
     for a in attachments:
         if not isinstance(a, dict):
             continue
 
         if "query" in a:
             result["query_attachment"] = a
+            want_new_text = True
 
-        elif "text" in a and result["text_attachment"] is None:
+        elif "text" in a and want_new_text:
             result["text_attachment"] = a
+            want_new_text = False
 
         elif "suggested_questions" in a and result["suggested_questions_attachment"] is None:
             result["suggested_questions_attachment"] = a

--- a/src/databricks_ai_bridge/genie.py
+++ b/src/databricks_ai_bridge/genie.py
@@ -203,7 +203,7 @@ def _parse_attachments(resp: Dict[str, Any]) -> Dict[str, Any]:
         if not isinstance(a, dict):
             continue
 
-        if "query" in a and result["query_attachment"] is None:
+        if "query" in a:
             result["query_attachment"] = a
 
         elif "text" in a and result["text_attachment"] is None:

--- a/src/databricks_ai_bridge/genie.py
+++ b/src/databricks_ai_bridge/genie.py
@@ -215,7 +215,7 @@ def _parse_attachments(resp: Dict[str, Any]) -> Dict[str, Any]:
             result["text_attachment"] = a
             want_new_text = False
 
-        elif "suggested_questions" in a and result["suggested_questions_attachment"] is None:
+        elif "suggested_questions" in a:
             result["suggested_questions_attachment"] = a
 
     return result

--- a/tests/databricks_ai_bridge/test_genie.py
+++ b/tests/databricks_ai_bridge/test_genie.py
@@ -934,7 +934,7 @@ def test_poll_for_result_continues_on_mlflow_tracing_exceptions(genie, mock_work
             },
             {"attachment_id": "4", "query": {"query": "SELECT correct"}},
             {"attachment_id": "5", "text": {"content": "explains correct"}},
-            {"attachment_id": "3", "suggested_questions": {"questions": ["Q1?"]}},
+            {"attachment_id": "7", "suggested_questions": {"questions": ["Q2?"]}},
         ),
     ],
 )

--- a/tests/databricks_ai_bridge/test_genie.py
+++ b/tests/databricks_ai_bridge/test_genie.py
@@ -911,6 +911,31 @@ def test_poll_for_result_continues_on_mlflow_tracing_exceptions(genie, mock_work
             None,
             None,
         ),
+        # Self-correction with paired text attachments - text should be paired
+        # with the final query (i.e., the first text AFTER the last query), not
+        # the first text overall or the final text (which may be a follow-up).
+        (
+            {
+                "attachments": [
+                    {"attachment_id": "1", "query": {"query": "SELECT wrong"}},
+                    {"attachment_id": "2", "text": {"content": "explains wrong"}},
+                    {
+                        "attachment_id": "3",
+                        "suggested_questions": {"questions": ["Q1?"]},
+                    },
+                    {"attachment_id": "4", "query": {"query": "SELECT correct"}},
+                    {"attachment_id": "5", "text": {"content": "explains correct"}},
+                    {"attachment_id": "6", "text": {"content": "follow-up prompt"}},
+                    {
+                        "attachment_id": "7",
+                        "suggested_questions": {"questions": ["Q2?"]},
+                    },
+                ]
+            },
+            {"attachment_id": "4", "query": {"query": "SELECT correct"}},
+            {"attachment_id": "5", "text": {"content": "explains correct"}},
+            {"attachment_id": "3", "suggested_questions": {"questions": ["Q1?"]}},
+        ),
     ],
 )
 def test_parse_attachments(resp, exp_query, exp_text, exp_questions):

--- a/tests/databricks_ai_bridge/test_genie.py
+++ b/tests/databricks_ai_bridge/test_genie.py
@@ -890,6 +890,27 @@ def test_poll_for_result_continues_on_mlflow_tracing_exceptions(genie, mock_work
             None,
             None,
         ),
+        # Multiple query attachments (self-correction) - should return the LAST one
+        (
+            {
+                "attachments": [
+                    {
+                        "attachment_id": "1",
+                        "query": {"query": "SELECT wrong", "description": "first attempt"},
+                    },
+                    {
+                        "attachment_id": "2",
+                        "query": {"query": "SELECT correct", "description": "corrected"},
+                    },
+                ]
+            },
+            {
+                "attachment_id": "2",
+                "query": {"query": "SELECT correct", "description": "corrected"},
+            },
+            None,
+            None,
+        ),
     ],
 )
 def test_parse_attachments(resp, exp_query, exp_text, exp_questions):


### PR DESCRIPTION
## Summary

Fix `_parse_attachments` to handle Genie self-correction. When Genie self-corrects, the response contains multiple query attachments and paired text attachments — the old logic returned the broken first attempt.                             
                                                                                                                          
  ## Changes                                                                                                              
  - `query_attachment`: return the last one (corrected query)
  - `text_attachment`: return the first text following the last query (its paired explanation)
  - `suggested_questions_attachment`: unchanged                                                                           
  
  ## Test plan                                                                                                            
  - [x] Added test cases for self-correction (single-query and full query+text interleaving)                                          
  - [x] Verified in e2-dogfood against space `01f0c4c9431611b8843a80bfd9ebe916` — [notebook](https://dogfood.staging.databricks.com/editor/notebooks/1504339675866128?o=6051921418418893#command/5643578246396567)