### PR TITLE
Agent Memory SDK cleanup

### DIFF
--- a/integrations/langchain/src/databricks_langchain/checkpoint.py
+++ b/integrations/langchain/src/databricks_langchain/checkpoint.py
@@ -52,12 +52,12 @@ class CheckpointSaver(PostgresSaver):
             schema=schema,
             **dict(pool_kwargs),
         )
-        self._schema = schema
         super().__init__(self._lakebase.pool)
 
     def setup(self) -> None:
         """Set up the checkpoint database, creating the schema if specified."""
-        self._lakebase.create_schema()
+        if self._lakebase.schema:
+            self._lakebase.create_schema()
         super().setup()
 
     def __enter__(self):
@@ -107,12 +107,12 @@ class AsyncCheckpointSaver(AsyncPostgresSaver):
             schema=schema,
             **dict(pool_kwargs),
         )
-        self._schema = schema
         super().__init__(self._lakebase.pool)
 
     async def setup(self) -> None:
         """Set up the checkpoint database asynchronously, creating the schema if specified."""
-        await self._lakebase.create_schema()
+        if self._lakebase.schema:
+            await self._lakebase.create_schema()
         await super().setup()
 
     async def __aenter__(self):

--- a/integrations/langchain/src/databricks_langchain/checkpoint.py
+++ b/integrations/langchain/src/databricks_langchain/checkpoint.py
@@ -56,8 +56,7 @@ class CheckpointSaver(PostgresSaver):
 
     def setup(self) -> None:
         """Set up the checkpoint database, creating the schema if specified."""
-        if self._lakebase.schema:
-            LakebaseClient.create_schema(self._lakebase)
+        LakebaseClient.create_schema(self._lakebase)
         super().setup()
 
     def __enter__(self):
@@ -111,8 +110,7 @@ class AsyncCheckpointSaver(AsyncPostgresSaver):
 
     async def setup(self) -> None:
         """Set up the checkpoint database asynchronously, creating the schema if specified."""
-        if self._lakebase.schema:
-            await LakebaseClient.acreate_schema(self._lakebase)
+        await LakebaseClient.acreate_schema(self._lakebase)
         await super().setup()
 
     async def __aenter__(self):

--- a/integrations/langchain/src/databricks_langchain/checkpoint.py
+++ b/integrations/langchain/src/databricks_langchain/checkpoint.py
@@ -57,7 +57,7 @@ class CheckpointSaver(PostgresSaver):
     def setup(self) -> None:
         """Set up the checkpoint database, creating the schema if specified."""
         if self._lakebase.schema:
-            LakebaseClient(pool=self._lakebase).create_schema()
+            LakebaseClient.create_schema(self._lakebase)
         super().setup()
 
     def __enter__(self):
@@ -112,7 +112,7 @@ class AsyncCheckpointSaver(AsyncPostgresSaver):
     async def setup(self) -> None:
         """Set up the checkpoint database asynchronously, creating the schema if specified."""
         if self._lakebase.schema:
-            await self._lakebase.create_schema()
+            await LakebaseClient.acreate_schema(self._lakebase)
         await super().setup()
 
     async def __aenter__(self):

--- a/integrations/langchain/src/databricks_langchain/checkpoint.py
+++ b/integrations/langchain/src/databricks_langchain/checkpoint.py
@@ -5,7 +5,7 @@ from typing import Any
 from databricks.sdk import WorkspaceClient
 
 try:
-    from databricks_ai_bridge.lakebase import AsyncLakebasePool, LakebasePool
+    from databricks_ai_bridge.lakebase import AsyncLakebasePool, LakebaseClient, LakebasePool
     from langgraph.checkpoint.postgres import PostgresSaver
     from langgraph.checkpoint.postgres.aio import AsyncPostgresSaver
 
@@ -57,7 +57,7 @@ class CheckpointSaver(PostgresSaver):
     def setup(self) -> None:
         """Set up the checkpoint database, creating the schema if specified."""
         if self._lakebase.schema:
-            self._lakebase.create_schema()
+            LakebaseClient(pool=self._lakebase).create_schema()
         super().setup()
 
     def __enter__(self):

