### PR TITLE
Release Databricks OpenAI 0.17.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## databricks-openai 0.17.1 (2026-08-20)
+
+### Bug Fixes
+- databricks-openai: declare `mcp>=1.19,<2` as a direct dependency so `databricks_openai.agents.McpServer` imports correctly on fresh installs (mcp 2.0.0 removed `GetSessionIdCallback`) (#463)
+
 ## databricks-ai-bridge 0.21.0 databricks-openai 0.17.0 (2026-06-25)
 
 ### Improvements

--- a/integrations/openai/pyproject.toml
+++ b/integrations/openai/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "databricks-openai"
-version = "0.17.0"
+version = "0.17.1"
 description = "Support for Databricks AI support with OpenAI"
 authors = [
     { name="Databricks", email="agent-feedback@databricks.com" },


### PR DESCRIPTION
## databricks-openai 0.17.1 (2026-08-20)

### Bug Fixes
- databricks-openai: declare `mcp>=1.19,<2` as a direct dependency so `databricks_openai.agents.McpServer` imports correctly on fresh installs (mcp 2.0.0 removed `GetSessionIdCallback`) (#463)

---

Prepares the next release following #449 (databricks-ai-bridge 0.21.0 / databricks-openai 0.17.0). Bumps:
- `databricks-openai`: `0.17.0` → `0.17.1`

Patch rather than minor: the only shippable change since the `databricks-openai-v0.17.0` tag is the dependency-bound fix in #463. This follows the precedent of 0.11.1 and 0.12.1, which were also patch releases for bug fixes.

The `databricks-ai-bridge>=0.21.0` floor is unchanged, since `databricks-ai-bridge` has no changes since 0.21.0.

Packages intentionally not re-released (consistent with prior releases that omit unchanged packages):
- `databricks-ai-bridge` — no changes since 0.21.0
- `databricks-langchain` — no changes since 0.20.0 (#453 touched only its unit tests)
- `databricks-mcp` — already released as 0.9.2 via #458

Note: `databricks-mcp` 0.9.2 was tagged and published without a CHANGELOG entry. Left as-is here to keep this PR scoped to the openai release, but worth backfilling separately.

This pull request and its description were written by Isaac.