### PR TITLE
Forward extra kwargs in McpServer.call_tool override

### DIFF
--- a/integrations/openai/src/databricks_openai/agents/mcp_server.py
+++ b/integrations/openai/src/databricks_openai/agents/mcp_server.py
@@ -274,8 +274,18 @@ class McpServer(MCPServerStreamableHttp):
         )
 
     @mlflow.trace(span_type=SpanType.TOOL)
-    async def call_tool(self, tool_name: str, arguments: dict[str, Any] | None) -> CallToolResult:
-        return await super().call_tool(tool_name, arguments)
+    async def call_tool(
+        self,
+        tool_name: str,
+        arguments: dict[str, Any] | None,
+        **kwargs: Any,
+    ) -> CallToolResult:
+        # Forward any extra kwargs (e.g. ``meta``) added by newer openai-agents
+        # versions so the override stays compatible across SDK releases. Older
+        # parents that don't accept these kwargs aren't sent any — the SDK only
+        # passes them when the corresponding feature is in use — so empty kwargs
+        # forward cleanly.
+        return await super().call_tool(tool_name, arguments, **kwargs)
 
     def create_streams(
         self,

--- a/integrations/openai/src/databricks_openai/agents/mcp_server.py
+++ b/integrations/openai/src/databricks_openai/agents/mcp_server.py
@@ -280,11 +280,8 @@ class McpServer(MCPServerStreamableHttp):
         arguments: dict[str, Any] | None,
         **kwargs: Any,
     ) -> CallToolResult:
-        # Forward any extra kwargs (e.g. ``meta``) added by newer openai-agents
-        # versions so the override stays compatible across SDK releases. Older
-        # parents that don't accept these kwargs aren't sent any — the SDK only
-        # passes them when the corresponding feature is in use — so empty kwargs
-        # forward cleanly.
+        # Forward extra kwargs (e.g. `meta` from newer openai-agents) so this
+        # override stays signature-compatible across SDK versions.
         return await super().call_tool(tool_name, arguments, **kwargs)
 
     def create_streams(

--- a/integrations/openai/tests/unit_tests/test_mcp_server.py
+++ b/integrations/openai/tests/unit_tests/test_mcp_server.py
@@ -1,4 +1,4 @@
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from agents.mcp import MCPServerStreamableHttpParams
@@ -232,3 +232,36 @@ class TestMcpServerFromUCResource:
                 == "https://test.databricks.com/api/2.0/mcp/vector-search/system/ai/test_index"
             )
             assert server.workspace_client == mock_workspace_client
+
+
+class TestMcpServerCallTool:
+    """The override must forward extra kwargs (e.g. ``meta``) the agents SDK passes."""
+
+    @pytest.mark.asyncio
+    async def test_call_tool_forwards_extra_kwargs(self, mock_workspace_client):
+        with patch(
+            "databricks_openai.agents.mcp_server.WorkspaceClient",
+            return_value=mock_workspace_client,
+        ):
+            from databricks_openai.agents.mcp_server import McpServer
+
+            server = McpServer(url="https://test.com/mcp")
+
+            sentinel = object()
+            with patch(
+                "agents.mcp.MCPServerStreamableHttp.call_tool",
+                new=AsyncMock(return_value=sentinel),
+            ) as mock_super_call:
+                # No extra kwargs — should call through with positional args only.
+                result = await server.call_tool("my_tool", {"x": 1})
+                assert result is sentinel
+                mock_super_call.assert_awaited_once_with("my_tool", {"x": 1})
+
+                mock_super_call.reset_mock()
+
+                # With ``meta`` — must be forwarded so newer openai-agents
+                # versions that pass meta don't break with TypeError.
+                meta = {"trace_id": "abc"}
+                result = await server.call_tool("my_tool", {"x": 1}, meta=meta)
+                assert result is sentinel
+                mock_super_call.assert_awaited_once_with("my_tool", {"x": 1}, meta=meta)


### PR DESCRIPTION
The override `McpServer.call_tool(self, tool_name, arguments)` drops kwargs that newer versions of `openai-agents` pass to the parent. When the agents SDK at `agents/mcp/util.py` resolves a non-None `merged_meta`, it calls `server.call_tool(tool.name, json_data, meta=merged_meta)`, which fails:

    TypeError: McpServer.call_tool() got an unexpected keyword argument 'meta'

This breaks all MCP tool calls (system.ai UC functions, Genie spaces, Vector Search, custom Apps-hosted MCP servers) for users on a recent `openai-agents` whenever the meta-passing branch is taken.

Forward `**kwargs` to the parent so the override stays compatible with both old and new SDK signatures: empty kwargs forward as no-ops to old parents, and `meta` (or any future additions) reach new parents intact.

Co-authored-by: Isaac