### PR TITLE
Fix pre-existing CI failures: ty typecheck and openai cross-version tests

### DIFF
--- a/integrations/langchain/tests/unit_tests/test_multi_server_mcp_client.py
+++ b/integrations/langchain/tests/unit_tests/test_multi_server_mcp_client.py
@@ -51,7 +51,9 @@ class TestMCPServer:
         # Check that extra params are in connection dict
         for key, value in extra_params.items():
             if key == "timeout" and isinstance(value, float):
-                assert connection_dict["timeout"].seconds == value
+                timeout = connection_dict["timeout"]
+                assert isinstance(timeout, timedelta)
+                assert timeout.seconds == value
             else:
                 assert connection_dict[key] == value  # ty:ignore[invalid-key]
             assert "name" not in connection_dict

--- a/src/databricks_ai_bridge/test_utils/vector_search.py
+++ b/src/databricks_ai_bridge/test_utils/vector_search.py
@@ -141,11 +141,34 @@ def mock_vs_client() -> Generator:
 
     mock_client = MagicMock()
     mock_client.get_index.side_effect = _get_index
-    with mock.patch(
-        "databricks.ai_search.client.VectorSearchClient",
-        return_value=mock_client,
-    ):
+    patches = [
+        mock.patch(
+            "databricks.ai_search.client.VectorSearchClient",
+            return_value=mock_client,
+        ),
+    ]
+    # Also patch the deprecated `databricks.vector_search` import path so that
+    # older integrations (e.g. databricks-openai < v0.6) that still import via
+    # `databricks.vector_search.client.VectorSearchClient` are mocked correctly.
+    # The shim module is only present when `databricks-vectorsearch` is installed.
+    try:
+        import databricks.vector_search.client  # noqa: F401  # ty: ignore[unresolved-import]
+    except ImportError:
+        pass
+    else:
+        patches.append(
+            mock.patch(
+                "databricks.vector_search.client.VectorSearchClient",
+                return_value=mock_client,
+            )
+        )
+    for p in patches:
+        p.start()
+    try:
         yield
+    finally:
+        for p in patches:
+            p.stop()
 
 
 @pytest.fixture(autouse=True)


### PR DESCRIPTION
Two pre-existing CI failures on main:

1. typechecking for integrations/langchain (ty check): test_multi_server_mcp_client.py line 54 accessed .seconds on a union of float|timedelta. Add isinstance check to narrow the type so ty recognizes the timedelta attribute access.

2. openai cross-version tests (v0.3.0, v0.4.0, v0.5.0): The mock_vs_client fixture patches databricks.ai_search.client .VectorSearchClient but older integrations import via the deprecated databricks.vector_search.client.VectorSearchClient shim. mock.patch only replaces the attribute on the specific module, so the old import path was not mocked and the real VectorSearchClient tried to authenticate. Now the fixture also patches the old path when the shim module is installed.

Both fixes are backward compatible.