### PR TITLE
DatabricksOpenAI: forward extra kwargs to OpenAI init

### DIFF
--- a/integrations/langchain/tests/unit_tests/test_chat_models.py
+++ b/integrations/langchain/tests/unit_tests/test_chat_models.py
@@ -123,26 +123,6 @@ def test_timeout_and_max_retries_parameters() -> None:
     assert llm.max_retries == 5
 
 
-def test_async_client_forwards_timeout_and_max_retries() -> None:
-    """Regression test for issue #423: async_client used to crash on these kwargs."""
-    from unittest.mock import MagicMock
-
-    mock_workspace_client = MagicMock(spec=sdk.WorkspaceClient)
-    mock_workspace_client.config.host = "https://test.databricks.com"
-    mock_workspace_client.config.authenticate.return_value = {"Authorization": "Bearer t"}
-
-    llm = ChatDatabricks(
-        model="test-model",
-        workspace_client=mock_workspace_client,
-        timeout=42.0,
-        max_retries=8,
-    )
-
-    async_client = llm.async_client
-    assert async_client.timeout == 42.0
-    assert async_client.max_retries == 8
-
-
 def test_timeout_and_max_retries_with_workspace_client() -> None:
     """Test timeout and max_retries parameters work with workspace_client."""
     from unittest.mock import Mock, patch

--- a/integrations/langchain/tests/unit_tests/test_chat_models.py
+++ b/integrations/langchain/tests/unit_tests/test_chat_models.py
@@ -123,6 +123,26 @@ def test_timeout_and_max_retries_parameters() -> None:
     assert llm.max_retries == 5
 
 
+def test_async_client_forwards_timeout_and_max_retries() -> None:
+    """Regression test for issue #423: async_client used to crash on these kwargs."""
+    from unittest.mock import MagicMock
+
+    mock_workspace_client = MagicMock(spec=sdk.WorkspaceClient)
+    mock_workspace_client.config.host = "https://test.databricks.com"
+    mock_workspace_client.config.authenticate.return_value = {"Authorization": "Bearer t"}
+
+    llm = ChatDatabricks(
+        model="test-model",
+        workspace_client=mock_workspace_client,
+        timeout=42.0,
+        max_retries=8,
+    )
+
+    async_client = llm.async_client
+    assert async_client.timeout == 42.0
+    assert async_client.max_retries == 8
+
+
 def test_timeout_and_max_retries_with_workspace_client() -> None:
     """Test timeout and max_retries parameters work with workspace_client."""
     from unittest.mock import Mock, patch

--- a/integrations/openai/src/databricks_openai/utils/clients.py
+++ b/integrations/openai/src/databricks_openai/utils/clients.py
@@ -343,6 +343,10 @@ class DatabricksOpenAI(OpenAI):
             with ``base_url`` or ``use_ai_gateway``. Defaults to False.
         use_ai_gateway: If True, auto-detect AI Gateway V2 availability and route
             requests through it using the MLflow API. Defaults to False.
+        **kwargs: Additional keyword arguments forwarded to the underlying ``openai.OpenAI``
+            client (e.g. ``timeout``, ``max_retries``, ``default_headers``). ``api_key`` and
+            ``http_client`` are managed internally for Databricks authentication and cannot
+            be overridden.
 
     Example - Query a serving or AI gateway endpoint:
         >>> client = DatabricksOpenAI()
@@ -506,6 +510,10 @@ class AsyncDatabricksOpenAI(AsyncOpenAI):
             with ``base_url`` or ``use_ai_gateway``. Defaults to False.
         use_ai_gateway: If True, auto-detect AI Gateway V2 availability and route
             requests through it using the MLflow API. Defaults to False.
+        **kwargs: Additional keyword arguments forwarded to the underlying ``openai.AsyncOpenAI``
+            client (e.g. ``timeout``, ``max_retries``, ``default_headers``). ``api_key`` and
+            ``http_client`` are managed internally for Databricks authentication and cannot
+            be overridden.
 
     Example - Query a serving or AI gateway endpoint:
         >>> client = AsyncDatabricksOpenAI()

--- a/integrations/openai/src/databricks_openai/utils/clients.py
+++ b/integrations/openai/src/databricks_openai/utils/clients.py
@@ -344,9 +344,7 @@ class DatabricksOpenAI(OpenAI):
         use_ai_gateway: If True, auto-detect AI Gateway V2 availability and route
             requests through it using the MLflow API. Defaults to False.
         **kwargs: Additional keyword arguments forwarded to the underlying ``openai.OpenAI``
-            client (e.g. ``timeout``, ``max_retries``, ``default_headers``). ``api_key`` and
-            ``http_client`` are managed internally for Databricks authentication and cannot
-            be overridden.
+            client (e.g. ``timeout``, ``max_retries``, ``default_headers``).
 
     Example - Query a serving or AI gateway endpoint:
         >>> client = DatabricksOpenAI()
@@ -511,9 +509,7 @@ class AsyncDatabricksOpenAI(AsyncOpenAI):
         use_ai_gateway: If True, auto-detect AI Gateway V2 availability and route
             requests through it using the MLflow API. Defaults to False.
         **kwargs: Additional keyword arguments forwarded to the underlying ``openai.AsyncOpenAI``
