### PR TITLE
Release Databricks AI Bridge 0.21.0, Databricks OpenAI 0.17.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # CHANGELOG
 
+## databricks-ai-bridge 0.21.0 databricks-openai 0.17.0 (2026-06-25)
+
+### Improvements
+- databricks-openai: `DatabricksOpenAI` and `AsyncDatabricksOpenAI` clients now follow HTTP redirects by default, configurable via the new `follow_redirects` parameter (#445)
+
+### Bug Fixes
+- databricks-ai-bridge: Genie now returns the full answer text aggregated from all text attachments (#432)
+
 ## databricks-ai-bridge 0.20.0 databricks-langchain 0.20.0 databricks-openai 0.16.0 (2026-06-10)
 
 ### New Features

--- a/integrations/openai/pyproject.toml
+++ b/integrations/openai/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "databricks-openai"
-version = "0.16.0"
+version = "0.17.0"
 description = "Support for Databricks AI support with OpenAI"
 authors = [
     { name="Databricks", email="agent-feedback@databricks.com" },
@@ -10,7 +10,7 @@ license = { text="Apache-2.0" }
 requires-python = ">=3.10"
 dependencies = [
     "databricks-ai-search>=0.73",
-    "databricks-ai-bridge>=0.20.0",
+    "databricks-ai-bridge>=0.21.0",
     "openai>=1.99.9",
     "pydantic>2.10.0",
     "mlflow>=3.10.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "databricks-ai-bridge"
-version = "0.20.0"
+version = "0.21.0"
 description = "Official Python library for Databricks AI support"
 authors = [
     { name="Databricks", email="agent-feedback@databricks.com" },


### PR DESCRIPTION
## databricks-ai-bridge 0.21.0 databricks-openai 0.17.0 (2026-06-25)

### Improvements
- databricks-openai: `DatabricksOpenAI` and `AsyncDatabricksOpenAI` clients now follow HTTP redirects by default, configurable via the new `follow_redirects` parameter (#445)

### Bug Fixes
- databricks-ai-bridge: Genie now returns the full answer text aggregated from all text attachments (#432)

---

Prepares the next release following #439 (0.20.0). Bumps:
- `databricks-ai-bridge`: `0.20.0` → `0.21.0` (genie fix #432)
- `databricks-openai`: `0.16.0` → `0.17.0` (HTTP redirect support #445), with its `databricks-ai-bridge>=` floor bumped to `0.21.0`

`databricks-langchain` has no changes since 0.20.0 and is intentionally not re-released (consistent with prior releases that omitted unchanged packages).

🤖 Generated with [Claude Code](https://claude.com/claude-code)