### PR TITLE
test_vector_search_retriever_tool: flush async traces before assertion

### DIFF
--- a/integrations/langchain/tests/unit_tests/test_vector_search_retriever_tool.py
+++ b/integrations/langchain/tests/unit_tests/test_vector_search_retriever_tool.py
@@ -214,6 +214,7 @@ def test_vector_search_retriever_tool_description_generation(index_name: str) ->
 def test_vs_tool_tracing(index_name: str, tool_name: str | None) -> None:
     vector_search_tool = init_vector_search_tool(index_name, tool_name=tool_name)
     vector_search_tool._run("Databricks Agent Framework")
+    mlflow.flush_trace_async_logging()
     trace = mlflow.get_trace(mlflow.get_last_active_trace_id())
     spans = trace.search_spans(name=tool_name or index_name, span_type=SpanType.RETRIEVER)
     assert len(spans) == 1

--- a/integrations/openai/tests/unit_tests/test_vector_search_retriever_tool.py
+++ b/integrations/openai/tests/unit_tests/test_vector_search_retriever_tool.py
@@ -187,6 +187,7 @@ def test_vector_search_retriever_tool_init(
     assert all(["id" in d["metadata"] for d in docs])
 
     # Ensure tracing works properly
+    mlflow.flush_trace_async_logging()
     trace = mlflow.get_trace(mlflow.get_last_active_trace_id())
     spans = trace.search_spans(name=tool_name or index_name, span_type=SpanType.RETRIEVER)
     assert len(spans) == 1


### PR DESCRIPTION
## Summary

Two-line test fix for a CI regression introduced by mlflow 3.12 (released 2026-05-05).

mlflow 3.12 flipped OSS-default trace logging from synchronous to asynchronous ([mlflow/mlflow#22304](https://github.com/mlflow/mlflow/pull/22304) deleted the early-return in `MlflowV3SpanExporter._should_enable_async_logging()` that previously forced sync for non-Databricks tracking URIs). After the bump, this pattern in our retriever-tracing tests:

```python
vector_search_tool._run("Databricks Agent Framework")
trace = mlflow.get_trace(mlflow.get_last_active_trace_id())
spans = trace.search_spans(...)
```

reads the span store before the `BatchSpanProcessor` has flushed the just-ended span. `get_trace` returns `None`, the next line fails with:

```
AttributeError: 'NoneType' object has no attribute 'search_spans'
```

The fix is a single `mlflow.flush_trace_async_logging()` call before the read. That public API has existed since at least mlflow 3.10.1 (no-op when async logging isn't enabled), so it works on both `uv: highest` and `uv: lowest-direct` matrix variants without a version pin or any other resolution-dependent code.

## Why it didn't show up sooner

Bridge `main` last ran CI on 2026-05-01 (the #425 merge). mlflow 3.12 shipped on 2026-05-05. The next CI run after that bump was on [#427](https://github.com/databricks/databricks-ai-bridge/pull/427), which is how this surfaced. The matrix tells the whole story:

| Job | Result on #427 | Why |
|---|---|---|
| `openai_test (uv: highest)` | fail | resolves `mlflow==3.12.0`, async on |
| `openai_test (uv: lowest-direct)` | pass | resolves older sync-default mlflow per the floor pin |
| `langchain_test (uv: highest)` | fail | same |
| `langchain_test (3.10, v0.2.0–v0.5.0)` | pass | pin `mlflow==3.10.1` explicitly |

A fresh `main` CI run today would fail identically without this patch.

## Files

| File | Change |
|---|---|
| `integrations/openai/tests/unit_tests/test_vector_search_retriever_tool.py:189` | add `mlflow.flush_trace_async_logging()` before `mlflow.get_trace(...)` |
| `integrations/langchain/tests/unit_tests/test_vector_search_retriever_tool.py:216` | same |

No production code touched, no version pin.

## Test plan

- [x] CI green on `openai_test`, `langchain_test`, and `_with_extras` variants on both `uv: highest` and `uv: lowest-direct` (this PR opens to verify)