### PR TITLE
Lazily re-export databricks_openai package root symbols

### DIFF
--- a/integrations/openai/src/databricks_openai/__init__.py
+++ b/integrations/openai/src/databricks_openai/__init__.py
@@ -8,17 +8,17 @@ Available aliases:
 - :class:`databricks_openai.UCFunctionToolkit`
 - :class:`databricks_openai.DatabricksFunctionClient`
 - :func:`databricks_openai.set_uc_function_client`
+- :class:`databricks_openai.DatabricksOpenAI`
+- :class:`databricks_openai.AsyncDatabricksOpenAI`
+- :class:`databricks_openai.McpServerToolkit`
+- :class:`databricks_openai.ToolInfo`
+- :class:`databricks_openai.VectorSearchRetrieverTool`
 
 Refer to the Unity Catalog `documentation <https://docs.unitycatalog.io/ai/integrations/openai/#using-unity-catalog-ai-with-the-openai-sdk>`_ for more information.
 """
 
-from unitycatalog.ai.core.base import set_uc_function_client
-from unitycatalog.ai.core.databricks import DatabricksFunctionClient
-from unitycatalog.ai.openai.toolkit import UCFunctionToolkit
-
-from databricks_openai.mcp_server_toolkit import McpServerToolkit, ToolInfo
-from databricks_openai.utils.clients import AsyncDatabricksOpenAI, DatabricksOpenAI
-from databricks_openai.vector_search_retriever_tool import VectorSearchRetrieverTool
+from importlib import import_module
+from typing import Any
 
 # Expose all integrations to users under databricks-openai
 __all__ = [
@@ -31,3 +31,35 @@ __all__ = [
     "McpServerToolkit",
     "ToolInfo",
 ]
+
+_LAZY_EXPORTS = {
+    "DatabricksOpenAI": ("databricks_openai.utils.clients", "DatabricksOpenAI"),
+    "AsyncDatabricksOpenAI": ("databricks_openai.utils.clients", "AsyncDatabricksOpenAI"),
+    "McpServerToolkit": ("databricks_openai.mcp_server_toolkit", "McpServerToolkit"),
+    "ToolInfo": ("databricks_openai.mcp_server_toolkit", "ToolInfo"),
+    "VectorSearchRetrieverTool": (
+        "databricks_openai.vector_search_retriever_tool",
+        "VectorSearchRetrieverTool",
+    ),
+    "UCFunctionToolkit": ("unitycatalog.ai.openai.toolkit", "UCFunctionToolkit"),
+    "DatabricksFunctionClient": (
+        "unitycatalog.ai.core.databricks",
+        "DatabricksFunctionClient",
+    ),
+    "set_uc_function_client": ("unitycatalog.ai.core.base", "set_uc_function_client"),
+}
+
+
+def __getattr__(name: str) -> Any:
+    try:
+        module_name, attribute_name = _LAZY_EXPORTS[name]
+    except KeyError as exc:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}") from exc
+
+    value = getattr(import_module(module_name), attribute_name)
+    globals()[name] = value
+    return value
+
+
+def __dir__() -> list[str]:
+    return sorted(set(globals()) | set(__all__))

--- a/integrations/openai/tests/unit_tests/test_imports.py
+++ b/integrations/openai/tests/unit_tests/test_imports.py
@@ -1,21 +1,22 @@
-from databricks_openai import (
-    AsyncDatabricksOpenAI,
-    DatabricksFunctionClient,
-    DatabricksOpenAI,
-    McpServerToolkit,
-    ToolInfo,
-    UCFunctionToolkit,
-    VectorSearchRetrieverTool,
-    set_uc_function_client,
-)
-from databricks_openai.agents import McpServer
+def test_package_root_reexports_remain_available():
+    from databricks_openai import (
+        AsyncDatabricksOpenAI,
+        DatabricksFunctionClient,
+        DatabricksOpenAI,
+        McpServerToolkit,
+        ToolInfo,
+        UCFunctionToolkit,
+        VectorSearchRetrieverTool,
+        set_uc_function_client,
+    )
+    from databricks_openai.agents import McpServer
 
-assert DatabricksFunctionClient
-assert UCFunctionToolkit
-assert VectorSearchRetrieverTool
-assert set_uc_function_client
-assert DatabricksOpenAI
-assert AsyncDatabricksOpenAI
-assert McpServerToolkit
-assert ToolInfo
-assert McpServer
+    assert DatabricksFunctionClient
+    assert UCFunctionToolkit
+    assert VectorSearchRetrieverTool
+    assert set_uc_function_client
+    assert DatabricksOpenAI
+    assert AsyncDatabricksOpenAI
+    assert McpServerToolkit
+    assert ToolInfo
+    assert McpServer

--- a/integrations/openai/tests/unit_tests/test_lazy_imports.py
+++ b/integrations/openai/tests/unit_tests/test_lazy_imports.py
@@ -1,0 +1,37 @@
+import importlib
+import sys
+
+FORBIDDEN_EAGER_IMPORTS = [
+    "databricks_openai.mcp_server_toolkit",
+    "databricks_openai.vector_search_retriever_tool",
+    "unitycatalog.ai.core.base",
+    "unitycatalog.ai.core.databricks",
+    "unitycatalog.ai.openai.toolkit",
+]
+
+
+def test_package_root_import_does_not_eagerly_import_integrations(monkeypatch):
+    monkeypatch.delitem(sys.modules, "databricks_openai", raising=False)
+    for module_name in FORBIDDEN_EAGER_IMPORTS:
+        monkeypatch.delitem(sys.modules, module_name, raising=False)
+
+    importlib.import_module("databricks_openai")
+
+    loaded = [name for name in FORBIDDEN_EAGER_IMPORTS if name in sys.modules]
+    assert not loaded
+
+
+def test_package_root_client_import_only_loads_client_module(monkeypatch):
+    monkeypatch.delitem(sys.modules, "databricks_openai", raising=False)
+    monkeypatch.delitem(sys.modules, "databricks_openai.utils.clients", raising=False)
+    for module_name in FORBIDDEN_EAGER_IMPORTS:
+        monkeypatch.delitem(sys.modules, module_name, raising=False)
+
+    databricks_openai = importlib.import_module("databricks_openai")
+    client = databricks_openai.DatabricksOpenAI
+
+    assert client.__name__ == "DatabricksOpenAI"
+    assert "databricks_openai.utils.clients" in sys.modules
+
+    loaded = [name for name in FORBIDDEN_EAGER_IMPORTS if name in sys.modules]
+    assert not loaded


### PR DESCRIPTION
## Summary

This PR preserves the existing `databricks_openai` package-root API while resolving exported symbols lazily.

The main motivation is to make narrow package-root imports like this avoid loading unrelated package-root re-exports:

```python
from databricks_openai import DatabricksOpenAI
```

`DatabricksOpenAI` is implemented in `databricks_openai.utils.clients`. It does not require the MCP toolkit, vector search retriever tool, or Unity Catalog toolkit modules to be imported. Before this change, importing `DatabricksOpenAI` from the package root also eagerly imported those unrelated package-root re-exports because they were imported at package import time.

After this change, each package-root export is imported only when that symbol is accessed. The public aliases in `__all__` are unchanged.

This PR also updates the existing package-root import smoke check so it is collected and reported as a normal pytest test item.

## Changes

* Replace eager package-root imports in `databricks_openai/__init__.py` with lazy re-exports using `_LAZY_EXPORTS` and module-level `__getattr__`.
* Preserve the existing public aliases in `__all__`.
* Cache resolved aliases in module globals after first access.
* Keep `__dir__` aligned with module globals and `__all__`.
* Update the docstring alias list to include aliases that were already exported before this PR.
* Wrap the existing package-root import smoke assertions in `test_imports.py` in a `test_` function so the smoke check is collected and reported as a normal pytest test item.
* Add focused lazy-import regression tests covering:

  * `import databricks_openai` does not eagerly import MCP/vector/UC integration modules.
  * Accessing `databricks_openai.DatabricksOpenAI` loads the client module without importing unrelated integrations.

## References

* PEP 562 defines module-level `__getattr__` and `__dir__`, which is the mechanism used here for lazy package-root attribute access: [https://peps.python.org/pep-0562/](https://peps.python.org/pep-0562/)
* Pytest standard discovery collects `test_` functions/methods from `test_*.py` files. The existing package-root smoke check is now wrapped in a `test_` function so it appears as a collected and reportable test item: [https://docs.pytest.org/en/stable/explanation/goodpractices.html#conventions-for-python-test-discovery](https://docs.pytest.org/en/stable/explanation/goodpractices.html#conventions-for-python-test-discovery)

## Testing

Validated with:

```bash
uv run --exact --group tests pytest --cov --cov-report=term tests/unit_tests
uv run --exact --group tests pytest tests/unit_tests/test_imports.py -q
uv run --exact --group tests pytest tests/unit_tests/test_lazy_imports.py
uv run ruff check src tests
```