### PR TITLE
Enable databricks-mason TestPyPI development releases

### DIFF
--- a/.github/workflows/generate_release_workflows.py
+++ b/.github/workflows/generate_release_workflows.py
@@ -8,16 +8,16 @@ from pathlib import Path
 @dataclass
 class Package:
     name: str
+    release_enabled: bool
     working_dir: str | None = None  # None means root level
-    release_enabled: bool = False
 
 
 PACKAGES = [
-    Package("databricks-ai-bridge"),
-    Package("databricks-langchain", "integrations/langchain"),
-    Package("databricks-mason", "integrations/mason", release_enabled=True),
-    Package("databricks-mcp", "databricks_mcp"),
-    Package("databricks-openai", "integrations/openai"),
+    Package("databricks-ai-bridge", release_enabled=False),
+    Package("databricks-langchain", release_enabled=False, working_dir="integrations/langchain"),
+    Package("databricks-mason", release_enabled=True, working_dir="integrations/mason"),
+    Package("databricks-mcp", release_enabled=False, working_dir="databricks_mcp"),
+    Package("databricks-openai", release_enabled=False, working_dir="integrations/openai"),
 ]
 
 

--- a/.github/workflows/generate_release_workflows.py
+++ b/.github/workflows/generate_release_workflows.py
@@ -9,12 +9,13 @@ from pathlib import Path
 class Package:
     name: str
     working_dir: str | None = None  # None means root level
+    release_enabled: bool = False
 
 
 PACKAGES = [
     Package("databricks-ai-bridge"),
     Package("databricks-langchain", "integrations/langchain"),
-    Package("databricks-mason", "integrations/mason"),
+    Package("databricks-mason", "integrations/mason", release_enabled=True),
     Package("databricks-mcp", "databricks_mcp"),
     Package("databricks-openai", "integrations/openai"),
 ]
@@ -24,6 +25,11 @@ def generate_workflow(pkg: Package) -> str:
     """Generate a release workflow YAML for a package."""
     is_root = pkg.working_dir is None
     dist_path = "dist/" if is_root else f"{pkg.working_dir}/dist/"
+    disabled_guard = (
+        ""
+        if pkg.release_enabled
+        else "    if: false  # TEMPORARILY DISABLED - remove this line to re-enable\n"
+    )
 
     # Build the defaults section for non-root packages
     defaults_section = ""
@@ -62,8 +68,7 @@ on:
 
 jobs:
   release:
-    if: false  # TEMPORARILY DISABLED - remove this line to re-enable
-    runs-on:
+{disabled_guard}    runs-on:
       group: databricks-protected-runner-group
       labels: linux-ubuntu-latest
 

--- a/.github/workflows/release-databricks-mason.yml
+++ b/.github/workflows/release-databricks-mason.yml
@@ -17,7 +17,6 @@ on:
 
 jobs:
   release:
-    if: false  # TEMPORARILY DISABLED - remove this line to re-enable
     runs-on:
       group: databricks-protected-runner-group
       labels: linux-ubuntu-latest

--- a/integrations/mason/pyproject.toml
+++ b/integrations/mason/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "databricks-mason"
-version = "0.1.0"
+version = "0.1.0.dev0"
 description = "Databricks integration for Mason"
 authors = [
     { name="Databricks", email="agent-feedback@databricks.com" },

--- a/integrations/mason/pyproject.toml
+++ b/integrations/mason/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "databricks-mason"
-version = "0.0.1.dev0"
+version = "0.1.0"
 description = "Databricks integration for Mason"
 authors = [
     { name="Databricks", email="agent-feedback@databricks.com" },


### PR DESCRIPTION
## Summary
- set the initial databricks-mason scaffold version to 0.1.0.dev0
- enable only the generated databricks-mason release workflow
- retain TestPyPI as the default destination for tag-triggered releases

## Verification
- regenerated all release workflows and confirmed only the Mason workflow changed
- verified release metadata, OIDC permission, and TestPyPI environment selection

This development release validates packaging and trusted publishing. The first functional production release remains 0.1.0. Production publishing also requires a separately configured PyPI trusted publisher and an explicitly approved production workflow dispatch.