### PR TITLE
Fix tests for openai v2.45.0 cache_write_tokens compatibility

### DIFF
--- a/integrations/langchain/tests/unit_tests/test_chat_models.py
+++ b/integrations/langchain/tests/unit_tests/test_chat_models.py
@@ -1778,7 +1778,7 @@ def test_convert_responses_usage_to_usage_metadata(cached_tokens, reasoning_toke
         input_tokens=100,
         output_tokens=50,
         total_tokens=150,
-        input_tokens_details=InputTokensDetails(cached_tokens=cached_tokens),
+        input_tokens_details=InputTokensDetails(cache_write_tokens=0, cached_tokens=cached_tokens),
         output_tokens_details=OutputTokensDetails(reasoning_tokens=reasoning_tokens),
     )
 
@@ -1856,7 +1856,7 @@ def test_extract_response_usage_from_chunk(stream_usage):
         input_tokens=100,
         output_tokens=50,
         total_tokens=150,
-        input_tokens_details=InputTokensDetails(cached_tokens=25),
+        input_tokens_details=InputTokensDetails(cache_write_tokens=0, cached_tokens=25),
         output_tokens_details=OutputTokensDetails(reasoning_tokens=10),
     )
     response = Mock()
@@ -1906,7 +1906,7 @@ def test_build_usage_chunk_from_responses(use_response_usage):
             input_tokens=100,
             output_tokens=50,
             total_tokens=150,
-            input_tokens_details=InputTokensDetails(cached_tokens=25),
+            input_tokens_details=InputTokensDetails(cache_write_tokens=0, cached_tokens=25),
             output_tokens_details=OutputTokensDetails(reasoning_tokens=10),
         )
     else:
@@ -2083,7 +2083,7 @@ def test_chat_databricks_responses_api_invoke_returns_usage_metadata():
                 input_tokens=100,
                 output_tokens=50,
                 total_tokens=150,
-                input_tokens_details=InputTokensDetails(cached_tokens=25),
+                input_tokens_details=InputTokensDetails(cache_write_tokens=0, cached_tokens=25),
                 output_tokens_details=OutputTokensDetails(reasoning_tokens=10),
             ),
         )


### PR DESCRIPTION
 ## Problem

 CI started failing for the `langchain` tests and type checks due to a breaking change in `openai v2.45.0` (released July 9, 2026).

 `openai v2.45.0` added a new **required** field `cache_write_tokens: int` to `InputTokensDetails` in `openai.types.responses.response_usage`:

 ```python
 # v2.44.0
 class InputTokensDetails(BaseModel):
     cached_tokens: int

 # v2.45.0
 class InputTokensDetails(BaseModel):
     cache_write_tokens: int   # NEW, required, no default
     cached_tokens: int
 ```

 Existing tests construct `InputTokensDetails(cached_tokens=...)` without `cache_write_tokens`, causing `ValidationError` on v2.45.0.

 ## Failures

 This causes 6 test failures and 4 `ty` type-check errors:
 - `test_convert_responses_usage_to_usage_metadata` (2 parametrized)
 - `test_extract_response_usage_from_chunk` (2 parametrized)
 - `test_build_usage_chunk_from_responses` (1 parametrized)
 - `test_chat_databricks_responses_api_invoke_returns_usage_metadata`

 The `langchain_test` and `langchain_test_with_extras` jobs fail with `uv: highest` resolution (which picks up v2.45.0), while `lowest-direct` still passes (uses older version).

 ## Fix

 Pass `cache_write_tokens=0` to all `InputTokensDetails` constructions.

 This is **backward compatible**: openai's `BaseModel` uses `extra='allow'`, so the extra field is silently accepted on older versions (e.g. v2.44.0) that don't define it.

 Verified passing on both `openai==2.44.0` and `openai==2.45.0`.                                                                                                                                                            