--- a/integrations/langchain/src/databricks_langchain/store.py
+++ b/integrations/langchain/src/databricks_langchain/store.py
@@ -6,7 +6,7 @@ from typing import Any, Iterable
 from databricks.sdk import WorkspaceClient
 
 try:
-    from databricks_ai_bridge.lakebase import AsyncLakebasePool, LakebasePool
+    from databricks_ai_bridge.lakebase import AsyncLakebasePool, LakebaseClient, LakebasePool
     from langgraph.store.base import BaseStore, Op, Result
     from langgraph.store.base.batch import AsyncBatchedBaseStore
     from langgraph.store.postgres import AsyncPostgresStore, PostgresStore
@@ -129,7 +129,7 @@ class DatabricksStore(BaseStore):
     def setup(self) -> None:
         """Instantiate the store, setting up necessary persistent storage."""
         if self._lakebase.schema:
-            self._lakebase.create_schema()
+            LakebaseClient(pool=self._lakebase).create_schema()
         return self._with_store(lambda s: s.setup())
 
     def batch(self, ops: Iterable[Op]) -> list[Result]:

--- a/integrations/langchain/src/databricks_langchain/store.py
+++ b/integrations/langchain/src/databricks_langchain/store.py
@@ -128,8 +128,7 @@ class DatabricksStore(BaseStore):
 
     def setup(self) -> None:
         """Instantiate the store, setting up necessary persistent storage."""
-        if self._lakebase.schema:
-            LakebaseClient.create_schema(self._lakebase)
+        LakebaseClient.create_schema(self._lakebase)
         return self._with_store(lambda s: s.setup())
 
     def batch(self, ops: Iterable[Op]) -> list[Result]:
@@ -261,8 +260,7 @@ class AsyncDatabricksStore(AsyncBatchedBaseStore):
 
     async def setup(self) -> None:
         """Instantiate the store, setting up necessary persistent storage."""
-        if self._lakebase.schema:
-            await LakebaseClient.acreate_schema(self._lakebase)
+        await LakebaseClient.acreate_schema(self._lakebase)
         return await self._with_store(lambda s: s.setup())
 
     async def abatch(self, ops: Iterable[Op]) -> list[Result]:

--- a/integrations/langchain/src/databricks_langchain/store.py
+++ b/integrations/langchain/src/databricks_langchain/store.py
@@ -129,7 +129,7 @@ class DatabricksStore(BaseStore):
     def setup(self) -> None:
         """Instantiate the store, setting up necessary persistent storage."""
         if self._lakebase.schema:
-            LakebaseClient(pool=self._lakebase).create_schema()
+            LakebaseClient.create_schema(self._lakebase)
         return self._with_store(lambda s: s.setup())
 
     def batch(self, ops: Iterable[Op]) -> list[Result]:
@@ -262,7 +262,7 @@ class AsyncDatabricksStore(AsyncBatchedBaseStore):
     async def setup(self) -> None:
         """Instantiate the store, setting up necessary persistent storage."""
         if self._lakebase.schema:
-            await self._lakebase.create_schema()
+            await LakebaseClient.acreate_schema(self._lakebase)
         return await self._with_store(lambda s: s.setup())
 
     async def abatch(self, ops: Iterable[Op]) -> list[Result]:

--- a/integrations/langchain/src/databricks_langchain/store.py
+++ b/integrations/langchain/src/databricks_langchain/store.py
@@ -72,7 +72,6 @@ class DatabricksStore(BaseStore):
                 "Install with: pip install 'databricks-langchain[memory]'"
             )
 
