### PR TITLE
fix(databricks-mcp): pin mcp dependency to <2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,11 @@
 ### Bug Fixes
 - databricks-ai-bridge: Use the last query attachment in `_parse_attachments` to support Genie self-correction (#419)
 
+## databricks-mcp 0.9.1 (2026-07-28)
+
+### Bug Fixes
+- Pin `mcp` dependency to `>=1.13.0,<2.0.0` to avoid breaking `ImportError` caused by the `streamablehttp_client` rename in `mcp` 2.0.0.
+
 ## databricks-ai-bridge 0.17.0 databricks-langchain 0.17.0 databricks-openai 0.13.0 (2026-03-09)
 
 ### Release

--- a/databricks_mcp/pyproject.toml
+++ b/databricks_mcp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "databricks-mcp"
-version = "0.9.0"
+version = "0.9.1"
 description = "MCP helpers for Databricks"
 authors = [
     { name="Databricks", email="agent-feedback@databricks.com" },
@@ -9,7 +9,7 @@ readme = "README.md"
 license = { text="Apache-2.0" }
 requires-python = ">=3.10"
 dependencies = [
-    "mcp>=1.13.0",
+    "mcp>=1.13.0,<2.0.0",
     "databricks-sdk>=0.49.0",
     "databricks-ai-bridge>=0.4.2",
     "mlflow>=3.1"

--- a/integrations/langchain/tests/unit_tests/test_chat_models.py
+++ b/integrations/langchain/tests/unit_tests/test_chat_models.py
@@ -1778,7 +1778,9 @@ def test_convert_responses_usage_to_usage_metadata(cached_tokens, reasoning_toke
         input_tokens=100,
         output_tokens=50,
         total_tokens=150,
-        input_tokens_details=InputTokensDetails(cache_write_tokens=0, cached_tokens=cached_tokens),
+        input_tokens_details=InputTokensDetails.model_construct(
+            cache_write_tokens=0, cached_tokens=cached_tokens
+        ),
         output_tokens_details=OutputTokensDetails(reasoning_tokens=reasoning_tokens),
     )
 
@@ -1856,7 +1858,9 @@ def test_extract_response_usage_from_chunk(stream_usage):
         input_tokens=100,
         output_tokens=50,
         total_tokens=150,
-        input_tokens_details=InputTokensDetails(cache_write_tokens=0, cached_tokens=25),
+        input_tokens_details=InputTokensDetails.model_construct(
+            cache_write_tokens=0, cached_tokens=25
+        ),
         output_tokens_details=OutputTokensDetails(reasoning_tokens=10),
     )
     response = Mock()
@@ -1906,7 +1910,9 @@ def test_build_usage_chunk_from_responses(use_response_usage):
             input_tokens=100,
             output_tokens=50,
             total_tokens=150,
-            input_tokens_details=InputTokensDetails(cache_write_tokens=0, cached_tokens=25),
+            input_tokens_details=InputTokensDetails.model_construct(
+                cache_write_tokens=0, cached_tokens=25
+            ),
             output_tokens_details=OutputTokensDetails(reasoning_tokens=10),
         )
     else:
@@ -2083,7 +2089,9 @@ def test_chat_databricks_responses_api_invoke_returns_usage_metadata():
                 input_tokens=100,
                 output_tokens=50,
                 total_tokens=150,
-                input_tokens_details=InputTokensDetails(cache_write_tokens=0, cached_tokens=25),
+                input_tokens_details=InputTokensDetails.model_construct(
+                    cache_write_tokens=0, cached_tokens=25
+                ),
                 output_tokens_details=OutputTokensDetails(reasoning_tokens=10),
             ),
         )


### PR DESCRIPTION
mcp 2.0.0 removes the legacy `streamablehttp_client` symbol from `mcp.client.streamable_http`, which causes `databricks-mcp 0.9.0` to fail at import time on any fresh install that resolves to mcp 2.x.

This change adds an upper bound `mcp>=1.13.0,<2.0.0` so the dependency resolver picks a compatible 1.x release, and bumps `databricks-mcp` to `0.9.1`.

- [x] Added CHANGELOG entry
- [ ] Automated tests / manual verification: unit tests pass with `uv run pytest tests/unit_tests -q` and lint passes with `uv run ruff check .`