### PR TITLE
Add experimental Session Store SDK adapters

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 The Databricks AI Bridge library provides a shared layer of APIs to interact with Databricks AI features, such as [Databricks AI/BI Genie ](https://www.databricks.com/product/ai-bi/genie) and [Vector Search](https://docs.databricks.com/en/generative-ai/vector-search.html). Use these packages to help [author agents with Agent Framework](https://docs.databricks.com/aws/en/generative-ai/agent-framework/author-agent#requirements) on Databricks.
 
+The experimental Session Store client and adapters let OpenAI Agents SDK and Claude Agent SDK
+applications keep their native transcripts in a shared Databricks-managed store. See the
+[Session Store prototype guide](./docs/session-store.md).
+
 ## Integration Packages
 
 If you are using LangChain/LangGraph or the OpenAI SDK, we provide these integration packages for seamless integration of Databricks AI features.

--- a/docs/session-store.md
+++ b/docs/session-store.md
@@ -1,0 +1,96 @@
+# Session Store SDK prototype
+
+The experimental Session Store integration separates framework-specific adapters from one thin,
+authenticated REST client:
+
+- `DatabricksSessionStoreClient` owns Databricks authentication, REST calls, pagination, and
+  Session/SessionEvent resource handling.
+- `databricks_openai.agents.DatabricksSession` implements OpenAI Agents SDK's four-method
+  `Session` protocol.
+- `DatabricksClaudeSessionStore` implements Claude Agent SDK's transcript-mirroring
+  `SessionStore` protocol, including subagent transcripts.
+
+The default API prefix is `/api/2.0/agent-conversation`. It is a temporary prototype path and may
+change with the REST contract. All three classes are marked experimental so their names and
+constructor arguments may change before release.
+
+## Install this branch
+
+Install the core client and Claude adapter from the repository root:
+
+```shell
+pip install "databricks-ai-bridge @ git+https://github.com/annzhang-db/databricks-ai-bridge.git@codex/conversations-base-url"
+```
+
+Install the OpenAI integration package from its subdirectory:
+
+```shell
+pip install "databricks-openai @ git+https://github.com/annzhang-db/databricks-ai-bridge.git@codex/conversations-base-url#subdirectory=integrations/openai"
+```
+
+Claude applications also need the Claude Agent SDK version that provides `SessionStore`:
+
+```shell
+pip install "claude-agent-sdk>=0.2.128"
+```
+
+## OpenAI Agents SDK
+
+```python
+from agents import Agent, Runner
+from databricks_openai.agents import DatabricksSession
+
+session = DatabricksSession("conversation-123")
+agent = Agent(name="Support agent", instructions="Help the customer.", model="...")
+
+result = await Runner.run(
+    agent,
+    "Where is my order?",
+    session=session,
+)
+```
+
+`DatabricksSession` stores each native Agents SDK item verbatim in `SessionEvent.data`. It maps
+`get_items`, `add_items`, `pop_item`, and `clear_session` directly to list, append, pop, and clear
+REST operations. If `session_id` is omitted, the adapter creates one locally.
+
+## Claude Agent SDK
+
+```python
+from claude_agent_sdk import ClaudeAgentOptions, query
+from databricks_ai_bridge.session_store import DatabricksClaudeSessionStore
+
+session_store = DatabricksClaudeSessionStore()
+
+options = ClaudeAgentOptions(
+    session_store=session_store,
+    session_store_flush="batched",
+    session_id="00000000-0000-0000-0000-000000000123",
+)
+
+async for message in query(prompt="Where is my order?", options=options):
+    print(message)
+```
+
+Claude identifies storage by `project_key`, `session_id`, and an optional `subpath`. The adapter
+maps the main transcript to one Databricks Session and each subagent `subpath` to a child Session.
+This makes `list_subkeys` a direct-child listing and lets deletion of a main transcript use the
+Session API's subtree cascade.
+
+Claude retries transcript entries carrying a stable `uuid`, but the current SessionEvent contract
+only exposes service-generated event IDs. The adapter performs a read-before-append duplicate
+check for prototype testing. That check is not atomic under concurrent writers; a production
+contract needs a caller idempotency key per event or equivalent conditional append semantics.
+
+## LiteSwap
+
+Supply the swap unit as the traffic ID without changing the API URL:
+
+```python
+client = DatabricksSessionStoreClient(
+    traffic_id="testenv://liteswap/my-session-store",
+)
+```
+
+You can also override `base_url` or set `DATABRICKS_SESSION_STORE_BASE_URL`. The traffic ID can be
+set with `DATABRICKS_SESSION_STORE_TRAFFIC_ID`.

--- a/integrations/openai/README.md
+++ b/integrations/openai/README.md
@@ -17,6 +17,8 @@ pip install git+https://git@github.com/databricks/databricks-ai-bridge.git#subdi
 ## Key Features
 
 - **Vector Search:** Store and query vector representations using `VectorSearchRetrieverTool`.
+- **OpenAI-compatible clients:** Use Databricks authentication with OpenAI SDK resources,
+  including optional separate routing for Conversations API calls.
 
 ## Getting Started
 
@@ -56,6 +58,31 @@ second_response = client.chat.completions.create(
 )
 ```
 
+### Use Conversations API state
+
+Conversations API calls default to `{workspace_url}/api/2.1/unity-catalog`, even when
+Responses API calls use another Databricks OpenAI-compatible base URL such as AI Gateway.
+Use `conversations_base_url` only when the Conversations API is served from a custom path.
+
+```python
+from databricks.sdk import WorkspaceClient
+from databricks_openai import DatabricksOpenAI
+
+workspace_client = WorkspaceClient()
+
+client = DatabricksOpenAI(
+    workspace_client=workspace_client,
+    use_ai_gateway=True,
+)
+
+conversation = client.conversations.create()
+response = client.responses.create(
+    model="databricks-claude-sonnet-4-5",
+    conversation=conversation.id,
+    input="Tell me about Databricks",
+)
+```
+
 ---
 
 ## Contribution Guide
@@ -65,4 +92,3 @@ We welcome contributions! Please see our [contribution guidelines](https://githu
 This project is licensed under the [MIT License](LICENSE).
 
 Thank you for using Databricks OpenAI!
-

--- a/integrations/openai/README.md
+++ b/integrations/openai/README.md
@@ -19,6 +19,8 @@ pip install git+https://git@github.com/databricks/databricks-ai-bridge.git#subdi
 - **Vector Search:** Store and query vector representations using `VectorSearchRetrieverTool`.
 - **OpenAI-compatible clients:** Use Databricks authentication with OpenAI SDK resources,
   including optional separate routing for Conversations API calls.
+- **Agents SDK sessions (experimental):** Persist native OpenAI Agents SDK items in the
+  Databricks Session Store.
 
 ## Getting Started
 
@@ -82,6 +84,39 @@ response = client.responses.create(
     input="Tell me about Databricks",
 )
 ```
+
+### Use Databricks Session Store with the OpenAI Agents SDK
+
+`DatabricksSession` implements the Agents SDK `Session` protocol. The agent and runner code stay
+the same; only the `session` construction changes.
+
+```python
+from agents import Agent, Runner
+from databricks_openai.agents import DatabricksSession
+
+session = DatabricksSession("order-support-123")
+agent = Agent(name="Support agent", instructions="Help the customer.", model="...")
+
+result = await Runner.run(
+    agent,
+    "Where is my order?",
+    session=session,
+)
+```
+
+For a LiteSwap prototype, inject the shared client and traffic ID:
+
+```python
+from databricks_ai_bridge.session_store import DatabricksSessionStoreClient
+from databricks_openai.agents import DatabricksSession
+
+client = DatabricksSessionStoreClient(
+    traffic_id="testenv://liteswap/my-session-store",
+)
+session = DatabricksSession("order-support-123", client=client)
+```
+
+The adapter is experimental while the Session Store REST contract is being finalized.
 
 ---
 

--- a/integrations/openai/src/databricks_openai/agents/__init__.py
+++ b/integrations/openai/src/databricks_openai/agents/__init__.py
@@ -1,4 +1,5 @@
 from databricks_openai.agents.mcp_server import McpServer
 from databricks_openai.agents.session import AsyncDatabricksSession
+from databricks_openai.agents.session_store import DatabricksSession
 
-__all__ = ["AsyncDatabricksSession", "McpServer"]
+__all__ = ["AsyncDatabricksSession", "DatabricksSession", "McpServer"]

--- a/integrations/openai/src/databricks_openai/agents/session_store.py
+++ b/integrations/openai/src/databricks_openai/agents/session_store.py
@@ -1,0 +1,133 @@
+"""OpenAI Agents SDK adapter for the experimental Databricks Session Store."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+from uuid import uuid4
+
+from databricks.sdk import WorkspaceClient
+from databricks_ai_bridge.session_store import DatabricksSessionStoreClient
+from databricks_ai_bridge.utils.annotations import experimental
+
+
+@experimental
+class DatabricksSession:
+    """OpenAI Agents SDK ``Session`` backed by Databricks.
+
+    The adapter preserves each Agents SDK item as opaque JSON in a
+    ``SessionEvent``. Databricks owns event IDs and sequence numbers; the SDK
+    continues to see its original item objects.
+
+    Args:
+        session_id: Stable session ID. A client-generated ID is used when
+            omitted.
+        client: Shared Session Store client. When omitted, the adapter creates
+            and owns one.
+        workspace_client: Workspace client used when creating ``client``.
+        base_url: Optional Session Store API prefix.
+        traffic_id: Optional ``x-databricks-traffic-id`` value for LiteSwap.
+        display_name: Display name assigned when the session is first created.
+        metadata: Metadata assigned when the session is first created.
+        user_id: Optional application-level grouping key.
+        parent_session: Optional parent resource name for a subagent session.
+        session_settings: Optional OpenAI Agents SDK session settings object.
+    """
+
+    def __init__(
+        self,
+        session_id: str | None = None,
+        *,
+        client: DatabricksSessionStoreClient | None = None,
+        workspace_client: WorkspaceClient | None = None,
+        base_url: str | None = None,
+        traffic_id: str | None = None,
+        display_name: str = "OpenAI Agents SDK session",
+        metadata: dict[str, str] | None = None,
+        user_id: str | None = None,
+        parent_session: str | None = None,
+        session_settings: Any | None = None,
+    ) -> None:
+        self.session_id = session_id or f"session-{uuid4().hex}"
+        self.session_settings = session_settings
+        self._client = client or DatabricksSessionStoreClient(
+            workspace_client=workspace_client,
+            base_url=base_url,
+            traffic_id=traffic_id,
+        )
+        self._owns_client = client is None
+        self._display_name = display_name
+        self._metadata = {"sdk": "openai-agents", **(metadata or {})}
+        self._user_id = user_id
+        self._parent_session = parent_session
+        self._session_created = False
+        self._create_lock = asyncio.Lock()
+
+    async def get_items(self, limit: int | None = None) -> list[dict[str, Any]]:
+        """Return the latest items in chronological order."""
+        await self._ensure_session()
+        events = await self._client.list_events(self.session_id)
+        items = [self._event_data(event) for event in events]
+        effective_limit = limit
+        if effective_limit is None:
+            effective_limit = getattr(self.session_settings, "limit", None)
+        if effective_limit is None:
+            return items
+        if effective_limit <= 0:
+            return []
+        return items[-effective_limit:]
+
+    async def add_items(self, items: list[dict[str, Any]]) -> None:
+        """Append OpenAI Agents SDK items to the remote transcript."""
+        if not items:
+            return
+        await self._ensure_session()
+        events: list[dict[str, Any]] = []
+        for item in items:
+            event: dict[str, Any] = {
+                "type": str(item.get("type") or "openai_item"),
+                "data": item,
+            }
+            role = item.get("role")
+            if isinstance(role, str):
+                event["role"] = role
+            events.append(event)
+        await self._client.append_events(self.session_id, events)
+
+    async def pop_item(self) -> dict[str, Any] | None:
+        """Remove and return the latest SDK item."""
+        await self._ensure_session()
+        event = await self._client.pop_event(self.session_id)
+        return self._event_data(event) if event is not None else None
+
+    async def clear_session(self) -> None:
+        """Remove all SDK items while preserving the session resource."""
+        await self._ensure_session()
+        await self._client.clear_events(self.session_id)
+
+    async def aclose(self) -> None:
+        """Close the internally created Session Store client, if any."""
+        if self._owns_client:
+            await self._client.aclose()
+
+    async def _ensure_session(self) -> None:
+        if self._session_created:
+            return
+        async with self._create_lock:
+            if self._session_created:
+                return
+            await self._client.ensure_session(
+                self.session_id,
+                display_name=self._display_name,
+                metadata=self._metadata,
+                user_id=self._user_id,
+                parent_session=self._parent_session,
+            )
+            self._session_created = True
+
+    @staticmethod
+    def _event_data(event: dict[str, Any]) -> dict[str, Any]:
+        data = event.get("data")
+        if not isinstance(data, dict):
+            raise TypeError("OpenAI session event data must be a JSON object")
+        return data

--- a/integrations/openai/src/databricks_openai/utils/clients.py
+++ b/integrations/openai/src/databricks_openai/utils/clients.py
@@ -6,6 +6,7 @@ from httpx import AsyncClient, Auth, Client, Request, Response
 from openai import APIConnectionError, APIStatusError, AsyncOpenAI, OpenAI
 from openai.resources.chat import AsyncChat, Chat
 from openai.resources.chat.completions import AsyncCompletions, Completions
+from openai.resources.conversations import AsyncConversations, Conversations
 from openai.resources.responses import AsyncResponses, Responses
 from typing_extensions import override
 
@@ -135,6 +136,15 @@ def _resolve_base_url(
 
     # Fallback to using serving endpoints
     return f"{host}/serving-endpoints"
+
+
+def _resolve_conversations_base_url(
+    workspace_client: WorkspaceClient,
+    conversations_base_url: str | None,
+) -> str:
+    if conversations_base_url is not None:
+        return conversations_base_url
+    return f"{workspace_client.config.host}/api/2.1/unity-catalog"
 
 
 def _get_authorized_http_client(workspace_client: WorkspaceClient) -> Client:
@@ -337,6 +347,8 @@ class DatabricksOpenAI(OpenAI):
         base_url: Optional base URL to override the default serving endpoints URL. When the URL
             points to a Databricks App (contains "databricksapps"), OAuth authentication is
             required.
+        conversations_base_url: Optional base URL to use for OpenAI Conversations API calls.
+            Defaults to ``{workspace_url}/api/2.1/unity-catalog``.
         use_ai_gateway_native_api: If True, auto-detect AI Gateway V2 and route requests through
             its native OpenAI-compatible API (``<ai_gateway_url>/openai/v1``). This allows use of
             provider-native features not available through the MLflow API. Cannot be combined
@@ -385,6 +397,7 @@ class DatabricksOpenAI(OpenAI):
         self,
         workspace_client: WorkspaceClient | None = None,
         base_url: str | None = None,
+        conversations_base_url: str | None = None,
         use_ai_gateway_native_api: bool = False,
         use_ai_gateway: bool = False,
         **kwargs: Any,
@@ -393,6 +406,9 @@ class DatabricksOpenAI(OpenAI):
             workspace_client = WorkspaceClient()
 
         self._workspace_client = workspace_client
+        self._conversations_base_url = _resolve_conversations_base_url(
+            workspace_client, conversations_base_url
+        )
 
         target_base_url = _resolve_base_url(
             workspace_client, base_url, use_ai_gateway, use_ai_gateway_native_api
@@ -424,6 +440,20 @@ class DatabricksOpenAI(OpenAI):
         if not hasattr(self, "_databricks_responses"):
             self._databricks_responses = DatabricksResponses(self, self._workspace_client)
         return self._databricks_responses
+
+    @property
+    def conversations(self) -> Conversations:
+        if not hasattr(self, "_databricks_conversations_client"):
+            self._databricks_conversations_client = OpenAI(
+                base_url=self._conversations_base_url,
+                api_key=self.api_key,
+                http_client=self._client,
+                timeout=self.timeout,
+                max_retries=self.max_retries,
+                default_headers=self._custom_headers,
+                default_query=self._custom_query,
+            )
+        return self._databricks_conversations_client.conversations
 
 
 class AsyncDatabricksCompletions(AsyncCompletions):
@@ -502,6 +532,8 @@ class AsyncDatabricksOpenAI(AsyncOpenAI):
         base_url: Optional base URL to override the default serving endpoints URL. When the URL
             points to a Databricks App (contains "databricksapps"), OAuth authentication is
             required.
+        conversations_base_url: Optional base URL to use for OpenAI Conversations API calls.
+            Defaults to ``{workspace_url}/api/2.1/unity-catalog``.
         use_ai_gateway_native_api: If True, auto-detect AI Gateway V2 and route requests through
             its native OpenAI-compatible API (``<ai_gateway_url>/openai/v1``). This allows use of
             provider-native features not available through the MLflow API. Cannot be combined
@@ -550,6 +582,7 @@ class AsyncDatabricksOpenAI(AsyncOpenAI):
         self,
         workspace_client: WorkspaceClient | None = None,
         base_url: str | None = None,
+        conversations_base_url: str | None = None,
         use_ai_gateway_native_api: bool = False,
         use_ai_gateway: bool = False,
         **kwargs: Any,
@@ -558,6 +591,9 @@ class AsyncDatabricksOpenAI(AsyncOpenAI):
             workspace_client = WorkspaceClient()
 
         self._workspace_client = workspace_client
+        self._conversations_base_url = _resolve_conversations_base_url(
+            workspace_client, conversations_base_url
+        )
 
         target_base_url = _resolve_base_url(
             workspace_client, base_url, use_ai_gateway, use_ai_gateway_native_api
@@ -588,3 +624,17 @@ class AsyncDatabricksOpenAI(AsyncOpenAI):
         if not hasattr(self, "_databricks_responses"):
             self._databricks_responses = AsyncDatabricksResponses(self, self._workspace_client)
         return self._databricks_responses
+
+    @property
+    def conversations(self) -> AsyncConversations:
+        if not hasattr(self, "_databricks_conversations_client"):
+            self._databricks_conversations_client = AsyncOpenAI(
+                base_url=self._conversations_base_url,
+                api_key=self.api_key,
+                http_client=self._client,
+                timeout=self.timeout,
+                max_retries=self.max_retries,
+                default_headers=self._custom_headers,
+                default_query=self._custom_query,
+            )
+        return self._databricks_conversations_client.conversations

--- a/integrations/openai/tests/unit_tests/test_clients.py
+++ b/integrations/openai/tests/unit_tests/test_clients.py
@@ -9,6 +9,7 @@ from httpx import Request
 from openai import APIConnectionError, APIStatusError, AsyncOpenAI, OpenAI
 from openai._types import NOT_GIVEN, Omit
 from openai.resources.chat.completions import AsyncCompletions, Completions
+from openai.resources.conversations import AsyncConversations, Conversations
 from openai.resources.responses import AsyncResponses, Responses
 
 from databricks_openai import AsyncDatabricksOpenAI, DatabricksOpenAI
@@ -544,6 +545,48 @@ class TestDatabricksClientWithBaseUrl:
         assert "custom-endpoint.example.com" in str(client.base_url)
         # OAuth should not be validated for non-databricksapps URLs
         mock_workspace_client_no_oauth.config.oauth_token.assert_not_called()
+
+
+class TestConversationsBaseUrl:
+    """Tests for routing OpenAI Conversations API calls to a separate base URL."""
+
+    def test_sync_conversations_use_default_unity_catalog_base_url(self, mock_workspace_client):
+        client = DatabricksOpenAI(workspace_client=mock_workspace_client, use_ai_gateway=True)
+
+        assert isinstance(client.conversations, Conversations)
+        assert "/ai-gateway/mlflow/v1/" in str(client.base_url)
+        assert "/api/2.1/unity-catalog/" in str(client.conversations._client.base_url)
+
+    def test_sync_conversations_use_override_base_url(self, mock_workspace_client):
+        client = DatabricksOpenAI(
+            workspace_client=mock_workspace_client,
+            use_ai_gateway=True,
+            conversations_base_url="https://test.databricks.com/serving-endpoints",
+        )
+
+        assert "/ai-gateway/mlflow/v1/" in str(client.base_url)
+        assert "/serving-endpoints/" in str(client.conversations._client.base_url)
+        assert client.conversations is client.conversations
+
+    def test_async_conversations_use_default_unity_catalog_base_url(self, mock_workspace_client):
+        client = AsyncDatabricksOpenAI(
+            workspace_client=mock_workspace_client, use_ai_gateway=True
+        )
+
+        assert isinstance(client.conversations, AsyncConversations)
+        assert "/ai-gateway/mlflow/v1/" in str(client.base_url)
+        assert "/api/2.1/unity-catalog/" in str(client.conversations._client.base_url)
+
+    def test_async_conversations_use_override_base_url(self, mock_workspace_client):
+        client = AsyncDatabricksOpenAI(
+            workspace_client=mock_workspace_client,
+            use_ai_gateway=True,
+            conversations_base_url="https://test.databricks.com/serving-endpoints",
+        )
+
+        assert "/ai-gateway/mlflow/v1/" in str(client.base_url)
+        assert "/serving-endpoints/" in str(client.conversations._client.base_url)
+        assert client.conversations is client.conversations
 
 
 class TestAppsRouting:

--- a/integrations/openai/tests/unit_tests/test_clients.py
+++ b/integrations/openai/tests/unit_tests/test_clients.py
@@ -569,9 +569,7 @@ class TestConversationsBaseUrl:
         assert client.conversations is client.conversations
 
     def test_async_conversations_use_default_unity_catalog_base_url(self, mock_workspace_client):
-        client = AsyncDatabricksOpenAI(
-            workspace_client=mock_workspace_client, use_ai_gateway=True
-        )
+        client = AsyncDatabricksOpenAI(workspace_client=mock_workspace_client, use_ai_gateway=True)
 
         assert isinstance(client.conversations, AsyncConversations)
         assert "/ai-gateway/mlflow/v1/" in str(client.base_url)

--- a/integrations/openai/tests/unit_tests/test_imports.py
+++ b/integrations/openai/tests/unit_tests/test_imports.py
@@ -8,7 +8,7 @@ from databricks_openai import (
     VectorSearchRetrieverTool,
     set_uc_function_client,
 )
-from databricks_openai.agents import McpServer
+from databricks_openai.agents import DatabricksSession, McpServer
 
 assert DatabricksFunctionClient
 assert UCFunctionToolkit
@@ -19,3 +19,4 @@ assert AsyncDatabricksOpenAI
 assert McpServerToolkit
 assert ToolInfo
 assert McpServer
+assert DatabricksSession

--- a/integrations/openai/tests/unit_tests/test_session_store.py
+++ b/integrations/openai/tests/unit_tests/test_session_store.py
@@ -1,0 +1,120 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from agents.memory.session import Session
+
+from databricks_openai.agents import DatabricksSession
+
+
+class FakeSessionStoreClient:
+    def __init__(self) -> None:
+        self.ensure_calls: list[tuple[str, dict[str, Any]]] = []
+        self.append_calls: list[tuple[str, list[dict[str, Any]]]] = []
+        self.events: list[dict[str, Any]] = []
+        self.popped: dict[str, Any] | None = None
+        self.clear_calls: list[str] = []
+        self.closed = False
+
+    async def ensure_session(self, session_id: str, **kwargs: Any) -> dict[str, Any]:
+        self.ensure_calls.append((session_id, kwargs))
+        return {"session_id": session_id}
+
+    async def list_events(self, session_id: str) -> list[dict[str, Any]]:
+        return list(self.events)
+
+    async def append_events(
+        self, session_id: str, events: list[dict[str, Any]]
+    ) -> list[dict[str, Any]]:
+        self.append_calls.append((session_id, events))
+        return events
+
+    async def pop_event(self, session_id: str) -> dict[str, Any] | None:
+        return self.popped
+
+    async def clear_events(self, session_id: str) -> None:
+        self.clear_calls.append(session_id)
+
+    async def aclose(self) -> None:
+        self.closed = True
+
+
+@pytest.mark.asyncio
+async def test_maps_openai_items_to_opaque_events() -> None:
+    client = FakeSessionStoreClient()
+    session = DatabricksSession(
+        "session-1",
+        client=client,  # type: ignore[arg-type]
+        display_name="Support",
+        metadata={"app": "demo"},
+        user_id="user-1",
+        parent_session="sessions/parent",
+    )
+    items = [
+        {"type": "message", "role": "user", "content": "Hello"},
+        {"type": "function_call", "name": "lookup"},
+    ]
+
+    await session.add_items(items)
+    await session.add_items([])
+
+    assert client.ensure_calls == [
+        (
+            "session-1",
+            {
+                "display_name": "Support",
+                "metadata": {"sdk": "openai-agents", "app": "demo"},
+                "user_id": "user-1",
+                "parent_session": "sessions/parent",
+            },
+        )
+    ]
+    assert client.append_calls == [
+        (
+            "session-1",
+            [
+                {"type": "message", "role": "user", "data": items[0]},
+                {"type": "function_call", "data": items[1]},
+            ],
+        )
+    ]
+
+
+@pytest.mark.asyncio
+async def test_get_items_respects_explicit_and_session_limits() -> None:
+    class Settings:
+        limit = 2
+
+    client = FakeSessionStoreClient()
+    client.events = [{"data": {"type": "message", "content": str(index)}} for index in range(4)]
+    session = DatabricksSession(
+        "session-1",
+        client=client,  # type: ignore[arg-type]
+        session_settings=Settings(),
+    )
+
+    assert [item["content"] for item in await session.get_items()] == ["2", "3"]
+    assert [item["content"] for item in await session.get_items(1)] == ["3"]
+    assert await session.get_items(0) == []
+    assert len(client.ensure_calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_pop_clear_and_close_injected_client() -> None:
+    client = FakeSessionStoreClient()
+    client.popped = {"data": {"type": "message", "content": "latest"}}
+    session = DatabricksSession("session-1", client=client)  # type: ignore[arg-type]
+
+    assert await session.pop_item() == {"type": "message", "content": "latest"}
+    await session.clear_session()
+    await session.aclose()
+
+    assert client.clear_calls == ["session-1"]
+    assert not client.closed
+
+
+def test_generates_session_id_when_omitted() -> None:
+    session = DatabricksSession(client=FakeSessionStoreClient())  # type: ignore[arg-type]
+    assert session.session_id.startswith("session-")
+    assert isinstance(session, Session)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ dependencies = [
   "typing_extensions>=4.15.0",
   "pydantic>=2.10.0",
   "databricks-sdk>=0.49.0",
+  "httpx>=0.28.1",
   "databricks-vectorsearch>=0.57",
   "pandas>=2.2.0",
   "tiktoken>=0.8.0",

--- a/src/databricks_ai_bridge/session_store/__init__.py
+++ b/src/databricks_ai_bridge/session_store/__init__.py
@@ -1,0 +1,13 @@
+"""Experimental client and adapters for the Databricks Session Store API."""
+
+from databricks_ai_bridge.session_store.claude import DatabricksClaudeSessionStore
+from databricks_ai_bridge.session_store.client import (
+    DatabricksSessionStoreClient,
+    SessionStoreError,
+)
+
+__all__ = [
+    "DatabricksClaudeSessionStore",
+    "DatabricksSessionStoreClient",
+    "SessionStoreError",
+]

--- a/src/databricks_ai_bridge/session_store/claude.py
+++ b/src/databricks_ai_bridge/session_store/claude.py
@@ -1,0 +1,212 @@
+"""Claude Agent SDK adapter for the experimental Databricks Session Store."""
+
+from __future__ import annotations
+
+import hashlib
+from datetime import datetime
+from typing import Any
+
+from databricks.sdk import WorkspaceClient
+
+from databricks_ai_bridge.session_store.client import DatabricksSessionStoreClient
+from databricks_ai_bridge.utils.annotations import experimental
+
+
+@experimental
+class DatabricksClaudeSessionStore:
+    """Claude Agent SDK ``SessionStore`` backed by Databricks.
+
+    This class is intentionally duck typed so importing it does not require the
+    Claude Agent SDK. Pass an instance as ``ClaudeAgentOptions(session_store=...)``.
+
+    Claude's ``project_key`` and ``session_id`` identify the main Databricks
+    session. Each Claude ``subpath`` is represented as a direct child session,
+    which lets resume discover subagent transcripts via ``list_subkeys``.
+
+    Args:
+        client: Shared Session Store REST client. When omitted, the adapter
+            creates and owns one.
+        workspace_client: Workspace client used when creating ``client``.
+        base_url: Optional Session Store API prefix.
+        traffic_id: Optional ``x-databricks-traffic-id`` value for LiteSwap.
+        display_name: Display name assigned to newly created main sessions.
+        metadata: Additional metadata copied onto main and child sessions.
+    """
+
+    def __init__(
+        self,
+        client: DatabricksSessionStoreClient | None = None,
+        *,
+        workspace_client: WorkspaceClient | None = None,
+        base_url: str | None = None,
+        traffic_id: str | None = None,
+        display_name: str = "Claude Agent SDK session",
+        metadata: dict[str, str] | None = None,
+    ) -> None:
+        self._client = client or DatabricksSessionStoreClient(
+            workspace_client=workspace_client,
+            base_url=base_url,
+            traffic_id=traffic_id,
+        )
+        self._owns_client = client is None
+        self._display_name = display_name
+        self._metadata = dict(metadata or {})
+
+    async def append(self, key: dict[str, str], entries: list[dict[str, Any]]) -> None:
+        """Append opaque Claude JSONL entries to a main or subagent transcript."""
+        if not entries:
+            return
+        physical_id = await self._ensure_key(key)
+
+        # Claude retries UUID-bearing lines. Until the Session Store contract exposes a
+        # caller idempotency key per event, avoid ordinary duplicates with a read check.
+        # This is best effort and does not make concurrent writers atomic.
+        existing = await self._client.list_events(physical_id)
+        existing_uuids = {
+            data.get("uuid") for event in existing if isinstance((data := event.get("data")), dict)
+        }
+        new_entries: list[dict[str, Any]] = []
+        for entry in entries:
+            entry_uuid = entry.get("uuid")
+            if entry_uuid and entry_uuid in existing_uuids:
+                continue
+            new_entries.append(entry)
+            if entry_uuid:
+                existing_uuids.add(entry_uuid)
+        if not new_entries:
+            return
+
+        events: list[dict[str, Any]] = []
+        for entry in new_entries:
+            event: dict[str, Any] = {
+                "type": str(entry.get("type") or "claude_transcript_line"),
+                "data": entry,
+            }
+            message = entry.get("message")
+            if isinstance(message, dict) and isinstance(message.get("role"), str):
+                event["role"] = message["role"]
+            events.append(event)
+        await self._client.append_events(physical_id, events)
+
+    async def load(self, key: dict[str, str]) -> list[dict[str, Any]] | None:
+        """Load an opaque Claude transcript for resume."""
+        physical_id = self._physical_id(key)
+        if not await self._client.session_exists(physical_id):
+            return None
+        events = await self._client.list_events(physical_id)
+        return [self._event_data(event) for event in events]
+
+    async def list_sessions(self, project_key: str) -> list[dict[str, Any]]:
+        """List main Claude sessions for one project."""
+        project_hash = self._project_hash(project_key)
+        sessions = await self._client.list_sessions(
+            filter_expression=f'metadata.claude_project_hash = "{project_hash}"'
+        )
+        result: list[dict[str, Any]] = []
+        for session in sessions:
+            metadata = session.get("metadata")
+            if not isinstance(metadata, dict) or "claude_subpath" in metadata:
+                continue
+            session_id = metadata.get("claude_session_id")
+            if isinstance(session_id, str):
+                result.append(
+                    {
+                        "session_id": session_id,
+                        "mtime": self._epoch_millis(session.get("update_time")),
+                    }
+                )
+        return result
+
+    async def delete(self, key: dict[str, str]) -> None:
+        """Delete one subagent transcript or cascade-delete a main transcript."""
+        await self._client.delete_session(self._physical_id(key), force="subpath" not in key)
+
+    async def list_subkeys(self, key: dict[str, str]) -> list[str]:
+        """Return Claude subpaths stored beneath a main transcript."""
+        main_id = self._main_id(key)
+        sessions = await self._client.list_sessions(parent_session=f"sessions/{main_id}")
+        result: list[str] = []
+        for session in sessions:
+            metadata = session.get("metadata")
+            if isinstance(metadata, dict) and isinstance(metadata.get("claude_subpath"), str):
+                result.append(metadata["claude_subpath"])
+        return result
+
+    async def main_session_exists(self, project_key: str, session_id: str) -> bool:
+        """Return whether the main Claude transcript has been created."""
+        return await self._client.session_exists(
+            self._main_id({"project_key": project_key, "session_id": session_id})
+        )
+
+    async def aclose(self) -> None:
+        """Close the internally created Session Store client, if any."""
+        if self._owns_client:
+            await self._client.aclose()
+
+    async def _ensure_key(self, key: dict[str, str]) -> str:
+        self._validate_key(key)
+        main_id = self._main_id(key)
+        project_hash = self._project_hash(key["project_key"])
+        metadata = {
+            **self._metadata,
+            "sdk": "claude-agent-sdk",
+            "claude_session_id": key["session_id"],
+            "claude_project_hash": project_hash,
+        }
+        await self._client.ensure_session(
+            main_id,
+            display_name=self._display_name,
+            metadata=metadata,
+        )
+
+        subpath = key.get("subpath")
+        if subpath is None:
+            return main_id
+        child_id = self._physical_id(key)
+        await self._client.ensure_session(
+            child_id,
+            display_name=f"Claude subagent transcript: {subpath}",
+            metadata={**metadata, "claude_subpath": subpath},
+            parent_session=f"sessions/{main_id}",
+        )
+        return child_id
+
+    @classmethod
+    def _main_id(cls, key: dict[str, str]) -> str:
+        cls._validate_key(key)
+        return f"claude-{cls._project_hash(key['project_key'])}-{key['session_id']}"
+
+    @classmethod
+    def _physical_id(cls, key: dict[str, str]) -> str:
+        main_id = cls._main_id(key)
+        subpath = key.get("subpath")
+        if subpath is None:
+            return main_id
+        if not subpath:
+            raise ValueError("Claude SessionKey subpath must not be empty")
+        digest = hashlib.sha256(subpath.encode()).hexdigest()[:16]
+        return f"{main_id}-sub-{digest}"
+
+    @staticmethod
+    def _validate_key(key: dict[str, str]) -> None:
+        if not key.get("project_key"):
+            raise ValueError("Claude SessionKey project_key must not be empty")
+        if not key.get("session_id"):
+            raise ValueError("Claude SessionKey session_id must not be empty")
+
+    @staticmethod
+    def _project_hash(project_key: str) -> str:
+        return hashlib.sha256(project_key.encode()).hexdigest()[:24]
+
+    @staticmethod
+    def _event_data(event: dict[str, Any]) -> dict[str, Any]:
+        data = event.get("data")
+        if not isinstance(data, dict):
+            raise TypeError("Claude session event data must be a JSON object")
+        return data
+
+    @staticmethod
+    def _epoch_millis(timestamp: object) -> int:
+        if not isinstance(timestamp, str) or not timestamp:
+            return 0
+        return int(datetime.fromisoformat(timestamp.replace("Z", "+00:00")).timestamp() * 1000)

--- a/src/databricks_ai_bridge/session_store/client.py
+++ b/src/databricks_ai_bridge/session_store/client.py
@@ -1,0 +1,304 @@
+"""Async client for the experimental Databricks Session Store REST API."""
+
+from __future__ import annotations
+
+import os
+from typing import Any, cast
+from urllib.parse import quote
+
+import httpx
+from databricks.sdk import WorkspaceClient
+
+from databricks_ai_bridge.utils.annotations import experimental
+
+DEFAULT_API_PATH = "/api/2.0/agent-conversation"
+DEFAULT_PAGE_SIZE = 1000
+
+
+class SessionStoreError(RuntimeError):
+    """Raised when the Databricks Session Store rejects a request."""
+
+    def __init__(self, status_code: int, detail: object) -> None:
+        self.status_code = status_code
+        self.detail = detail
+        super().__init__(f"Session Store returned {status_code}: {detail}")
+
+
+@experimental
+class DatabricksSessionStoreClient:
+    """Authenticated async client for the Databricks Session Store.
+
+    The default endpoint is ``/api/2.0/agent-conversation`` on the configured
+    workspace. ``base_url`` and ``traffic_id`` are explicit escape hatches for
+    prototype deployments such as LiteSwap.
+
+    Args:
+        workspace_client: Databricks client used for the workspace URL and
+            authentication. A default client is created when omitted.
+        base_url: API prefix including the workspace host. Defaults to
+            ``{workspace_host}/api/2.0/agent-conversation``.
+        traffic_id: Optional ``x-databricks-traffic-id`` value.
+        timeout: Request timeout in seconds when this class creates the HTTP
+            client.
+        http_client: Optional async HTTP client. Injected clients are not closed
+            by :meth:`aclose`.
+    """
+
+    def __init__(
+        self,
+        *,
+        workspace_client: WorkspaceClient | None = None,
+        base_url: str | None = None,
+        traffic_id: str | None = None,
+        timeout: float = 60.0,
+        http_client: httpx.AsyncClient | None = None,
+    ) -> None:
+        self._workspace_client = workspace_client or WorkspaceClient()
+        configured_base_url = base_url or os.getenv("DATABRICKS_SESSION_STORE_BASE_URL")
+        self._base_url = (
+            configured_base_url
+            or f"{self._workspace_client.config.host.rstrip('/')}{DEFAULT_API_PATH}"
+        ).rstrip("/")
+        self._traffic_id = traffic_id or os.getenv("DATABRICKS_SESSION_STORE_TRAFFIC_ID")
+        self._http_client = http_client or httpx.AsyncClient(timeout=timeout)
+        self._owns_http_client = http_client is None
+
+    async def __aenter__(self) -> DatabricksSessionStoreClient:
+        return self
+
+    async def __aexit__(self, *args: object) -> None:
+        await self.aclose()
+
+    async def aclose(self) -> None:
+        """Close the internally created HTTP client, if any."""
+        if self._owns_http_client:
+            await self._http_client.aclose()
+
+    async def create_session(
+        self,
+        *,
+        session_id: str | None = None,
+        display_name: str = "",
+        metadata: dict[str, str] | None = None,
+        user_id: str | None = None,
+        parent_session: str | None = None,
+    ) -> dict[str, Any]:
+        """Create a session, optionally with a caller-provided ID."""
+        body: dict[str, Any] = {
+            "display_name": display_name,
+            "metadata": dict(metadata or {}),
+        }
+        if user_id is not None:
+            body["user_id"] = user_id
+        if parent_session is not None:
+            body["parent_session"] = parent_session
+        params = {"session_id": session_id} if session_id is not None else None
+        response = await self._request("POST", "/sessions", params=params, json=body)
+        self._raise_for_status(response)
+        return self._json_object(response)
+
+    async def ensure_session(
+        self,
+        session_id: str,
+        *,
+        display_name: str = "",
+        metadata: dict[str, str] | None = None,
+        user_id: str | None = None,
+        parent_session: str | None = None,
+    ) -> dict[str, Any]:
+        """Create a session, or return the existing session on a conflict."""
+        body: dict[str, Any] = {
+            "display_name": display_name,
+            "metadata": dict(metadata or {}),
+        }
+        if user_id is not None:
+            body["user_id"] = user_id
+        if parent_session is not None:
+            body["parent_session"] = parent_session
+        response = await self._request(
+            "POST", "/sessions", params={"session_id": session_id}, json=body
+        )
+        if response.status_code == 409:
+            return await self.get_session(session_id)
+        self._raise_for_status(response)
+        return self._json_object(response)
+
+    async def get_session(self, session_id: str) -> dict[str, Any]:
+        """Return one session by ID."""
+        response = await self._request("GET", self._session_path(session_id))
+        self._raise_for_status(response)
+        return self._json_object(response)
+
+    async def session_exists(self, session_id: str) -> bool:
+        """Return whether a session exists."""
+        response = await self._request("GET", self._session_path(session_id))
+        if response.status_code == 404:
+            return False
+        self._raise_for_status(response)
+        return True
+
+    async def list_sessions(
+        self,
+        *,
+        user_id: str | None = None,
+        parent_session: str | None = None,
+        root_session: str | None = None,
+        filter_expression: str | None = None,
+        order_by: str | None = None,
+        page_size: int = DEFAULT_PAGE_SIZE,
+    ) -> list[dict[str, Any]]:
+        """Return all sessions matching the supplied filters."""
+        result: list[dict[str, Any]] = []
+        page_token: str | None = None
+        while True:
+            params: dict[str, str | int] = {"page_size": page_size}
+            if user_id is not None:
+                params["user_id"] = user_id
+            if parent_session is not None:
+                params["parent_session"] = parent_session
+            if root_session is not None:
+                params["root_session"] = root_session
+            if filter_expression is not None:
+                params["filter"] = filter_expression
+            if order_by is not None:
+                params["order_by"] = order_by
+            if page_token is not None:
+                params["page_token"] = page_token
+            response = await self._request("GET", "/sessions", params=params)
+            self._raise_for_status(response)
+            body = self._json_object(response)
+            result.extend(self._json_object_list(body.get("sessions"), "sessions"))
+            page_token = self._next_page_token(body)
+            if page_token is None:
+                return result
+
+    async def append_events(
+        self,
+        session_id: str,
+        events: list[dict[str, Any]],
+        *,
+        idempotency_key: str | None = None,
+    ) -> list[dict[str, Any]]:
+        """Append events and return the service-owned event resources."""
+        headers = {"Idempotency-Key": idempotency_key} if idempotency_key else None
+        response = await self._request(
+            "POST",
+            f"{self._session_path(session_id)}/events:append",
+            json={"events": events},
+            headers=headers,
+        )
+        self._raise_for_status(response)
+        return self._json_object_list(self._json_object(response).get("events"), "events")
+
+    async def list_events(
+        self,
+        session_id: str,
+        *,
+        filter_expression: str | None = None,
+        order_by: str = "sequence asc",
+        page_size: int = DEFAULT_PAGE_SIZE,
+    ) -> list[dict[str, Any]]:
+        """Return every event in a session in the requested order."""
+        result: list[dict[str, Any]] = []
+        page_token: str | None = None
+        while True:
+            params: dict[str, str | int] = {
+                "page_size": page_size,
+                "order_by": order_by,
+            }
+            if filter_expression is not None:
+                params["filter"] = filter_expression
+            if page_token is not None:
+                params["page_token"] = page_token
+            response = await self._request(
+                "GET", f"{self._session_path(session_id)}/events", params=params
+            )
+            if response.status_code == 404:
+                return []
+            self._raise_for_status(response)
+            body = self._json_object(response)
+            result.extend(self._json_object_list(body.get("events"), "events"))
+            page_token = self._next_page_token(body)
+            if page_token is None:
+                return result
+
+    async def pop_event(self, session_id: str) -> dict[str, Any] | None:
+        """Remove and return the most recently appended event."""
+        response = await self._request(
+            "POST", f"{self._session_path(session_id)}/events:pop", json={}
+        )
+        self._raise_for_status(response)
+        event = self._json_object(response).get("event")
+        if event is None:
+            return None
+        if not isinstance(event, dict):
+            raise TypeError("Session Store response field 'event' must be an object")
+        return event
+
+    async def clear_events(self, session_id: str) -> None:
+        """Remove every event from a session without deleting the session."""
+        response = await self._request(
+            "POST", f"{self._session_path(session_id)}/events:clear", json={}
+        )
+        self._raise_for_status(response)
+
+    async def delete_session(self, session_id: str, *, force: bool = False) -> None:
+        """Delete a session, optionally cascading to its descendants."""
+        response = await self._request(
+            "DELETE",
+            self._session_path(session_id),
+            params={"force": str(force).lower()},
+        )
+        if response.status_code == 404:
+            return
+        self._raise_for_status(response)
+
+    async def _request(self, method: str, path: str, **kwargs: Any) -> httpx.Response:
+        headers = dict(self._workspace_client.config.authenticate())
+        headers["Content-Type"] = "application/json"
+        if self._traffic_id is not None:
+            headers["x-databricks-traffic-id"] = self._traffic_id
+        headers.update(kwargs.pop("headers", None) or {})
+        return await self._http_client.request(
+            method, f"{self._base_url}{path}", headers=headers, **kwargs
+        )
+
+    @staticmethod
+    def _raise_for_status(response: httpx.Response) -> None:
+        if response.is_success:
+            return
+        try:
+            detail: object = response.json()
+        except ValueError:
+            detail = response.text
+        raise SessionStoreError(response.status_code, detail)
+
+    @staticmethod
+    def _json_object(response: httpx.Response) -> dict[str, Any]:
+        value = response.json()
+        if not isinstance(value, dict):
+            raise TypeError("Session Store response must be a JSON object")
+        return cast(dict[str, Any], value)
+
+    @staticmethod
+    def _json_object_list(value: object, field_name: str) -> list[dict[str, Any]]:
+        if value is None:
+            return []
+        if not isinstance(value, list) or not all(isinstance(item, dict) for item in value):
+            raise TypeError(
+                f"Session Store response field {field_name!r} must be a list of objects"
+            )
+        return cast(list[dict[str, Any]], value)
+
+    @staticmethod
+    def _next_page_token(body: dict[str, Any]) -> str | None:
+        value = body.get("next_page_token")
+        if value in (None, ""):
+            return None
+        if not isinstance(value, str):
+            raise TypeError("Session Store response field 'next_page_token' must be a string")
+        return value
+
+    @staticmethod
+    def _session_path(session_id: str) -> str:
+        return f"/sessions/{quote(session_id, safe='')}"

--- a/tests/databricks_ai_bridge/test_session_store_claude.py
+++ b/tests/databricks_ai_bridge/test_session_store_claude.py
@@ -1,0 +1,134 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from databricks_ai_bridge.session_store.claude import DatabricksClaudeSessionStore
+
+
+class FakeSessionStoreClient:
+    def __init__(self) -> None:
+        self.sessions: dict[str, dict[str, Any]] = {}
+        self.events: dict[str, list[dict[str, Any]]] = {}
+        self.deleted: list[tuple[str, bool]] = []
+
+    async def ensure_session(self, session_id: str, **kwargs: Any) -> dict[str, Any]:
+        session = {"session_id": session_id, **kwargs}
+        self.sessions.setdefault(session_id, session)
+        return self.sessions[session_id]
+
+    async def session_exists(self, session_id: str) -> bool:
+        return session_id in self.sessions
+
+    async def append_events(
+        self, session_id: str, events: list[dict[str, Any]]
+    ) -> list[dict[str, Any]]:
+        self.events.setdefault(session_id, []).extend(events)
+        return events
+
+    async def list_events(self, session_id: str) -> list[dict[str, Any]]:
+        return list(self.events.get(session_id, []))
+
+    async def list_sessions(self, **kwargs: Any) -> list[dict[str, Any]]:
+        parent_session = kwargs.get("parent_session")
+        result = list(self.sessions.values())
+        if parent_session is not None:
+            result = [
+                session for session in result if session.get("parent_session") == parent_session
+            ]
+        filter_expression = kwargs.get("filter_expression")
+        if filter_expression is not None:
+            project_hash = filter_expression.rsplit('"', 2)[1]
+            result = [
+                session
+                for session in result
+                if session.get("metadata", {}).get("claude_project_hash") == project_hash
+            ]
+        return result
+
+    async def delete_session(self, session_id: str, *, force: bool = False) -> None:
+        self.deleted.append((session_id, force))
+
+
+@pytest.mark.asyncio
+async def test_round_trips_entries_and_deduplicates_uuids() -> None:
+    client = FakeSessionStoreClient()
+    store = DatabricksClaudeSessionStore(client)  # type: ignore[arg-type]
+    key = {"project_key": "project-a", "session_id": "session-1"}
+
+    await store.append(
+        key,
+        [
+            {"type": "user", "uuid": "duplicate", "message": {"role": "user"}},
+            {"type": "assistant", "uuid": "new", "message": {"role": "assistant"}},
+            {"type": "assistant", "uuid": "new", "message": {"role": "assistant"}},
+        ],
+    )
+    await store.append(
+        key,
+        [
+            {"type": "user", "uuid": "duplicate", "message": {"role": "user"}},
+            {"type": "progress", "timestamp": "now"},
+        ],
+    )
+
+    entries = await store.load(key)
+    assert entries == [
+        {"type": "user", "uuid": "duplicate", "message": {"role": "user"}},
+        {"type": "assistant", "uuid": "new", "message": {"role": "assistant"}},
+        {"type": "progress", "timestamp": "now"},
+    ]
+    physical_id = store._physical_id(key)
+    assert client.events[physical_id][0]["role"] == "user"
+    assert client.sessions[physical_id]["metadata"]["claude_session_id"] == "session-1"
+
+
+@pytest.mark.asyncio
+async def test_maps_subpaths_to_child_sessions() -> None:
+    client = FakeSessionStoreClient()
+    store = DatabricksClaudeSessionStore(client)  # type: ignore[arg-type]
+    main_key = {"project_key": "project-a", "session_id": "session-1"}
+    child_key = {**main_key, "subpath": "subagents/agent-a"}
+
+    await store.append(child_key, [{"type": "assistant", "uuid": "child-1"}])
+
+    main_id = store._main_id(main_key)
+    child_id = store._physical_id(child_key)
+    assert client.sessions[child_id]["parent_session"] == f"sessions/{main_id}"
+    assert await store.list_subkeys(main_key) == ["subagents/agent-a"]
+    assert await store.load(child_key) == [{"type": "assistant", "uuid": "child-1"}]
+
+    await store.delete(child_key)
+    await store.delete(main_key)
+    assert client.deleted == [(child_id, False), (main_id, True)]
+
+
+@pytest.mark.asyncio
+async def test_project_key_is_part_of_physical_identity_and_listing_scope() -> None:
+    client = FakeSessionStoreClient()
+    store = DatabricksClaudeSessionStore(client)  # type: ignore[arg-type]
+    first = {"project_key": "project-a", "session_id": "same-session"}
+    second = {"project_key": "project-b", "session_id": "same-session"}
+
+    assert store._physical_id(first) != store._physical_id(second)
+    await store.append(first, [{"type": "user"}])
+    await store.append(second, [{"type": "user"}])
+    first_id = store._physical_id(first)
+    client.sessions[first_id]["update_time"] = "2026-08-06T12:00:00Z"
+
+    listed = await store.list_sessions("project-a")
+    assert listed == [{"session_id": "same-session", "mtime": 1786017600000}]
+
+
+@pytest.mark.asyncio
+async def test_load_returns_none_for_unknown_key() -> None:
+    store = DatabricksClaudeSessionStore(FakeSessionStoreClient())  # type: ignore[arg-type]
+    assert await store.load({"project_key": "project", "session_id": "missing"}) is None
+
+
+def test_rejects_empty_subpath() -> None:
+    with pytest.raises(ValueError, match="subpath"):
+        DatabricksClaudeSessionStore._physical_id(
+            {"project_key": "project", "session_id": "session", "subpath": ""}
+        )

--- a/tests/databricks_ai_bridge/test_session_store_client.py
+++ b/tests/databricks_ai_bridge/test_session_store_client.py
@@ -1,0 +1,178 @@
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import httpx
+import pytest
+
+from databricks_ai_bridge.session_store import (
+    DatabricksSessionStoreClient,
+    SessionStoreError,
+)
+
+
+def _workspace_client() -> MagicMock:
+    workspace = MagicMock()
+    workspace.config.host = "https://workspace.example.com/"
+    workspace.config.authenticate.return_value = {"Authorization": "Bearer token"}
+    return workspace
+
+
+@pytest.mark.asyncio
+async def test_uses_workspace_auth_traffic_id_and_url_encoding() -> None:
+    requests: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        return httpx.Response(200, json={"session_id": "a/b"})
+
+    http_client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    client = DatabricksSessionStoreClient(
+        workspace_client=_workspace_client(),
+        traffic_id="testenv://liteswap/session-store",
+        http_client=http_client,
+    )
+
+    assert await client.get_session("a/b") == {"session_id": "a/b"}
+    request = requests[0]
+    assert str(request.url) == (
+        "https://workspace.example.com/api/2.0/agent-conversation/sessions/a%2Fb"
+    )
+    assert request.headers["Authorization"] == "Bearer token"
+    assert request.headers["x-databricks-traffic-id"] == ("testenv://liteswap/session-store")
+
+    await client.aclose()
+    assert not http_client.is_closed
+    await http_client.aclose()
+
+
+@pytest.mark.asyncio
+async def test_ensure_session_returns_existing_session_after_conflict() -> None:
+    requests: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        if request.method == "POST":
+            return httpx.Response(409, json={"error": "exists"})
+        return httpx.Response(200, json={"session_id": "existing"})
+
+    http_client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    client = DatabricksSessionStoreClient(
+        workspace_client=_workspace_client(), http_client=http_client
+    )
+
+    session = await client.ensure_session(
+        "existing",
+        display_name="Support",
+        metadata={"app": "demo"},
+        user_id="user-1",
+        parent_session="sessions/parent",
+    )
+
+    assert session == {"session_id": "existing"}
+    assert [request.method for request in requests] == ["POST", "GET"]
+    create_request = requests[0]
+    assert create_request.url.params["session_id"] == "existing"
+    assert create_request.read() == (
+        b'{"display_name":"Support","metadata":{"app":"demo"},'
+        b'"user_id":"user-1","parent_session":"sessions/parent"}'
+    )
+    await http_client.aclose()
+
+
+@pytest.mark.asyncio
+async def test_list_methods_follow_page_tokens() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        page_token = request.url.params.get("page_token")
+        if request.url.path.endswith("/events"):
+            if page_token is None:
+                return httpx.Response(
+                    200,
+                    json={
+                        "events": [{"sequence": 1, "data": {"value": 1}}],
+                        "next_page_token": "event-page-2",
+                    },
+                )
+            assert page_token == "event-page-2"
+            return httpx.Response(200, json={"events": [{"sequence": 2, "data": {"value": 2}}]})
+        if page_token is None:
+            return httpx.Response(
+                200,
+                json={
+                    "sessions": [{"session_id": "one"}],
+                    "next_page_token": "session-page-2",
+                },
+            )
+        assert page_token == "session-page-2"
+        return httpx.Response(200, json={"sessions": [{"session_id": "two"}]})
+
+    http_client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    client = DatabricksSessionStoreClient(
+        workspace_client=_workspace_client(), http_client=http_client
+    )
+
+    sessions = await client.list_sessions(
+        user_id="user-1",
+        parent_session="sessions/parent",
+        root_session="sessions/root",
+        filter_expression='metadata.app = "demo"',
+        order_by="update_time desc",
+        page_size=25,
+    )
+    events = await client.list_events("one", page_size=20)
+
+    assert [session["session_id"] for session in sessions] == ["one", "two"]
+    assert [event["sequence"] for event in events] == [1, 2]
+    await http_client.aclose()
+
+
+@pytest.mark.asyncio
+async def test_event_mutations_and_idempotency_key() -> None:
+    requests: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        if request.url.path.endswith("events:append"):
+            return httpx.Response(200, json={"events": [{"event_id": "event-1"}]})
+        if request.url.path.endswith("events:pop"):
+            return httpx.Response(200, json={"event": {"event_id": "event-1"}})
+        return httpx.Response(200, json={})
+
+    http_client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    client = DatabricksSessionStoreClient(
+        workspace_client=_workspace_client(), http_client=http_client
+    )
+
+    appended = await client.append_events(
+        "session-1",
+        [{"type": "message", "data": {"role": "user"}}],
+        idempotency_key="append-1",
+    )
+    popped = await client.pop_event("session-1")
+    await client.clear_events("session-1")
+    await client.delete_session("session-1", force=True)
+
+    assert appended == [{"event_id": "event-1"}]
+    assert popped == {"event_id": "event-1"}
+    assert requests[0].headers["Idempotency-Key"] == "append-1"
+    assert requests[-1].url.params["force"] == "true"
+    await http_client.aclose()
+
+
+@pytest.mark.asyncio
+async def test_raises_structured_error() -> None:
+    http_client = httpx.AsyncClient(
+        transport=httpx.MockTransport(
+            lambda request: httpx.Response(400, json={"error": "bad filter"})
+        )
+    )
+    client = DatabricksSessionStoreClient(
+        workspace_client=_workspace_client(), http_client=http_client
+    )
+
+    with pytest.raises(SessionStoreError) as error:
+        await client.list_sessions(filter_expression="bad")
+
+    assert error.value.status_code == 400
+    assert error.value.detail == {"error": "bad filter"}
+    await http_client.aclose()


### PR DESCRIPTION
## Summary

This draft prototypes how third-party agent SDKs can use the proposed Databricks Session Store REST API.

- adds a shared async REST client with Databricks authentication, pagination, LiteSwap routing, and Session/SessionEvent operations
- adds `databricks_openai.agents.DatabricksSession`, implementing the OpenAI Agents SDK `Session` protocol
- adds `DatabricksClaudeSessionStore`, implementing Claude Agent SDK transcript mirroring, listing, deletion, and subagent transcript discovery
- supports a separate Conversations API base URL for the Databricks OpenAI client
- documents branch installation and runnable OpenAI/Claude integration shapes

## Why this is a draft

The REST resource names, endpoint prefix, and idempotency contract are still being finalized. The public classes are marked experimental so we can use this branch in Databricks Apps while continuing to make breaking prototype changes.

## API design findings

- OpenAI maps directly to list, append, pop, and clear operations.
- Claude storage identity is `(project_key, session_id, optional subpath)`; the adapter includes the project hash in the physical Databricks session ID to avoid cross-project collisions.
- Claude subagent `subpath` values map naturally to child Sessions.
- Claude retries UUID-bearing transcript entries. The prototype performs best-effort read-before-append deduplication, but atomic retry safety still requires a caller idempotency key per event or equivalent conditional append semantics.

## How do you know it works?

The new tests cover authenticated request construction, URL encoding, pagination, errors, all event mutations, OpenAI item mapping and protocol conformance, Claude UUID deduplication, project isolation, subagent child sessions, listing, and cascade deletion.

- Core suite: 104 passed, 54 skipped, 1 environment-bound credential test deselected.
- OpenAI unit suite: 179 passed, 1 skipped, 2 environment-bound credential tests deselected.
- Ruff formatting and lint pass for the core and OpenAI packages.
- Targeted type checks pass; full package checks report only pre-existing unused-ignore warnings.
- A live LiteSwap smoke test successfully created, appended, listed, popped, cleared, and deleted a session.
- Live adapter smoke tests round-tripped an OpenAI item and verified Claude UUID deduplication, project listing, and subagent discovery.
