### PR TITLE
Enable HTTP redirect following in DatabricksOpenAI clients

### DIFF
--- a/integrations/openai/src/databricks_openai/utils/clients.py
+++ b/integrations/openai/src/databricks_openai/utils/clients.py
@@ -137,14 +137,18 @@ def _resolve_base_url(
     return f"{host}/serving-endpoints"
 
 
-def _get_authorized_http_client(workspace_client: WorkspaceClient) -> Client:
+def _get_authorized_http_client(
+    workspace_client: WorkspaceClient, follow_redirects: bool = True
+) -> Client:
     databricks_token_auth = BearerAuth(workspace_client.config.authenticate)
-    return Client(auth=databricks_token_auth)
+    return Client(auth=databricks_token_auth, follow_redirects=follow_redirects)
 
 
-def _get_authorized_async_http_client(workspace_client: WorkspaceClient) -> AsyncClient:
+def _get_authorized_async_http_client(
+    workspace_client: WorkspaceClient, follow_redirects: bool = True
+) -> AsyncClient:
     databricks_token_auth = BearerAuth(workspace_client.config.authenticate)
-    return AsyncClient(auth=databricks_token_auth)
+    return AsyncClient(auth=databricks_token_auth, follow_redirects=follow_redirects)
 
 
 def _validate_oauth_for_apps(workspace_client: WorkspaceClient) -> None:
@@ -343,6 +347,8 @@ class DatabricksOpenAI(OpenAI):
             with ``base_url`` or ``use_ai_gateway``. Defaults to False.
         use_ai_gateway: If True, auto-detect AI Gateway V2 availability and route
             requests through it using the MLflow API. Defaults to False.
+        follow_redirects: If True, the underlying HTTP client follows redirect responses.
+            Defaults to True, matching the OpenAI SDK's default behavior.
         **kwargs: Additional keyword arguments forwarded to the underlying ``openai.OpenAI``
             client (e.g. ``timeout``, ``max_retries``, ``default_headers``).
 
@@ -387,6 +393,7 @@ class DatabricksOpenAI(OpenAI):
         base_url: str | None = None,
         use_ai_gateway_native_api: bool = False,
         use_ai_gateway: bool = False,
+        follow_redirects: bool = True,
         **kwargs: Any,
     ):
         if workspace_client is None:
@@ -402,7 +409,7 @@ class DatabricksOpenAI(OpenAI):
         super().__init__(
             base_url=target_base_url,
             api_key=_get_openai_api_key(),
-            http_client=_get_authorized_http_client(workspace_client),
+            http_client=_get_authorized_http_client(workspace_client, follow_redirects),
             **kwargs,
         )
 
@@ -508,6 +515,8 @@ class AsyncDatabricksOpenAI(AsyncOpenAI):
             with ``base_url`` or ``use_ai_gateway``. Defaults to False.
         use_ai_gateway: If True, auto-detect AI Gateway V2 availability and route
             requests through it using the MLflow API. Defaults to False.
+        follow_redirects: If True, the underlying HTTP client follows redirect responses.
+            Defaults to True, matching the OpenAI SDK's default behavior.
         **kwargs: Additional keyword arguments forwarded to the underlying ``openai.AsyncOpenAI``
             client (e.g. ``timeout``, ``max_retries``, ``default_headers``).
 
@@ -552,6 +561,7 @@ class AsyncDatabricksOpenAI(AsyncOpenAI):
         base_url: str | None = None,
         use_ai_gateway_native_api: bool = False,
         use_ai_gateway: bool = False,
+        follow_redirects: bool = True,
         **kwargs: Any,
     ):
         if workspace_client is None:
@@ -567,7 +577,7 @@ class AsyncDatabricksOpenAI(AsyncOpenAI):
         super().__init__(
             base_url=target_base_url,
             api_key=_get_openai_api_key(),
-            http_client=_get_authorized_async_http_client(workspace_client),
+            http_client=_get_authorized_async_http_client(workspace_client, follow_redirects),
             **kwargs,
         )
 

