### PR TITLE
Call saver.setup() explicitly in autoscaling checkpoint tests

### DIFF
--- a/integrations/langchain/tests/integration_tests/test_langchain_lakebase.py
+++ b/integrations/langchain/tests/integration_tests/test_langchain_lakebase.py
@@ -457,10 +457,12 @@ class TestAutoscalingProjectBranch:
         assert store._lakebase.pool.closed
 
     def test_checkpoint_write_and_read(self, cleanup_all_tables_project_branch):
-        """Test CheckpointSaver: context manager auto-setup + put + get_tuple."""
+        """Test CheckpointSaver: setup + put + get_tuple + pool cleanup."""
         thread_id = uuid.uuid4().hex
 
         with CheckpointSaver(project=get_project(), branch=get_branch()) as saver:
+            saver.setup()
+
             config = {"configurable": {"thread_id": thread_id, "checkpoint_ns": ""}}
             checkpoint = _make_checkpoint()
             saver.put(config, checkpoint, CheckpointMetadata(), {})
@@ -473,10 +475,12 @@ class TestAutoscalingProjectBranch:
 
     @pytest.mark.asyncio
     async def test_async_checkpoint_write_and_read(self, cleanup_all_tables_project_branch):
-        """Test AsyncCheckpointSaver: async context manager auto-setup + put + get_tuple."""
+        """Test AsyncCheckpointSaver: setup + put + get_tuple + pool cleanup."""
         thread_id = uuid.uuid4().hex
 
         async with AsyncCheckpointSaver(project=get_project(), branch=get_branch()) as saver:
+            await saver.setup()
+
             config = {"configurable": {"thread_id": thread_id, "checkpoint_ns": ""}}
             checkpoint = _make_checkpoint()
             await saver.aput(config, checkpoint, CheckpointMetadata(), {})
@@ -526,10 +530,12 @@ class TestAutoscalingEndpoint:
         assert store._lakebase.pool.closed
 
     def test_checkpoint_write_and_read(self, cleanup_all_tables_endpoint):
-        """Test CheckpointSaver: endpoint context manager auto-setup + put + get_tuple."""
+        """Test CheckpointSaver: setup + put + get_tuple + pool cleanup."""
         thread_id = uuid.uuid4().hex
 
         with CheckpointSaver(autoscaling_endpoint=get_autoscaling_endpoint()) as saver:
+            saver.setup()
+
             config = {"configurable": {"thread_id": thread_id, "checkpoint_ns": ""}}
             checkpoint = _make_checkpoint()
             saver.put(config, checkpoint, CheckpointMetadata(), {})
@@ -542,10 +548,12 @@ class TestAutoscalingEndpoint:
 
     @pytest.mark.asyncio
     async def test_async_checkpoint_write_and_read(self, cleanup_all_tables_endpoint):
-        """Test AsyncCheckpointSaver: async endpoint pool lifecycle."""
+        """Test AsyncCheckpointSaver: setup + put + get_tuple + pool cleanup."""
         thread_id = uuid.uuid4().hex
 
         async with AsyncCheckpointSaver(autoscaling_endpoint=get_autoscaling_endpoint()) as saver:
+            await saver.setup()
+
             config = {"configurable": {"thread_id": thread_id, "checkpoint_ns": ""}}
             checkpoint = _make_checkpoint()
             await saver.aput(config, checkpoint, CheckpointMetadata(), {})


### PR DESCRIPTION
## TL;DR

Four autoscaling checkpoint tests in `test_langchain_lakebase.py` have been silently broken since **#396** (2026-03-26) removed auto-`setup()` from `CheckpointSaver.__enter__`. The failures weren't visible on CI because an earlier step in the same job was short-circuiting; they surfaced now that the nightly runs are moving past that earlier step.

- ✅ **Passing run on this PR's branch:** [databricks-eng/ai-oss-integration-tests-runner#24863315937](https://github.com/databricks-eng/ai-oss-integration-tests-runner/actions/runs/24863315937) — `lakebase-tests` green, all 4 previously-failing autoscaling checkpoint tests pass.
- ❌ **Currently failing run on `main`:** [databricks-eng/ai-oss-integration-tests-runner#24862876705 → lakebase-tests → Run LangChain Lakebase Integration Tests](https://github.com/databricks-eng/ai-oss-integration-tests-runner/actions/runs/24862876705)
- **PR that introduced the breakage:** [#396 — "langchain checkpointer fix"](https://github.com/databricks/databricks-ai-bridge/pull/396)
- **Runner-repo fix unblocking the earlier step so these failures surfaced:** [databricks-eng/ai-oss-integration-tests-runner#51](https://github.com/databricks-eng/ai-oss-integration-tests-runner/pull/51)

## Why they broke

PR #396 removed auto-`setup()` from `CheckpointSaver.__enter__` / `AsyncCheckpointSaver.__aenter__`, because concurrent context-manager entries in production were racing on `INSERT INTO checkpoint_migrations` and hitting:

```
psycopg.errors.UniqueViolation: duplicate key value violates unique constraint "checkpoint_migrations_pkey"
DETAIL:  Key (v)=(7) already exists.
```

The new contract is "caller invokes `setup()` once at app startup." The provisioned checkpoint tests in this file were already following that pattern. The autoscaling checkpoint tests (added in #374, before #396 landed) weren't — they entered the context manager and went straight to `saver.put(...)`, so `put` hit:

```
psycopg.errors.UndefinedTable: relation "checkpoints" does not exist
```

## What this PR changes

Add explicit `saver.setup()` / `await saver.setup()` at the top of the four autoscaling checkpoint tests, matching the provisioned-variant pattern already present in the same file. Tighten the docstrings to match ("setup + put + get_tuple + pool cleanup").

Affects:
- `TestAutoscalingProjectBranch.test_checkpoint_write_and_read`
- `TestAutoscalingProjectBranch.test_async_checkpoint_write_and_read`
- `TestAutoscalingEndpoint.test_checkpoint_write_and_read`
- `TestAutoscalingEndpoint.test_async_checkpoint_write_and_read`

No library changes — this is a pure test fix to align with the post-#396 contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
## Verification

Targeted validation on the runner repo with:
- `databricks-ai-bridge` checked out at this PR's branch (`fix-autoscaling-checkpoint-tests-setup`)
- Only the `lakebase-tests` job enabled (others skipped with `if: false`)

Result: [run 24863315937](https://github.com/databricks-eng/ai-oss-integration-tests-runner/actions/runs/24863315937) → `lakebase-tests` green. All three lakebase steps pass:
- Core: **69 passed**
- OpenAI: **8 passed**
- LangChain: includes the 4 autoscaling checkpoint tests that failed on `main` (`TestAutoscalingProjectBranch.test_checkpoint_write_and_read`, `TestAutoscalingProjectBranch.test_async_checkpoint_write_and_read`, `TestAutoscalingEndpoint.test_checkpoint_write_and_read`, `TestAutoscalingEndpoint.test_async_checkpoint_write_and_read`) — all now passing.

The diff is +12/-4 in one test file; no behavior change to `CheckpointSaver` / `AsyncCheckpointSaver`. The provisioned variants of these tests (which already call `setup()` explicitly) have been green throughout, confirming the same pattern works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)