-        self._schema = schema
         self._lakebase: LakebasePool = LakebasePool(
             instance_name=instance_name,
             autoscaling_endpoint=autoscaling_endpoint,
@@ -129,7 +128,8 @@ class DatabricksStore(BaseStore):
 
     def setup(self) -> None:
         """Instantiate the store, setting up necessary persistent storage."""
-        self._lakebase.create_schema()
+        if self._lakebase.schema:
+            self._lakebase.create_schema()
         return self._with_store(lambda s: s.setup())
 
     def batch(self, ops: Iterable[Op]) -> list[Result]:
@@ -205,7 +205,6 @@ class AsyncDatabricksStore(AsyncBatchedBaseStore):
 
         super().__init__()
 
-        self._schema = schema
         self._lakebase: AsyncLakebasePool = AsyncLakebasePool(
             instance_name=instance_name,
             autoscaling_endpoint=autoscaling_endpoint,
@@ -262,7 +261,8 @@ class AsyncDatabricksStore(AsyncBatchedBaseStore):
 
     async def setup(self) -> None:
         """Instantiate the store, setting up necessary persistent storage."""
-        await self._lakebase.create_schema()
+        if self._lakebase.schema:
+            await self._lakebase.create_schema()
         return await self._with_store(lambda s: s.setup())
 
     async def abatch(self, ops: Iterable[Op]) -> list[Result]:

--- a/integrations/langchain/tests/unit_tests/test_checkpoint.py
+++ b/integrations/langchain/tests/unit_tests/test_checkpoint.py
@@ -268,7 +268,7 @@ def test_checkpoint_saver_setup_calls_create_schema(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_async_checkpoint_saver_setup_calls_create_schema(monkeypatch):
-    """AsyncCheckpointSaver.setup() delegates schema creation to AsyncLakebasePool.create_schema()."""
+    """AsyncCheckpointSaver.setup() delegates schema creation to LakebaseClient.acreate_schema()."""
     from unittest.mock import AsyncMock
 
     test_pool = TestAsyncConnectionPool()
@@ -280,15 +280,19 @@ async def test_async_checkpoint_saver_setup_calls_create_schema(monkeypatch):
 
     monkeypatch.setattr(AsyncPostgresSaver, "setup", AsyncMock())
 
+    mock_acreate_schema = AsyncMock()
+    monkeypatch.setattr(
+        "databricks_langchain.checkpoint.LakebaseClient.acreate_schema", mock_acreate_schema
+    )
+
     saver = AsyncCheckpointSaver(
         instance_name="lakebase-instance",
         workspace_client=workspace,
         schema="my_schema",
     )
-    saver._lakebase.create_schema = AsyncMock()  # type: ignore[assignment]
     await saver.setup()
 
-    saver._lakebase.create_schema.assert_called_once()  # type: ignore[union-attr]
+    mock_acreate_schema.assert_called_once()
 
 
 @pytest.mark.asyncio

--- a/integrations/langchain/tests/unit_tests/test_checkpoint.py
+++ b/integrations/langchain/tests/unit_tests/test_checkpoint.py
@@ -241,7 +241,7 @@ async def test_async_checkpoint_saver_autoscaling_configures_lakebase(monkeypatc
 
 
 def test_checkpoint_saver_setup_calls_create_schema(monkeypatch):
-    """CheckpointSaver.setup() delegates schema creation to LakebasePool.create_schema()."""
+    """CheckpointSaver.setup() delegates schema creation to LakebaseClient.create_schema()."""
     test_pool = TestConnectionPool()
     monkeypatch.setattr(lakebase, "ConnectionPool", test_pool)
 
@@ -251,15 +251,19 @@ def test_checkpoint_saver_setup_calls_create_schema(monkeypatch):
 
     monkeypatch.setattr(PostgresSaver, "setup", MagicMock())
 
+    mock_create_schema = MagicMock()
+    monkeypatch.setattr(
+        "databricks_langchain.checkpoint.LakebaseClient.create_schema", mock_create_schema
+    )
+
     saver = CheckpointSaver(
         instance_name="lakebase-instance",
         workspace_client=workspace,
         schema="my_schema",
     )
-    saver._lakebase.create_schema = MagicMock()  # type: ignore[assignment]
     saver.setup()
 
-    saver._lakebase.create_schema.assert_called_once()  # type: ignore[union-attr]
+    mock_create_schema.assert_called_once()
 
 
 @pytest.mark.asyncio

--- a/integrations/langchain/tests/unit_tests/test_store.py
+++ b/integrations/langchain/tests/unit_tests/test_store.py
@@ -668,13 +668,18 @@ async def test_async_databricks_store_branch_resource_path(monkeypatch):
 
 
 def test_databricks_store_setup_calls_create_schema(monkeypatch):
-    """DatabricksStore.setup() delegates schema creation to LakebasePool.create_schema()."""
+    """DatabricksStore.setup() delegates schema creation to LakebaseClient.create_schema()."""
     test_pool = TestConnectionPool()
     monkeypatch.setattr(lakebase, "ConnectionPool", test_pool)
 
     from langgraph.store.postgres import PostgresStore
 
     monkeypatch.setattr(PostgresStore, "setup", MagicMock())
+
+    mock_create_schema = MagicMock()
+    monkeypatch.setattr(
+        "databricks_langchain.store.LakebaseClient.create_schema", mock_create_schema
+    )
 
     workspace = _create_mock_workspace()
 
@@ -683,10 +688,9 @@ def test_databricks_store_setup_calls_create_schema(monkeypatch):
         workspace_client=workspace,
         schema="my_schema",
     )
-    store._lakebase.create_schema = MagicMock()  # type: ignore[assignment]
     store.setup()
 
-    store._lakebase.create_schema.assert_called_once()  # type: ignore[union-attr]
+    mock_create_schema.assert_called_once()
 
 
 @pytest.mark.asyncio

--- a/integrations/langchain/tests/unit_tests/test_store.py
+++ b/integrations/langchain/tests/unit_tests/test_store.py
@@ -695,7 +695,7 @@ def test_databricks_store_setup_calls_create_schema(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_async_databricks_store_setup_calls_create_schema(monkeypatch):
-    """AsyncDatabricksStore.setup() delegates schema creation to AsyncLakebasePool.create_schema()."""
+    """AsyncDatabricksStore.setup() delegates schema creation to LakebaseClient.acreate_schema()."""
     from unittest.mock import AsyncMock
 
     test_pool = TestAsyncConnectionPool()
@@ -705,6 +705,11 @@ async def test_async_databricks_store_setup_calls_create_schema(monkeypatch):
 
     monkeypatch.setattr(AsyncPostgresStore, "setup", AsyncMock())
 
+    mock_acreate_schema = AsyncMock()
+    monkeypatch.setattr(
+        "databricks_langchain.store.LakebaseClient.acreate_schema", mock_acreate_schema
+    )
+
     workspace = _create_mock_workspace()
 
     store = AsyncDatabricksStore(
@@ -712,7 +717,6 @@ async def test_async_databricks_store_setup_calls_create_schema(monkeypatch):
         workspace_client=workspace,
         schema="my_schema",
     )
-    store._lakebase.create_schema = AsyncMock()  # type: ignore[assignment]
     await store.setup()
 
-    store._lakebase.create_schema.assert_called_once()  # type: ignore[union-attr]
+    mock_acreate_schema.assert_called_once()

--- a/src/databricks_ai_bridge/lakebase.py
+++ b/src/databricks_ai_bridge/lakebase.py
@@ -505,15 +505,6 @@ class LakebasePool(_LakebaseBase):
         """Get a connection from the pool."""
         return self._pool.connection()
 
-    def create_schema(self) -> None:
-        """Create the schema if one was specified at init time. No-op otherwise."""
-        if not self.schema:
-            return
-        with self.connection() as conn:
-            conn.execute(
-                sql.SQL("CREATE SCHEMA IF NOT EXISTS {}").format(sql.Identifier(self.schema))
-            )
-
     def close(self) -> None:
         """Close the connection pool."""
         self._pool.close()
@@ -657,9 +648,12 @@ class AsyncLakebasePool(_LakebaseBase):
         if not self.schema:
             return
         async with self.connection() as conn:
-            await conn.execute(
-                sql.SQL("CREATE SCHEMA IF NOT EXISTS {}").format(sql.Identifier(self.schema))
-            )
+            async with conn.cursor() as cur:
+                await cur.execute(
+                    sql.SQL("CREATE SCHEMA IF NOT EXISTS {}").format(
+                        sql.Identifier(self.schema)
+                    )
+                )
 
     async def close(self) -> None:
         """Close the connection pool."""
@@ -837,6 +831,20 @@ class LakebaseClient:
                 if cur.description:
                     return cur.fetchall()
                 return None
+
+    # ---------------------------------------------------------
+    # Schema Management
+    # ---------------------------------------------------------
+
+    def create_schema(self) -> None:
+        """Create the schema if one was specified on the underlying pool. No-op otherwise."""
+        if not self._pool.schema:
+            return
+        self._execute_composed(
+            sql.SQL("CREATE SCHEMA IF NOT EXISTS {}").format(
+                sql.Identifier(self._pool.schema)
+            )
+        )
 
     # ---------------------------------------------------------
     # Permission / Role Management

--- a/src/databricks_ai_bridge/lakebase.py
+++ b/src/databricks_ai_bridge/lakebase.py
@@ -832,9 +832,7 @@ class LakebaseClient:
         with pool.connection() as conn:
             with conn.cursor() as cur:
                 cur.execute(
-                    sql.SQL("CREATE SCHEMA IF NOT EXISTS {}").format(
-                        sql.Identifier(pool.schema)
-                    )
+                    sql.SQL("CREATE SCHEMA IF NOT EXISTS {}").format(sql.Identifier(pool.schema))
                 )
 
     @staticmethod
@@ -845,9 +843,7 @@ class LakebaseClient:
         async with pool.connection() as conn:
             async with conn.cursor() as cur:
                 await cur.execute(
-                    sql.SQL("CREATE SCHEMA IF NOT EXISTS {}").format(
-                        sql.Identifier(pool.schema)
-                    )
+                    sql.SQL("CREATE SCHEMA IF NOT EXISTS {}").format(sql.Identifier(pool.schema))
                 )
 
     # ---------------------------------------------------------

--- a/src/databricks_ai_bridge/lakebase.py
+++ b/src/databricks_ai_bridge/lakebase.py
@@ -643,18 +643,6 @@ class AsyncLakebasePool(_LakebaseBase):
         """Open the connection pool."""
         await self._pool.open()
 
-    async def create_schema(self) -> None:
-        """Create the schema if one was specified at init time. No-op otherwise."""
-        if not self.schema:
-            return
-        async with self.connection() as conn:
-            async with conn.cursor() as cur:
-                await cur.execute(
-                    sql.SQL("CREATE SCHEMA IF NOT EXISTS {}").format(
-                        sql.Identifier(self.schema)
-                    )
-                )
-
     async def close(self) -> None:
         """Close the connection pool."""
         await self._pool.close()
@@ -836,15 +824,31 @@ class LakebaseClient:
     # Schema Management
     # ---------------------------------------------------------
 
-    def create_schema(self) -> None:
-        """Create the schema if one was specified on the underlying pool. No-op otherwise."""
-        if not self._pool.schema:
+    @staticmethod
+    def create_schema(pool: LakebasePool) -> None:
+        """Create the schema if one was specified on the pool. No-op otherwise."""
+        if not pool.schema:
             return
-        self._execute_composed(
-            sql.SQL("CREATE SCHEMA IF NOT EXISTS {}").format(
-                sql.Identifier(self._pool.schema)
-            )
-        )
+        with pool.connection() as conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    sql.SQL("CREATE SCHEMA IF NOT EXISTS {}").format(
+                        sql.Identifier(pool.schema)
+                    )
+                )
+
+    @staticmethod
+    async def acreate_schema(pool: AsyncLakebasePool) -> None:
+        """Async variant of create_schema for use with AsyncLakebasePool. No-op if no schema."""
+        if not pool.schema:
+            return
+        async with pool.connection() as conn:
+            async with conn.cursor() as cur:
+                await cur.execute(
+                    sql.SQL("CREATE SCHEMA IF NOT EXISTS {}").format(
+                        sql.Identifier(pool.schema)
+                    )
+                )
 
     # ---------------------------------------------------------
     # Permission / Role Management

--- a/tests/databricks_ai_bridge/test_lakebase.py
+++ b/tests/databricks_ai_bridge/test_lakebase.py
@@ -2127,8 +2127,7 @@ def test_lakebase_client_create_schema(monkeypatch):
         workspace_client=workspace,
         schema="my_schema",
     )
-    client = LakebaseClient(pool=pool)
-    client.create_schema()
+    LakebaseClient.create_schema(pool)
 
     mock_cursor.execute.assert_called_once()
     executed_sql = str(mock_cursor.execute.call_args[0][0])
@@ -2136,8 +2135,8 @@ def test_lakebase_client_create_schema(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_async_lakebase_pool_create_schema(monkeypatch):
-    """AsyncLakebasePool.create_schema() executes CREATE SCHEMA when schema is set."""
+async def test_async_lakebase_client_acreate_schema(monkeypatch):
+    """LakebaseClient.acreate_schema() executes CREATE SCHEMA via the client layer."""
     mock_cursor = AsyncMock()
 
     class _AsyncCursorContextManager:
@@ -2171,7 +2170,7 @@ async def test_async_lakebase_pool_create_schema(monkeypatch):
         workspace_client=workspace,
         schema="my_schema",
     )
-    await pool.create_schema()
+    await LakebaseClient.acreate_schema(pool)
 
     mock_cursor.execute.assert_called_once()
     executed_sql = str(mock_cursor.execute.call_args[0][0])

--- a/tests/databricks_ai_bridge/test_lakebase.py
+++ b/tests/databricks_ai_bridge/test_lakebase.py
@@ -2105,9 +2105,12 @@ def test_lakebase_pool_preserves_user_configure_when_no_schema(monkeypatch):
     )
 
 
-def test_lakebase_pool_create_schema(monkeypatch):
-    """LakebasePool.create_schema() executes CREATE SCHEMA when schema is set."""
+def test_lakebase_client_create_schema(monkeypatch):
+    """LakebaseClient.create_schema() executes CREATE SCHEMA via the client layer."""
+    mock_cursor = MagicMock()
     mock_conn = MagicMock()
+    mock_conn.cursor.return_value.__enter__ = MagicMock(return_value=mock_cursor)
+    mock_conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
 
     class TestPool:
         def __init__(self, **kwargs):
@@ -2124,18 +2127,28 @@ def test_lakebase_pool_create_schema(monkeypatch):
         workspace_client=workspace,
         schema="my_schema",
     )
