### PR TITLE
Add memory store kwargs to DatabricksOpenAI conversations.create

### DIFF
--- a/integrations/openai/src/databricks_openai/utils/clients.py
+++ b/integrations/openai/src/databricks_openai/utils/clients.py
@@ -6,6 +6,7 @@ from httpx import AsyncClient, Auth, Client, Request, Response
 from openai import APIConnectionError, APIStatusError, AsyncOpenAI, OpenAI
 from openai.resources.chat import AsyncChat, Chat
 from openai.resources.chat.completions import AsyncCompletions, Completions
+from openai.resources.conversations import AsyncConversations, Conversations
 from openai.resources.responses import AsyncResponses, Responses
 from typing_extensions import override
 
@@ -322,6 +323,61 @@ class DatabricksResponses(Responses):
         return response
 
 
+def _merge_memory_params_into_extra_body(
+    kwargs: dict,
+    memory_store_name: str | None,
+    memory_scope: str | None,
+    memory_scope_kind: str,
+) -> dict:
+    """Translate memory kwargs into the Databricks-specific conversation body fields.
+
+    The Databricks conversations endpoint accepts ``memory_store`` and ``scope`` fields
+    that aren't part of the OpenAI API, so they're sent via ``extra_body``. Explicit
+    kwargs take precedence over the same keys in a caller-provided ``extra_body``.
+    """
+    if memory_store_name is None and memory_scope is None:
+        return kwargs
+    extra_body = dict(kwargs.pop("extra_body", None) or {})
+    if memory_store_name is not None:
+        extra_body["memory_store"] = {"name": memory_store_name}
+    if memory_scope is not None:
+        extra_body["scope"] = {"kind": memory_scope_kind, "value": memory_scope}
+    kwargs["extra_body"] = extra_body
+    return kwargs
+
+
+class DatabricksConversations(Conversations):
+    """Conversations resource with Databricks agent memory support.
+
+    Adds ``memory_store_name`` and ``memory_scope`` convenience kwargs to ``create``,
+    which attach the conversation to a Unity Catalog memory store. See
+    https://docs.databricks.com/aws/en/generative-ai/agent-memory/ for details.
+    """
+
+    def create(
+        self,
+        *,
+        memory_store_name: str | None = None,
+        memory_scope: str | None = None,
+        memory_scope_kind: str = "user",
+        **kwargs,
+    ):
+        """Create a conversation, optionally backed by a Databricks memory store.
+
+        Args:
+            memory_store_name: Full three-part Unity Catalog name of the memory store
+                (e.g. ``"main.default.support_agent_memory"``).
+            memory_scope: Scope value that partitions memory entries, typically a user id.
+            memory_scope_kind: Kind of the scope. Defaults to ``"user"``.
+            **kwargs: Standard OpenAI ``conversations.create`` arguments
+                (``items``, ``metadata``, ``extra_body``, etc.).
+        """
+        kwargs = _merge_memory_params_into_extra_body(
+            kwargs, memory_store_name, memory_scope, memory_scope_kind
+        )
+        return super().create(**kwargs)
+
+
 class DatabricksOpenAI(OpenAI):
     """OpenAI client authenticated with Databricks to query LLMs and agents hosted on Databricks.
 
@@ -385,6 +441,13 @@ class DatabricksOpenAI(OpenAI):
         ...     model="apps/my-agent",  # Looks up app URL automatically
         ...     input=[{"role": "user", "content": "Hello"}],
         ... )
+
+    Example - Create a conversation backed by a Databricks memory store:
+        >>> client = DatabricksOpenAI(use_ai_gateway=True)
+        >>> conversation = client.conversations.create(
+        ...     memory_store_name="main.default.support_agent_memory",
+        ...     memory_scope="user-123",
+        ... )
     """
 
     def __init__(
@@ -431,6 +494,12 @@ class DatabricksOpenAI(OpenAI):
         if not hasattr(self, "_databricks_responses"):
             self._databricks_responses = DatabricksResponses(self, self._workspace_client)
         return self._databricks_responses
+
+    @property
+    def conversations(self) -> Conversations:
+        if not hasattr(self, "_databricks_conversations"):
+            self._databricks_conversations = DatabricksConversations(self)
+        return self._databricks_conversations
 
 
 class AsyncDatabricksCompletions(AsyncCompletions):
@@ -488,6 +557,38 @@ class AsyncDatabricksResponses(AsyncResponses):
         response = await super().create(**kwargs)
         _truncate_response_ids(response)
         return response
+
+
+class AsyncDatabricksConversations(AsyncConversations):
+    """Async conversations resource with Databricks agent memory support.
+
+    Adds ``memory_store_name`` and ``memory_scope`` convenience kwargs to ``create``,
+    which attach the conversation to a Unity Catalog memory store. See
+    https://docs.databricks.com/aws/en/generative-ai/agent-memory/ for details.
+    """
+
+    async def create(
+        self,
+        *,
+        memory_store_name: str | None = None,
+        memory_scope: str | None = None,
+        memory_scope_kind: str = "user",
+        **kwargs,
+    ):
+        """Create a conversation, optionally backed by a Databricks memory store.
+
+        Args:
+            memory_store_name: Full three-part Unity Catalog name of the memory store
+                (e.g. ``"main.default.support_agent_memory"``).
+            memory_scope: Scope value that partitions memory entries, typically a user id.
+            memory_scope_kind: Kind of the scope. Defaults to ``"user"``.
+            **kwargs: Standard OpenAI ``conversations.create`` arguments
+                (``items``, ``metadata``, ``extra_body``, etc.).
+        """
+        kwargs = _merge_memory_params_into_extra_body(
+            kwargs, memory_store_name, memory_scope, memory_scope_kind
+        )
+        return await super().create(**kwargs)
 
 
 class AsyncDatabricksOpenAI(AsyncOpenAI):
@@ -553,6 +654,13 @@ class AsyncDatabricksOpenAI(AsyncOpenAI):
         ...     model="apps/my-agent",  # Looks up app URL automatically
         ...     input=[{"role": "user", "content": "Hello"}],
         ... )
