### PR TITLE
Release Databricks AI Bridge 0.19.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # CHANGELOG
 
+## databricks-ai-bridge 0.19.0 databricks-langchain 0.19.0 databricks-openai 0.15.0 databricks-mcp 0.10.0 (2026-04-22)
+
+### New Features
+- databricks-ai-bridge / databricks-langchain / databricks-openai: Agent Memory SDKs now allow custom schemas for Lakebase-backed checkpointers, stores, and sessions (#415)
+
+### Improvements
+- databricks-langchain: `ChatDatabricks` now uses `DatabricksOpenAI` under the hood (#418)
+- Agent Memory SDK cleanup across `databricks-ai-bridge` Lakebase utilities and `databricks-langchain` checkpoint/store (#420)
+
+### Bug Fixes
+- databricks-ai-bridge: Use the last query attachment in `_parse_attachments` to support Genie self-correction (#419)
+
 ## databricks-ai-bridge 0.17.0 databricks-langchain 0.17.0 databricks-openai 0.13.0 (2026-03-09)
 
 ### Release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # CHANGELOG
 
-## databricks-ai-bridge 0.19.0 databricks-langchain 0.19.0 databricks-openai 0.15.0 databricks-mcp 0.10.0 (2026-04-22)
+## databricks-ai-bridge 0.19.0 databricks-langchain 0.19.0 databricks-openai 0.15.0 (2026-04-22)
 
 ### New Features
 - databricks-ai-bridge / databricks-langchain / databricks-openai: Agent Memory SDKs now allow custom schemas for Lakebase-backed checkpointers, stores, and sessions (#415)

--- a/databricks_mcp/pyproject.toml
+++ b/databricks_mcp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "databricks-mcp"
-version = "0.10.0"
+version = "0.9.0"
 description = "MCP helpers for Databricks"
 authors = [
     { name="Databricks", email="agent-feedback@databricks.com" },

--- a/databricks_mcp/pyproject.toml
+++ b/databricks_mcp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "databricks-mcp"
-version = "0.9.0"
+version = "0.10.0"
 description = "MCP helpers for Databricks"
 authors = [
     { name="Databricks", email="agent-feedback@databricks.com" },

--- a/integrations/langchain/pyproject.toml
+++ b/integrations/langchain/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "databricks-langchain"
-version = "0.18.0"
+version = "0.19.0"
 description = "Support for Databricks AI support in LangChain"
 authors = [
     { name="Databricks", email="agent-feedback@databricks.com" },
@@ -11,7 +11,7 @@ requires-python = ">=3.10"
 dependencies = [
     "langchain>=1.0.0",
     "databricks-vectorsearch>=0.50",
-    "databricks-ai-bridge>=0.18.0",
+    "databricks-ai-bridge>=0.19.0",
     "mlflow>=3.0.0",
     "pydantic>2.10.0",
     "unitycatalog-langchain[databricks]>=0.3.0",

--- a/integrations/openai/pyproject.toml
+++ b/integrations/openai/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "databricks-openai"
-version = "0.14.0"
+version = "0.15.0"
 description = "Support for Databricks AI support with OpenAI"
 authors = [
     { name="Databricks", email="agent-feedback@databricks.com" },
@@ -10,7 +10,7 @@ license = { text="Apache-2.0" }
 requires-python = ">=3.10"
 dependencies = [
     "databricks-vectorsearch>=0.50",
-    "databricks-ai-bridge>=0.18.0",
+    "databricks-ai-bridge>=0.19.0",
     "openai>=1.99.9",
     "pydantic>2.10.0",
     "mlflow>=3.10.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "databricks-ai-bridge"
-version = "0.18.0"
+version = "0.19.0"
 description = "Official Python library for Databricks AI support"
 authors = [
     { name="Databricks", email="agent-feedback@databricks.com" },


### PR DESCRIPTION
Change Log:

databricks-ai-bridge (core)
- [#415] Agent Memory SDKs: allow for custom schemas — Lakebase-backed checkpointer/store/session now support custom DB schemas.
- [#419] Use last query attachment in `_parse_attachments` to support Genie self-correction.
- [#420] Agent Memory SDK cleanup — refactor of Lakebase utilities.

---
databricks-langchain
- [#415] Agent Memory SDKs: allow for custom schemas in `checkpoint` and `store`.
- [#418] Update `ChatDatabricks` to use `DatabricksOpenAI` under the hood.
- [#420] Agent Memory SDK cleanup — checkpoint/store refactor.

---
databricks-openai
- [#415] Agent Memory SDKs: allow for custom schemas in `AsyncDatabricksSession`.