-            client (e.g. ``timeout``, ``max_retries``, ``default_headers``). ``api_key`` and
-            ``http_client`` are managed internally for Databricks authentication and cannot
-            be overridden.
+            client (e.g. ``timeout``, ``max_retries``, ``default_headers``).
 
     Example - Query a serving or AI gateway endpoint:
         >>> client = AsyncDatabricksOpenAI()

--- a/integrations/openai/src/databricks_openai/utils/clients.py
+++ b/integrations/openai/src/databricks_openai/utils/clients.py
@@ -385,6 +385,7 @@ class DatabricksOpenAI(OpenAI):
         base_url: str | None = None,
         use_ai_gateway_native_api: bool = False,
         use_ai_gateway: bool = False,
+        **kwargs: Any,
     ):
         if workspace_client is None:
             workspace_client = WorkspaceClient()
@@ -400,6 +401,7 @@ class DatabricksOpenAI(OpenAI):
             base_url=target_base_url,
             api_key=_get_openai_api_key(),
             http_client=_get_authorized_http_client(workspace_client),
+            **kwargs,
         )
 
     @override
@@ -546,6 +548,7 @@ class AsyncDatabricksOpenAI(AsyncOpenAI):
         base_url: str | None = None,
         use_ai_gateway_native_api: bool = False,
         use_ai_gateway: bool = False,
+        **kwargs: Any,
     ):
         if workspace_client is None:
             workspace_client = WorkspaceClient()
@@ -561,6 +564,7 @@ class AsyncDatabricksOpenAI(AsyncOpenAI):
             base_url=target_base_url,
             api_key=_get_openai_api_key(),
             http_client=_get_authorized_async_http_client(workspace_client),
+            **kwargs,
         )
 
     @property

--- a/integrations/openai/tests/unit_tests/test_clients.py
+++ b/integrations/openai/tests/unit_tests/test_clients.py
@@ -168,6 +168,18 @@ class TestAsyncDatabricksOpenAI:
         mock_workspace_client.config.authenticate.assert_called()
 
 
+class TestDatabricksOpenAIKwargForwarding:
+    """Forwarding of OpenAI kwargs through the wrappers (issue #423)."""
+
+    @pytest.mark.parametrize(
+        "client_cls", [DatabricksOpenAI, AsyncDatabricksOpenAI], ids=["sync", "async"]
+    )
+    def test_forwards_timeout_and_max_retries(self, client_cls, mock_workspace_client):
+        client = client_cls(workspace_client=mock_workspace_client, timeout=42.0, max_retries=7)
+        assert client.timeout == 42.0
+        assert client.max_retries == 7
+
+
 class TestStrictFieldStripping:
     """Tests for strict field stripping helper functions."""
 

--- a/integrations/openai/tests/unit_tests/test_clients.py
+++ b/integrations/openai/tests/unit_tests/test_clients.py
@@ -179,6 +179,18 @@ class TestDatabricksOpenAIKwargForwarding:
         assert client.timeout == 42.0
         assert client.max_retries == 7
 
+    @pytest.mark.parametrize(
+        "client_cls", [DatabricksOpenAI, AsyncDatabricksOpenAI], ids=["sync", "async"]
+    )
+    @pytest.mark.parametrize("managed_kwarg", ["api_key", "http_client"])
+    def test_rejects_databricks_managed_auth_kwargs(
+        self, client_cls, managed_kwarg, mock_workspace_client
+    ):
+        # api_key and http_client are hardcoded with Databricks auth; passing them through
+        # **kwargs would collide with the super().__init__() call and raise TypeError.
+        with pytest.raises(TypeError, match="got multiple values for keyword argument"):
+            client_cls(workspace_client=mock_workspace_client, **{managed_kwarg: "anything"})
+
 
 class TestStrictFieldStripping:
     """Tests for strict field stripping helper functions."""


### PR DESCRIPTION
## Summary
- Add `**kwargs` to `DatabricksOpenAI.__init__` and `AsyncDatabricksOpenAI.__init__` so callers can pass `timeout`, `max_retries`, `default_headers`, etc. through to the underlying `openai.OpenAI` / `openai.AsyncOpenAI`.
- Fixes #423 — `ChatDatabricks(max_retries=...)` raised `TypeError` on both `.client` and `.async_client`. The async path has been broken since `databricks-langchain==0.15.0` (when `async_client` was introduced); the sync path regressed in 0.19.0 when `ChatDatabricks` was migrated onto `DatabricksOpenAI` in #418.
- Conflicts with the hardcoded `api_key` / `http_client` (which carry Databricks auth) surface as Python's native `TypeError: got multiple values for keyword argument 'api_key'`, so no custom validation is needed.

## Test plan
- [x] New parametrized test in `integrations/openai/tests/unit_tests/test_clients.py` verifies sync + async wrappers forward `timeout`/`max_retries`.
- Tested with notebook, verified error exited with the most up to date version and is fixed with our changes 
https://dogfood.staging.databricks.com/editor/notebooks/278592140196282?o=6051921418418893#command/6233639109873383
https://dogfood.staging.databricks.com/editor/notebooks/278592140202289?o=6051921418418893#command/278592140202292

🤖 Generated with [Claude Code](https://claude.com/claude-code)