+
+    Example - Create a conversation backed by a Databricks memory store:
+        >>> client = AsyncDatabricksOpenAI(use_ai_gateway=True)
+        >>> conversation = await client.conversations.create(
+        ...     memory_store_name="main.default.support_agent_memory",
+        ...     memory_scope="user-123",
+        ... )
     """
 
     def __init__(
@@ -598,3 +706,9 @@ class AsyncDatabricksOpenAI(AsyncOpenAI):
         if not hasattr(self, "_databricks_responses"):
             self._databricks_responses = AsyncDatabricksResponses(self, self._workspace_client)
         return self._databricks_responses
+
+    @property
+    def conversations(self) -> AsyncConversations:
+        if not hasattr(self, "_databricks_conversations"):
+            self._databricks_conversations = AsyncDatabricksConversations(self)
+        return self._databricks_conversations

--- a/integrations/openai/src/databricks_openai/utils/clients.py
+++ b/integrations/openai/src/databricks_openai/utils/clients.py
@@ -326,7 +326,13 @@ class DatabricksResponses(Responses):
 def _resolve_scope_value(scope: "str | WorkspaceClient") -> str:
     """Resolve a scope value, extracting the authenticated user's id from a WorkspaceClient."""
     if isinstance(scope, WorkspaceClient):
-        return scope.current_user.me().user_name
+        user_name = scope.current_user.me().user_name
+        if not user_name:
+            raise ValueError(
+                "Could not determine the current user from the provided WorkspaceClient; "
+                "pass the scope value as a string instead."
+            )
+        return user_name
     return scope
 
 
@@ -503,7 +509,7 @@ class DatabricksOpenAI(OpenAI):
         return self._databricks_responses
 
     @property
-    def conversations(self) -> Conversations:
+    def conversations(self) -> "DatabricksConversations":
         if not hasattr(self, "_databricks_conversations"):
             self._databricks_conversations = DatabricksConversations(self)
         return self._databricks_conversations
@@ -715,7 +721,7 @@ class AsyncDatabricksOpenAI(AsyncOpenAI):
         return self._databricks_responses
 
     @property
-    def conversations(self) -> AsyncConversations:
+    def conversations(self) -> "AsyncDatabricksConversations":
         if not hasattr(self, "_databricks_conversations"):
             self._databricks_conversations = AsyncDatabricksConversations(self)
         return self._databricks_conversations

--- a/integrations/openai/src/databricks_openai/utils/clients.py
+++ b/integrations/openai/src/databricks_openai/utils/clients.py
@@ -323,11 +323,18 @@ class DatabricksResponses(Responses):
         return response
 
 
