### PR TITLE
genie: return full answer text from all text attachments

### DIFF
--- a/src/databricks_ai_bridge/genie.py
+++ b/src/databricks_ai_bridge/genie.py
@@ -186,12 +186,15 @@ def _end_current_span(client, parent_trace_id, current_span, final_state, error=
 
 
 def _parse_attachments(resp: Dict[str, Any]) -> Dict[str, Any]:
+    """Parse attachments from a Genie API response.
+
+    Returns the final query attachment, all text attachments belonging to the final
+    answer (an answer may carry several, e.g. a summary plus a follow-up), and the
+    suggested-questions attachment.
     """
-    Parse and normalize attachments from a Genie API response into a predictable structure.
-    """
-    result = {
+    result: Dict[str, Any] = {
         "query_attachment": None,
-        "text_attachment": None,
+        "text_attachments": [],
         "suggested_questions_attachment": None,
     }
 
@@ -199,22 +202,19 @@ def _parse_attachments(resp: Dict[str, Any]) -> Dict[str, Any]:
     if not isinstance(attachments, list):
         return result
 
-    # Genie may self-correct, producing multiple query+text pairs. We want
-    # the final query and its paired text (the first text attachment following
-    # the final query).
-    want_new_text = True
-    for a in attachments:
-        if not isinstance(a, dict):
-            continue
+    # Genie may self-correct, emitting multiple query+text pairs. Text strictly
+    # between the first and last query is a superseded attempt and is dropped; all
+    # other text is part of the answer and kept in order.
+    valid = [(i, a) for i, a in enumerate(attachments) if isinstance(a, dict)]
+    query_indices = [i for i, a in valid if "query" in a]
 
+    for i, a in valid:
         if "query" in a:
-            result["query_attachment"] = a
-            want_new_text = True
-
-        elif "text" in a and want_new_text:
-            result["text_attachment"] = a
-            want_new_text = False
-
+            result["query_attachment"] = a  # last query wins
+        elif "text" in a:
+            if query_indices and query_indices[0] < i < query_indices[-1]:
+                continue
+            result["text_attachments"].append(a)
         elif "suggested_questions" in a:
             result["suggested_questions_attachment"] = a
 
@@ -237,16 +237,23 @@ def _extract_suggested_questions_from_attachment(attachment) -> Optional[List[st
     return [q for q in questions if isinstance(q, str)] or None
 
 
-def _extract_text_attachment_content_from_attachment(attachment) -> Optional[str]:
-    """Extract text summary from a Genie API response attachment."""
-    if not isinstance(attachment, dict):
+def _extract_text_attachment_content_from_attachments(attachments) -> Optional[str]:
+    """Join the text summaries from a list of Genie API response text attachments."""
+    if not isinstance(attachments, list):
         return ""
 
-    text_obj = attachment.get("text")
-    if not isinstance(text_obj, dict):
-        return ""
+    contents: List[str] = []
+    for attachment in attachments:
+        if not isinstance(attachment, dict):
+            continue
+        text_obj = attachment.get("text")
+        if not isinstance(text_obj, dict):
+            continue
+        content = text_obj.get("content", "")
+        if content:
+            contents.append(content)
 
-    return text_obj.get("content", "")
+    return "\n\n".join(contents)
 
 
 class Genie:
@@ -403,8 +410,8 @@ class Genie:
                         suggested_questions = _extract_suggested_questions_from_attachment(
                             parsed["suggested_questions_attachment"]
                         )
-                        text_attachment_content = _extract_text_attachment_content_from_attachment(
-                            parsed["text_attachment"]
+                        text_attachment_content = _extract_text_attachment_content_from_attachments(
+                            parsed["text_attachments"]
                         )
 
                         if parsed["query_attachment"]:

--- a/tests/databricks_ai_bridge/test_genie.py
+++ b/tests/databricks_ai_bridge/test_genie.py
@@ -11,7 +11,7 @@ from databricks_ai_bridge.genie import (
     Genie,
     _count_tokens,
     _extract_suggested_questions_from_attachment,
-    _extract_text_attachment_content_from_attachment,
+    _extract_text_attachment_content_from_attachments,
     _parse_attachments,
     _parse_query_result,
 )
@@ -831,7 +831,7 @@ def test_poll_for_result_continues_on_mlflow_tracing_exceptions(genie, mock_work
 
 # Parametrized tests for _parse_attachments
 @pytest.mark.parametrize(
-    "resp,exp_query,exp_text,exp_questions",
+    "resp,exp_query,exp_texts,exp_questions",
     [
         # All three attachment types
         (
@@ -846,7 +846,7 @@ def test_poll_for_result_continues_on_mlflow_tracing_exceptions(genie, mock_work
                 ]
             },
             {"attachment_id": "1", "query": {"query": "SELECT *", "description": "Test"}},
-            {"attachment_id": "2", "text": {"content": "Summary text"}},
+            [{"attachment_id": "2", "text": {"content": "Summary text"}}],
             {"attachment_id": "3", "suggested_questions": {"questions": ["Q1?", "Q2?", "Q3?"]}},
         ),
         # Only query
@@ -857,14 +857,14 @@ def test_poll_for_result_continues_on_mlflow_tracing_exceptions(genie, mock_work
                 ]
             },
             {"attachment_id": "1", "query": {"query": "SELECT 1", "description": "Desc"}},
-            None,
+            [],
             None,
         ),
         # Only text
         (
             {"attachments": [{"attachment_id": "2", "text": {"content": "Text only"}}]},
             None,
-            {"attachment_id": "2", "text": {"content": "Text only"}},
+            [{"attachment_id": "2", "text": {"content": "Text only"}}],
             None,
         ),
         # Only suggested questions
@@ -875,19 +875,19 @@ def test_poll_for_result_continues_on_mlflow_tracing_exceptions(genie, mock_work
                 ]
             },
             None,
-            None,
+            [],
             {"attachment_id": "3", "suggested_questions": {"questions": ["Question?"]}},
         ),
-        # Edge cases - all return None for all fields
-        ({"attachments": []}, None, None, None),
-        ({}, None, None, None),
-        ({"attachments": None}, None, None, None),
-        ({"attachments": "not a list"}, None, None, None),
+        # Edge cases - empty text list and None for the single-valued fields
+        ({"attachments": []}, None, [], None),
+        ({}, None, [], None),
+        ({"attachments": None}, None, [], None),
+        ({"attachments": "not a list"}, None, [], None),
         # Invalid items - only valid dict is parsed
         (
             {"attachments": ["string", 123, None, {"query": {"query": "SELECT 1"}}]},
             {"query": {"query": "SELECT 1"}},
-            None,
+            [],
             None,
         ),
         # Multiple query attachments (self-correction) - should return the LAST one
@@ -908,12 +908,11 @@ def test_poll_for_result_continues_on_mlflow_tracing_exceptions(genie, mock_work
                 "attachment_id": "2",
                 "query": {"query": "SELECT correct", "description": "corrected"},
             },
-            None,
+            [],
             None,
         ),
-        # Self-correction with paired text attachments - text should be paired
-        # with the final query (i.e., the first text AFTER the last query), not
-        # the first text overall or the final text (which may be a follow-up).
+        # Self-correction: text between the first and last query is superseded and
+        # dropped; text after the final query is kept in order.
         (
             {
                 "attachments": [
@@ -933,16 +932,36 @@ def test_poll_for_result_continues_on_mlflow_tracing_exceptions(genie, mock_work
                 ]
             },
             {"attachment_id": "4", "query": {"query": "SELECT correct"}},
-            {"attachment_id": "5", "text": {"content": "explains correct"}},
+            [
+                {"attachment_id": "5", "text": {"content": "explains correct"}},
+                {"attachment_id": "6", "text": {"content": "follow-up prompt"}},
+            ],
             {"attachment_id": "7", "suggested_questions": {"questions": ["Q2?"]}},
+        ),
+        # A summary text before the query and a trailing text after it must both be
+        # kept (the leading summary was previously overwritten).
+        (
+            {
+                "attachments": [
+                    {"attachment_id": "1", "text": {"content": "Summary with bullets"}},
+                    {"attachment_id": "2", "query": {"query": "SELECT 1"}},
+                    {"attachment_id": "3", "text": {"content": "Anything else?"}},
+                ]
+            },
+            {"attachment_id": "2", "query": {"query": "SELECT 1"}},
+            [
+                {"attachment_id": "1", "text": {"content": "Summary with bullets"}},
+                {"attachment_id": "3", "text": {"content": "Anything else?"}},
+            ],
+            None,
         ),
     ],
 )
-def test_parse_attachments(resp, exp_query, exp_text, exp_questions):
+def test_parse_attachments(resp, exp_query, exp_texts, exp_questions):
     """Test parsing attachments with various input scenarios."""
     result = _parse_attachments(resp)
     assert result["query_attachment"] == exp_query
-    assert result["text_attachment"] == exp_text
+    assert result["text_attachments"] == exp_texts
     assert result["suggested_questions_attachment"] == exp_questions
 
 
@@ -971,23 +990,36 @@ def test_extract_suggested_questions(attachment, expected):
     assert _extract_suggested_questions_from_attachment(attachment) == expected
 
 
-# Parametrized tests for _extract_text_attachment_content_from_attachment
+# Parametrized tests for _extract_text_attachment_content_from_attachments
 @pytest.mark.parametrize(
-    "attachment,expected",
+    "attachments,expected",
     [
-        ({"text": {"content": "Summary text"}}, "Summary text"),
-        ({"text": {"content": ""}}, ""),
-        ("not a dict", ""),
+        # Single text attachment
+        ([{"text": {"content": "Summary text"}}], "Summary text"),
+        ([{"text": {"content": ""}}], ""),
+        # Multiple text attachments are joined with a blank line
+        (
+            [{"text": {"content": "Summary"}}, {"text": {"content": "Follow-up?"}}],
+            "Summary\n\nFollow-up?",
+        ),
+        # Empty content entries are skipped when joining
+        (
+            [{"text": {"content": "Only this"}}, {"text": {"content": ""}}],
+            "Only this",
+        ),
+        # Edge cases / invalid inputs
+        ([], ""),
+        ("not a list", ""),
         (None, ""),
-        ({"other_key": "value"}, ""),
-        ({"text": "not a dict"}, ""),
-        ({"text": {"other_key": "value"}}, ""),
-        ({"text": {"content": "Line 1\nLine 2\nLine 3"}}, "Line 1\nLine 2\nLine 3"),
+        ([{"other_key": "value"}], ""),
+        ([{"text": "not a dict"}], ""),
+        ([{"text": {"other_key": "value"}}], ""),
+        ([{"text": {"content": "Line 1\nLine 2\nLine 3"}}], "Line 1\nLine 2\nLine 3"),
     ],
 )
-def test_extract_text_content(attachment, expected):
-    """Test extracting text content with various inputs."""
-    assert _extract_text_attachment_content_from_attachment(attachment) == expected
+def test_extract_text_content(attachments, expected):
+    """Test extracting and joining text content with various inputs."""
+    assert _extract_text_attachment_content_from_attachments(attachments) == expected
 
 
 def test_poll_with_all_attachments(genie, mock_workspace_client):

--- a/tests/integration_tests/genie/conftest.py
+++ b/tests/integration_tests/genie/conftest.py
@@ -93,3 +93,11 @@ def genie_text_response(genie_instance):
 def genie_pandas_response(genie_pandas_instance):
     """Cached pandas-mode response: 'What is the average amount by status?'"""
     return genie_pandas_instance.ask_question("What is the average amount by status?")
+
+
+@pytest.fixture(scope="session")
+def genie_summary_response(genie_instance):
+    """Cached response that tends to yield a summary plus a follow-up."""
+    return genie_instance.ask_question(
+        "Summarize the key insights from the data and explain what stands out."
+    )

--- a/tests/integration_tests/genie/test_genie_behavior.py
+++ b/tests/integration_tests/genie/test_genie_behavior.py
@@ -73,6 +73,15 @@ class TestGenieConversationContinuity:
 
 
 @pytest.mark.behavior
+class TestGenieFullTextAttachment:
+    """poll_for_result must surface the complete answer text."""
+
+    def test_summary_text_is_nonempty(self, genie_summary_response):
+        text = genie_summary_response.text_attachment_content
+        assert isinstance(text, str) and text.strip(), "Expected non-empty summary text"
+
+
+@pytest.mark.behavior
 class TestGeniePandasMode:
     """Validates our _parse_query_result with return_pandas=True."""
 


### PR DESCRIPTION
## Summary

`Genie.poll_for_result` previously kept only the **first** text attachment following the final query, silently dropping a leading summary or a trailing follow-up. When Genie returns an answer split across multiple text attachments (e.g. a bulleted summary plus a follow-up prompt), part of the response text was lost.

This change makes `_parse_attachments` return **all** text attachments that belong to the final answer, and joins their contents in order:

- Text **strictly between the first and last query** attachment is treated as a superseded self-correction attempt and dropped.
- All other text — a leading summary before the query, or any text following the final query — is part of the answer and is kept in order.
- `_extract_text_attachment_content_from_attachments` (renamed from the singular form) joins the kept text contents with a blank line.

No public API changes; `GenieResponse.text_attachment_content` now contains the complete answer text.

## Tests

- Updated `_parse_attachments` parametrized unit tests to assert the list of kept text attachments, including a case with a summary before the query plus a trailing text after it.
- Updated `_extract_text_content` tests to cover joining multiple text attachments and skipping empty ones.
- Added an integration behavior test asserting the surfaced summary text is non-empty.

This pull request and its description were written by Isaac.