-    pool.create_schema()
+    client = LakebaseClient(pool=pool)
+    client.create_schema()
 
-    mock_conn.execute.assert_called_once()
-    executed_sql = str(mock_conn.execute.call_args[0][0])
+    mock_cursor.execute.assert_called_once()
+    executed_sql = str(mock_cursor.execute.call_args[0][0])
     assert "my_schema" in executed_sql
 
 
 @pytest.mark.asyncio
 async def test_async_lakebase_pool_create_schema(monkeypatch):
     """AsyncLakebasePool.create_schema() executes CREATE SCHEMA when schema is set."""
+    mock_cursor = AsyncMock()
+
+    class _AsyncCursorContextManager:
+        async def __aenter__(self):
+            return mock_cursor
+
+        async def __aexit__(self, *args):
+            return False
+
     mock_conn = MagicMock()
-    mock_conn.execute = AsyncMock()
+    mock_conn.cursor.return_value = _AsyncCursorContextManager()
 
     class TestPool:
         def __init__(self, **kwargs):
@@ -2160,8 +2173,8 @@ async def test_async_lakebase_pool_create_schema(monkeypatch):
     )
     await pool.create_schema()
 
-    mock_conn.execute.assert_called_once()
-    executed_sql = str(mock_conn.execute.call_args[0][0])
+    mock_cursor.execute.assert_called_once()
+    executed_sql = str(mock_cursor.execute.call_args[0][0])
     assert "my_schema" in executed_sql
 
 


### PR DESCRIPTION
- Move create_schema / acreate_schema from the pool layer (LakebasePool / AsyncLakebasePool) to LakebaseClient as static methods — schema creation is a client-level concern, not a pool responsibility
  - Remove unused _schema attributes from CheckpointSaver, AsyncCheckpointSaver, DatabricksStore, and AsyncDatabricksStore
  - Switch schema DDL execution from conn.execute() to explicit cursor.execute() for consistency with the rest of LakebaseClient