### PR TITLE
fix(databricks-langchain): don't repeat streamed Responses text

### DIFF
--- a/integrations/langchain/src/databricks_langchain/chat_models.py
+++ b/integrations/langchain/src/databricks_langchain/chat_models.py
@@ -1747,11 +1747,20 @@ def _convert_responses_api_chunk_to_lc_chunk(
             )
         elif item.type == "message":
             id = item.id
-            # skip text outputs that have already been streamed, but keep the annotations
+            # skip text outputs that have already been streamed, but keep the annotations.
+            # Providers close a message with output_text.done and content_part.done before
+            # output_item.done, so those terminators count as "already streamed" too.
             prev_type = previous_chunk.type if previous_chunk else None
             prev_item_id = getattr(previous_chunk, "item_id", None) if previous_chunk else None
             skip_duplicate_text = (
-                previous_chunk and prev_type == "response.output_text.delta" and id == prev_item_id
+                previous_chunk
+                and prev_type
+                in (
+                    "response.output_text.delta",
+                    "response.output_text.done",
+                    "response.content_part.done",
+                )
+                and id == prev_item_id
             )
             if item.content is not None:  # ty:ignore[unresolved-attribute]: astral-sh/ty#1479 should fix this
                 for content_item in item.content:  # ty:ignore[unresolved-attribute]: astral-sh/ty#1479 should fix this

--- a/integrations/langchain/tests/unit_tests/test_chat_models.py
+++ b/integrations/langchain/tests/unit_tests/test_chat_models.py
@@ -1106,6 +1106,23 @@ def test_convert_responses_api_chunk_to_lc_chunk_skip_duplicate():
     assert result is None
 
 
+@pytest.mark.parametrize("prev_type", ["response.output_text.done", "response.content_part.done"])
+def test_convert_responses_api_chunk_to_lc_chunk_skip_duplicate_after_terminator(prev_type):
+    """Text terminators between the last delta and output_item.done still skip the repeat."""
+    previous_chunk = ResponseTextDeltaEvent.model_construct(type=prev_type, item_id="item_123")
+
+    chunk = ResponseOutputItemDoneEvent.model_construct(
+        type="response.output_item.done",
+        item=ResponseOutputMessage.model_construct(
+            type="message",
+            id="item_123",
+            content=[ResponseOutputText.model_construct(type="output_text", text="Hello")],
+        ),
+    )
+
+    assert _convert_responses_api_chunk_to_lc_chunk(chunk, previous_chunk) is None
+
+
 def test_convert_responses_api_chunk_to_lc_chunk_skip_duplicate_with_annotations():
     """Test _convert_responses_api_chunk_to_lc_chunk skips duplicate text."""
     previous_chunk = ResponseTextDeltaEvent.model_construct(


### PR DESCRIPTION
Fixes #464.

## Summary

`_convert_responses_api_chunk_to_lc_chunk` suppressed the terminal full-text block only when the *immediately* previous chunk was `response.output_text.delta`. Providers close a message with `response.output_text.done` and `response.content_part.done` first, so the check never fired and the completed text was appended on top of the streamed deltas — every reply came back doubled.

Those two terminators now count as "already streamed" when the `item_id` matches.

## Test plan

- [x] New parametrized unit test covering both terminators before `output_item.done`; existing tests only covered a delta immediately preceding it, which is why this passed CI.
- [x] `pytest tests/unit_tests/test_chat_models.py` — 108 passed, 2 skipped.
- [x] Offline repro of the documented event order through `_stream` with a stubbed client:

  ```
  before: [{'text': 'hello'}, {'text': ' world'}, {'text': 'hello world', 'annotations': []}] -> 'hello worldhello world'
  after : [{'text': 'hello'}, {'text': ' world'}]                                             -> 'hello world'
  ```

- [x] Verified live against Unity AI Gateway (Azure Foundry GPT-5.6 and `system.ai.claude-haiku-4-5`) through a LangGraph agent with tool calls: streamed deltas and the final message now agree.