--- a/integrations/openai/src/databricks_openai/utils/clients.py
+++ b/integrations/openai/src/databricks_openai/utils/clients.py
@@ -348,7 +348,7 @@ class DatabricksOpenAI(OpenAI):
         use_ai_gateway: If True, auto-detect AI Gateway V2 availability and route
             requests through it using the MLflow API. Defaults to False.
         follow_redirects: If True, the underlying HTTP client follows redirect responses.
-            Defaults to True, matching the OpenAI SDK's default behavior.
+            Defaults to True.
         **kwargs: Additional keyword arguments forwarded to the underlying ``openai.OpenAI``
             client (e.g. ``timeout``, ``max_retries``, ``default_headers``).
 
@@ -516,7 +516,7 @@ class AsyncDatabricksOpenAI(AsyncOpenAI):
         use_ai_gateway: If True, auto-detect AI Gateway V2 availability and route
             requests through it using the MLflow API. Defaults to False.
         follow_redirects: If True, the underlying HTTP client follows redirect responses.
-            Defaults to True, matching the OpenAI SDK's default behavior.
+            Defaults to True.
         **kwargs: Additional keyword arguments forwarded to the underlying ``openai.AsyncOpenAI``
             client (e.g. ``timeout``, ``max_retries``, ``default_headers``).
 

--- a/integrations/openai/tests/unit_tests/test_clients.py
+++ b/integrations/openai/tests/unit_tests/test_clients.py
@@ -123,6 +123,16 @@ class TestDatabricksOpenAI:
         # Verify authenticate was called
         mock_workspace_client.config.authenticate.assert_called()
 
+    def test_follow_redirects_default_and_override(self, mock_workspace_client):
+        """follow_redirects defaults to True and can be disabled."""
+        assert _get_authorized_http_client(mock_workspace_client).follow_redirects is True
+        assert (
+            _get_authorized_http_client(
+                mock_workspace_client, follow_redirects=False
+            ).follow_redirects
+            is False
+        )
+
 
 class TestAsyncDatabricksOpenAI:
     """Tests for AsyncDatabricksOpenAI client."""
@@ -166,6 +176,16 @@ class TestAsyncDatabricksOpenAI:
 
         # Verify authenticate was called
         mock_workspace_client.config.authenticate.assert_called()
+
+    def test_follow_redirects_default_and_override(self, mock_workspace_client):
+        """follow_redirects defaults to True and can be disabled for the async client."""
+        assert _get_authorized_async_http_client(mock_workspace_client).follow_redirects is True
+        assert (
+            _get_authorized_async_http_client(
+                mock_workspace_client, follow_redirects=False
+            ).follow_redirects
+            is False
+        )
 
 
 class TestDatabricksOpenAIKwargForwarding:


### PR DESCRIPTION
## Summary
- `DatabricksOpenAI` and `AsyncDatabricksOpenAI` pass a custom httpx `http_client` to the OpenAI SDK. The OpenAI SDK only sets `follow_redirects=True` on the client it builds itself; when a custom client is supplied, httpx's own default of `follow_redirects=False` takes over, silently disabling redirect following.
- This restores the OpenAI SDK's intended default by building the authorized httpx clients with `follow_redirects=True`, applied to both the sync and async helpers for consistent behavior.
- Exposed as a `follow_redirects: bool = True` parameter on both client classes so callers can opt out if needed.

## Test plan
- [ ] `uv run pytest tests/unit_tests/test_clients.py` (added tests assert the default is `True` and can be overridden to `False` for both sync and async helpers)

> Note: the test suite could not be run locally in this environment (no network access to sync dependencies). Verified that httpx's `Client`/`AsyncClient` default `follow_redirects` to `False` and that the modules compile.

This pull request and its description were written by Isaac.