+def _resolve_scope_value(scope: "str | WorkspaceClient") -> str:
+    """Resolve a scope value, extracting the authenticated user's id from a WorkspaceClient."""
+    if isinstance(scope, WorkspaceClient):
+        return scope.current_user.me().user_name
+    return scope
+
+
 def _merge_memory_params_into_extra_body(
     kwargs: dict,
-    memory_store_name: str | None,
-    memory_scope: str | None,
-    memory_scope_kind: str,
+    store: str | None,
+    scope: "str | WorkspaceClient | None",
+    scope_kind: str,
 ) -> dict:
     """Translate memory kwargs into the Databricks-specific conversation body fields.
 
@@ -335,13 +342,13 @@ def _merge_memory_params_into_extra_body(
     that aren't part of the OpenAI API, so they're sent via ``extra_body``. Explicit
     kwargs take precedence over the same keys in a caller-provided ``extra_body``.
     """
-    if memory_store_name is None and memory_scope is None:
+    if store is None and scope is None:
         return kwargs
     extra_body = dict(kwargs.pop("extra_body", None) or {})
-    if memory_store_name is not None:
-        extra_body["memory_store"] = {"name": memory_store_name}
-    if memory_scope is not None:
-        extra_body["scope"] = {"kind": memory_scope_kind, "value": memory_scope}
+    if store is not None:
+        extra_body["memory_store"] = {"name": store}
+    if scope is not None:
+        extra_body["scope"] = {"kind": scope_kind, "value": _resolve_scope_value(scope)}
     kwargs["extra_body"] = extra_body
     return kwargs
 
