### PR TITLE
fix(openai): declare mcp<2 upper bound (mcp 2.0 removed GetSessionIdCallback)

### DIFF
--- a/integrations/openai/pyproject.toml
+++ b/integrations/openai/pyproject.toml
@@ -16,7 +16,10 @@ dependencies = [
     "mlflow>=3.10.1",
     "unitycatalog-openai[databricks]>=0.2.0",
     "databricks-mcp>=0.4.0",
-    "openai-agents>=0.5.0"
+    "openai-agents>=0.5.0",
+    # direct import in databricks_openai.agents.mcp_server; mcp 2.0.0 removed
+    # GetSessionIdCallback / rewrote the streamable-http transport
+    "mcp>=1.19,<2"
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
## Problem

`databricks_openai.agents.mcp_server` imports `GetSessionIdCallback` from `mcp.client.streamable_http`. mcp **2.0.0** (released 2026-07-28) is a transport rewrite (httpx2, mcp_types, `TransportStreams`) that removed this symbol.

`mcp` is not declared as a direct dependency of `databricks-openai` — it arrives transitively via `openai-agents` (`mcp<3,>=1.19`), which admits 2.x. So any fresh install today resolves `mcp==2.0.0` and fails at import time:

```
$ pip install databricks-openai
$ python -c "from databricks_openai.agents import McpServer"
ImportError: cannot import name 'GetSessionIdCallback' from 'mcp.client.streamable_http'
```

Still reproducible on `main` (`integrations/openai/src/databricks_openai/agents/mcp_server.py` line 9).

## Fix

Declare the direct dependency with the range that works today: `mcp>=1.19,<2` (1.29.0 is the newest 1.x). The bound can be lifted when the streamable-http client is ported to the mcp 2.x transport API — happy to file a follow-up issue tracking that if useful.

Found while building a Supervisor-API-compatible agent on the `agent-openai-agents-sdk` app template.

🤖 Generated with [Claude Code](https://claude.com/claude-code)