@@ -349,32 +356,32 @@ def _merge_memory_params_into_extra_body(
 class DatabricksConversations(Conversations):
     """Conversations resource with Databricks agent memory support.
 
-    Adds ``memory_store_name`` and ``memory_scope`` convenience kwargs to ``create``,
-    which attach the conversation to a Unity Catalog memory store. See
+    Adds ``store`` and ``scope`` convenience kwargs to ``create``, which attach the
+    conversation to a Unity Catalog memory store. See
     https://docs.databricks.com/aws/en/generative-ai/agent-memory/ for details.
     """
 
     def create(
         self,
         *,
-        memory_store_name: str | None = None,
-        memory_scope: str | None = None,
-        memory_scope_kind: str = "user",
+        store: str | None = None,
+        scope: "str | WorkspaceClient | None" = None,
+        scope_kind: str = "user",
         **kwargs,
     ):
         """Create a conversation, optionally backed by a Databricks memory store.
 
         Args:
-            memory_store_name: Full three-part Unity Catalog name of the memory store
+            store: Full three-part Unity Catalog name of the memory store
                 (e.g. ``"main.default.support_agent_memory"``).
-            memory_scope: Scope value that partitions memory entries, typically a user id.
-            memory_scope_kind: Kind of the scope. Defaults to ``"user"``.
+            scope: Scope value that partitions memory entries. Pass a ``WorkspaceClient``
+                to use its authenticated user's identity, or a string user id for
+                external (non-Databricks) users.
+            scope_kind: Kind of the scope. Defaults to ``"user"``.
             **kwargs: Standard OpenAI ``conversations.create`` arguments
                 (``items``, ``metadata``, ``extra_body``, etc.).
         """
-        kwargs = _merge_memory_params_into_extra_body(
-            kwargs, memory_store_name, memory_scope, memory_scope_kind
-        )
+        kwargs = _merge_memory_params_into_extra_body(kwargs, store, scope, scope_kind)
         return super().create(**kwargs)
 
 
@@ -445,8 +452,8 @@ class DatabricksOpenAI(OpenAI):
     Example - Create a conversation backed by a Databricks memory store:
         >>> client = DatabricksOpenAI(use_ai_gateway=True)
         >>> conversation = client.conversations.create(
-        ...     memory_store_name="main.default.support_agent_memory",
-        ...     memory_scope="user-123",
+        ...     store="main.default.support_agent_memory",
+        ...     scope=user_client,  # extracts the user id; pass a string for external users
         ... )
     """
 
@@ -562,32 +569,32 @@ class AsyncDatabricksResponses(AsyncResponses):
 class AsyncDatabricksConversations(AsyncConversations):
     """Async conversations resource with Databricks agent memory support.
 
-    Adds ``memory_store_name`` and ``memory_scope`` convenience kwargs to ``create``,
-    which attach the conversation to a Unity Catalog memory store. See
+    Adds ``store`` and ``scope`` convenience kwargs to ``create``, which attach the
+    conversation to a Unity Catalog memory store. See
     https://docs.databricks.com/aws/en/generative-ai/agent-memory/ for details.
     """
 
     async def create(
         self,
         *,
-        memory_store_name: str | None = None,
-        memory_scope: str | None = None,
-        memory_scope_kind: str = "user",
+        store: str | None = None,
+        scope: "str | WorkspaceClient | None" = None,
+        scope_kind: str = "user",
         **kwargs,
     ):
         """Create a conversation, optionally backed by a Databricks memory store.
 
         Args:
-            memory_store_name: Full three-part Unity Catalog name of the memory store
+            store: Full three-part Unity Catalog name of the memory store
                 (e.g. ``"main.default.support_agent_memory"``).
-            memory_scope: Scope value that partitions memory entries, typically a user id.
-            memory_scope_kind: Kind of the scope. Defaults to ``"user"``.
+            scope: Scope value that partitions memory entries. Pass a ``WorkspaceClient``
+                to use its authenticated user's identity, or a string user id for
+                external (non-Databricks) users.
+            scope_kind: Kind of the scope. Defaults to ``"user"``.
             **kwargs: Standard OpenAI ``conversations.create`` arguments
                 (``items``, ``metadata``, ``extra_body``, etc.).
         """
-        kwargs = _merge_memory_params_into_extra_body(
-            kwargs, memory_store_name, memory_scope, memory_scope_kind
-        )
+        kwargs = _merge_memory_params_into_extra_body(kwargs, store, scope, scope_kind)
         return await super().create(**kwargs)
 
 
@@ -658,8 +665,8 @@ class AsyncDatabricksOpenAI(AsyncOpenAI):
     Example - Create a conversation backed by a Databricks memory store:
         >>> client = AsyncDatabricksOpenAI(use_ai_gateway=True)
         >>> conversation = await client.conversations.create(
-        ...     memory_store_name="main.default.support_agent_memory",
-        ...     memory_scope="user-123",
+        ...     store="main.default.support_agent_memory",
+        ...     scope=user_client,  # extracts the user id; pass a string for external users
         ... )
     """
 

--- a/integrations/openai/tests/unit_tests/test_clients.py
+++ b/integrations/openai/tests/unit_tests/test_clients.py
@@ -9,6 +9,7 @@ from httpx import Request
 from openai import APIConnectionError, APIStatusError, AsyncOpenAI, OpenAI
 from openai._types import NOT_GIVEN, Omit
 from openai.resources.chat.completions import AsyncCompletions, Completions
+from openai.resources.conversations import AsyncConversations, Conversations
 from openai.resources.responses import AsyncResponses, Responses
 
 from databricks_openai import AsyncDatabricksOpenAI, DatabricksOpenAI
@@ -804,6 +805,115 @@ class TestOpenAIApiKey:
     def test_falls_back_to_no_token_when_empty_string(self):
         with patch.dict("os.environ", {"OPENAI_API_KEY": ""}):
             assert _get_openai_api_key() == "no-token"
+
+
+class TestDatabricksConversationsMemory:
+    """Tests for memory store kwargs on conversations.create."""
+
+    def test_memory_kwargs_translated_to_extra_body(self, mock_workspace_client):
+        client = DatabricksOpenAI(workspace_client=mock_workspace_client, use_ai_gateway=True)
+
+        with patch.object(Conversations, "create") as mock_create:
+            mock_create.return_value = MagicMock()
+            client.conversations.create(
+                memory_store_name="main.default.support_agent_memory",
+                memory_scope="user-123",
+            )
+
+            call_kwargs = mock_create.call_args.kwargs
+            assert call_kwargs["extra_body"] == {
+                "memory_store": {"name": "main.default.support_agent_memory"},
+                "scope": {"kind": "user", "value": "user-123"},
+            }
+            assert "memory_store_name" not in call_kwargs
+            assert "memory_scope" not in call_kwargs
+
+    def test_memory_scope_kind_override(self, mock_workspace_client):
+        client = DatabricksOpenAI(workspace_client=mock_workspace_client, use_ai_gateway=True)
+
+        with patch.object(Conversations, "create") as mock_create:
+            mock_create.return_value = MagicMock()
+            client.conversations.create(
+                memory_store_name="main.default.support_agent_memory",
+                memory_scope="acct-42",
+                memory_scope_kind="account",
+            )
+
+            extra_body = mock_create.call_args.kwargs["extra_body"]
+            assert extra_body["scope"] == {"kind": "account", "value": "acct-42"}
+
+    def test_memory_kwargs_merge_with_existing_extra_body(self, mock_workspace_client):
+        client = DatabricksOpenAI(workspace_client=mock_workspace_client, use_ai_gateway=True)
+
+        with patch.object(Conversations, "create") as mock_create:
+            mock_create.return_value = MagicMock()
+            client.conversations.create(
+                memory_store_name="main.default.support_agent_memory",
+                memory_scope="user-123",
+                extra_body={"custom_field": "value", "scope": {"kind": "user", "value": "old"}},
+            )
+
+            extra_body = mock_create.call_args.kwargs["extra_body"]
+            assert extra_body["custom_field"] == "value"
+            # Explicit kwargs take precedence over extra_body entries
+            assert extra_body["scope"] == {"kind": "user", "value": "user-123"}
+
+    def test_create_without_memory_kwargs_passes_through(self, mock_workspace_client):
+        client = DatabricksOpenAI(workspace_client=mock_workspace_client, use_ai_gateway=True)
+
+        with patch.object(Conversations, "create") as mock_create:
+            mock_create.return_value = MagicMock()
+            client.conversations.create(metadata={"topic": "support"})
+
+            call_kwargs = mock_create.call_args.kwargs
+            assert call_kwargs == {"metadata": {"topic": "support"}}
+
+    def test_raw_extra_body_still_works(self, mock_workspace_client):
+        """The original extra_body-based usage keeps working unchanged."""
+        client = DatabricksOpenAI(workspace_client=mock_workspace_client, use_ai_gateway=True)
+
+        with patch.object(Conversations, "create") as mock_create:
+            mock_create.return_value = MagicMock()
+            client.conversations.create(
+                extra_body={
+                    "memory_store": {"name": "main.default.support_agent_memory"},
+                    "scope": {"kind": "user", "value": "user-123"},
+                },
+            )
+
+            extra_body = mock_create.call_args.kwargs["extra_body"]
+            assert extra_body["memory_store"] == {"name": "main.default.support_agent_memory"}
+            assert extra_body["scope"] == {"kind": "user", "value": "user-123"}
+
+    def test_conversations_items_resource_still_accessible(self, mock_workspace_client):
+        client = DatabricksOpenAI(workspace_client=mock_workspace_client, use_ai_gateway=True)
+        assert client.conversations.items is not None
+
+    @pytest.mark.asyncio
+    async def test_async_memory_kwargs_translated_to_extra_body(self, mock_workspace_client):
+        client = AsyncDatabricksOpenAI(workspace_client=mock_workspace_client, use_ai_gateway=True)
+
+        with patch.object(AsyncConversations, "create", new_callable=AsyncMock) as mock_create:
+            await client.conversations.create(
+                memory_store_name="main.default.support_agent_memory",
+                memory_scope="user-123",
+            )
+
+            call_kwargs = mock_create.call_args.kwargs
+            assert call_kwargs["extra_body"] == {
+                "memory_store": {"name": "main.default.support_agent_memory"},
+                "scope": {"kind": "user", "value": "user-123"},
+            }
+
+    @pytest.mark.asyncio
+    async def test_async_create_without_memory_kwargs_passes_through(self, mock_workspace_client):
+        client = AsyncDatabricksOpenAI(workspace_client=mock_workspace_client, use_ai_gateway=True)
+
+        with patch.object(AsyncConversations, "create", new_callable=AsyncMock) as mock_create:
+            await client.conversations.create(metadata={"topic": "support"})
+
+            call_kwargs = mock_create.call_args.kwargs
+            assert call_kwargs == {"metadata": {"topic": "support"}}
 
 
 class TestDatabricksOpenAIWithGateway:

--- a/integrations/openai/tests/unit_tests/test_clients.py
+++ b/integrations/openai/tests/unit_tests/test_clients.py
@@ -816,8 +816,8 @@ class TestDatabricksConversationsMemory:
         with patch.object(Conversations, "create") as mock_create:
             mock_create.return_value = MagicMock()
             client.conversations.create(
-                memory_store_name="main.default.support_agent_memory",
-                memory_scope="user-123",
+                store="main.default.support_agent_memory",
+                scope="user-123",
             )
 
             call_kwargs = mock_create.call_args.kwargs
@@ -825,18 +825,33 @@ class TestDatabricksConversationsMemory:
                 "memory_store": {"name": "main.default.support_agent_memory"},
                 "scope": {"kind": "user", "value": "user-123"},
             }
-            assert "memory_store_name" not in call_kwargs
-            assert "memory_scope" not in call_kwargs
+            assert "store" not in call_kwargs
+            assert "scope" not in call_kwargs
 
-    def test_memory_scope_kind_override(self, mock_workspace_client):
+    def test_workspace_client_scope_extracts_user_id(self, mock_workspace_client):
+        user_client = MagicMock(spec=WorkspaceClient)
+        user_client.current_user.me.return_value.user_name = "jenny@databricks.com"
         client = DatabricksOpenAI(workspace_client=mock_workspace_client, use_ai_gateway=True)
 
         with patch.object(Conversations, "create") as mock_create:
             mock_create.return_value = MagicMock()
             client.conversations.create(
-                memory_store_name="main.default.support_agent_memory",
-                memory_scope="acct-42",
-                memory_scope_kind="account",
+                store="main.default.support_agent_memory",
+                scope=user_client,
+            )
+
+            extra_body = mock_create.call_args.kwargs["extra_body"]
+            assert extra_body["scope"] == {"kind": "user", "value": "jenny@databricks.com"}
+
+    def test_scope_kind_override(self, mock_workspace_client):
+        client = DatabricksOpenAI(workspace_client=mock_workspace_client, use_ai_gateway=True)
+
+        with patch.object(Conversations, "create") as mock_create:
+            mock_create.return_value = MagicMock()
+            client.conversations.create(
+                store="main.default.support_agent_memory",
+                scope="acct-42",
+                scope_kind="account",
             )
 
             extra_body = mock_create.call_args.kwargs["extra_body"]
@@ -848,8 +863,8 @@ class TestDatabricksConversationsMemory:
         with patch.object(Conversations, "create") as mock_create:
             mock_create.return_value = MagicMock()
             client.conversations.create(
-                memory_store_name="main.default.support_agent_memory",
-                memory_scope="user-123",
+                store="main.default.support_agent_memory",
+                scope="user-123",
                 extra_body={"custom_field": "value", "scope": {"kind": "user", "value": "old"}},
             )
 
@@ -895,8 +910,8 @@ class TestDatabricksConversationsMemory:
 
         with patch.object(AsyncConversations, "create", new_callable=AsyncMock) as mock_create:
             await client.conversations.create(
-                memory_store_name="main.default.support_agent_memory",
-                memory_scope="user-123",
+                store="main.default.support_agent_memory",
+                scope="user-123",
             )
 
             call_kwargs = mock_create.call_args.kwargs


### PR DESCRIPTION
## Summary

Databricks agent memory attaches conversations to a Unity Catalog memory store via `memory_store` and `scope` fields on the conversations endpoint. These aren't part of the OpenAI API, so callers previously had to pass them through `extra_body`:

```python
client = DatabricksOpenAI(use_ai_gateway=True)
conversation = client.conversations.create(
    extra_body={
        "memory_store": {"name": "main.default.support_agent_memory"},
        "scope": {"kind": "user", "value": user_id},
    },
)
```

This PR adds `DatabricksConversations` / `AsyncDatabricksConversations` resources (following the existing `DatabricksResponses` pattern) that accept first-class kwargs and translate them into `extra_body` before delegating to the stock OpenAI SDK resource:

```python
conversation = client.conversations.create(
    store="main.default.support_agent_memory",
    scope=user_client,  # SDK extracts the user id; pass a string for external (non-Databricks) users
)
```

- `scope` accepts either a `WorkspaceClient` (the authenticated user's id is extracted via `current_user.me().user_name`) or a plain string.
- `scope_kind` is exposed for non-`user` scope kinds (defaults to `"user"`).
- All standard `conversations.create` arguments (`items`, `metadata`, `extra_body`, `extra_headers`, ...) pass through unchanged, so existing `extra_body` usage keeps working; explicit kwargs win over the same keys in a caller-provided `extra_body`.
- `client.conversations.items.*` and the other conversation methods are inherited untouched from the OpenAI SDK.

No databricks-sdk changes required — the Databricks conversation endpoints are OpenAI-shaped, so this is purely client-side sugar over the gateway's OpenAI-compatible surface.

## Test plan

- New unit tests in `tests/unit_tests/test_clients.py` covering: kwarg-to-extra_body translation, `WorkspaceClient` scope extraction, scope kind override, merging with caller-provided `extra_body` (kwargs take precedence), passthrough when no memory kwargs are given, backward-compatible raw `extra_body` usage, and the async variants.
- `python -m pytest tests/unit_tests/` — 222 passed.
- `ruff check` / `ruff format --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)