### PR TITLE
Build out the Mason CLI: init, dev, and store-aware deploy

### DIFF
--- a/integrations/mason/src/databricks_mason/cli.py
+++ b/integrations/mason/src/databricks_mason/cli.py
@@ -13,6 +13,7 @@ import click
 from databricks_mason.auth import load_default_profile, login, logout
 from databricks_mason.client import AgentApiClient
 from databricks_mason.deploy import deploy, deployments
+from databricks_mason.init import init
 from databricks_mason.memory import memory
 from databricks_mason.sessions import sessions
 from databricks_mason.tracing import tracing
@@ -57,6 +58,7 @@ def mason(ctx: click.Context, profile: Optional[str], output: str) -> None:
 
 mason.add_command(login)
 mason.add_command(logout)
+mason.add_command(init)
 mason.add_command(memory)
 mason.add_command(sessions)
 mason.add_command(tracing)

--- a/integrations/mason/src/databricks_mason/cli.py
+++ b/integrations/mason/src/databricks_mason/cli.py
@@ -13,6 +13,7 @@ import click
 from databricks_mason.auth import load_default_profile, login, logout
 from databricks_mason.client import AgentApiClient
 from databricks_mason.deploy import deploy, deployments
+from databricks_mason.dev import dev
 from databricks_mason.init import init
 from databricks_mason.memory import memory
 from databricks_mason.sessions import sessions
@@ -59,6 +60,7 @@ def mason(ctx: click.Context, profile: Optional[str], output: str) -> None:
 mason.add_command(login)
 mason.add_command(logout)
 mason.add_command(init)
+mason.add_command(dev)
 mason.add_command(memory)
 mason.add_command(sessions)
 mason.add_command(tracing)

--- a/integrations/mason/src/databricks_mason/client.py
+++ b/integrations/mason/src/databricks_mason/client.py
@@ -56,6 +56,14 @@ class AgentApiClient:
         """The authenticated user's name (used to derive the app source workspace path)."""
         return str(self._w.current_user.me().user_name or "unknown")
 
+    def ensure_workspace_dir(self, path: str) -> None:
+        """Create a workspace directory (and parents), idempotently.
+
+        MLflow's create_experiment won't create the intermediate folder for a nested experiment
+        path, so callers make the parent dir first.
+        """
+        self._w.workspace.mkdirs(path)
+
     def _do(
         self, method: str, path: str, *, query: Optional[dict] = None, body: Optional[dict] = None
     ) -> Any:

--- a/integrations/mason/src/databricks_mason/deploy.py
+++ b/integrations/mason/src/databricks_mason/deploy.py
@@ -13,15 +13,15 @@ from __future__ import annotations
 
 import json
 import pathlib
-import subprocess
 from typing import Any, Optional
 
 import click
 import yaml
 
-from databricks_mason import render, timefmt
+from databricks_mason import memory_store_access, render, session_store_access, timefmt
 from databricks_mason.errors import AgentCliError
 from databricks_mason.render import field
+from databricks_mason.store_access import _databricks, apply_postgres_resources, grant_tables
 from databricks_mason.tracing import TRACES_DEST_ENV, TRACES_EXPERIMENT_ENV
 
 _MEMORY_ENV = "AGENT_MEMORY_STORE"
@@ -38,26 +38,19 @@ _PIP_INDEX_ENVS = ("PIP_INDEX_URL", "UV_INDEX_URL", "UV_DEFAULT_INDEX")
 # --- databricks CLI plumbing (the deployment runtime) -----------------------
 
 
-def _databricks(
-    args: list[str],
-    profile: Optional[str],
-    *,
-    capture: bool = False,
-    check: bool = True,
-    cwd: Optional[str] = None,
-) -> subprocess.CompletedProcess:
-    cmd = ["databricks", *args]
-    if profile:
-        cmd += ["--profile", profile]
-    result = subprocess.run(cmd, text=True, capture_output=capture, cwd=cwd)
-    if check and result.returncode != 0:
-        detail = (result.stderr or result.stdout or "").strip() if capture else None
-        raise AgentCliError(f"`{' '.join(cmd)}` failed (exit {result.returncode})", hint=detail)
-    return result
-
-
 def _deployment_exists(name: str, profile: Optional[str]) -> bool:
     return _databricks(["apps", "get", name], profile, capture=True, check=False).returncode == 0
+
+
+def _app_service_principal(name: str, profile: Optional[str]) -> Optional[str]:
+    """The app's service principal client id (its Postgres role identity), or None if unavailable."""
+    result = _databricks(["apps", "get", name, "-o", "json"], profile, capture=True, check=False)
+    if result.returncode != 0:
+        return None
+    try:
+        return json.loads(result.stdout).get("service_principal_client_id")
+    except json.JSONDecodeError:
+        return None
 
 
 # --- app.yaml manifest handling ---------------------------------------------
@@ -115,43 +108,43 @@ def _ensure_session_store(client, name: str) -> dict:
     return client.get_session_store(name)
 
 
-# Managed session stores are backed by a service-owned Lakebase project (shared, on its "production"
-# branch). The durable checkpointer connects to it as the app's service principal, so the SP needs a
-# Postgres grant — modeled as a `postgres` app resource. See agent/mason/session_store.py.
-_SESSION_STORE_LAKEBASE_PROJECT = "databricks-internal-lakebase-agent-session-store"
-_SESSION_STORE_LAKEBASE_BRANCH = "production"
-_SESSION_STORE_LAKEBASE_DB = "databricks-postgres"
+def _memory_store_database(client, memory_store: str) -> Optional[str]:
+    """Resolve the memory store's per-store Lakebase database name from its storage backend."""
+    store = client.get_memory_store(memory_store)
+    backend_id = field(field(store, "storage_backend") or {}, "backend_id")
+    return memory_store_access.database_from_backend_id(backend_id) if backend_id else None
 
 
-def _grant_session_store_lakebase(name: str, profile: Optional[str]) -> Optional[str]:
-    """Attach the `postgres` resource that grants the app's SP access to the session store's Lakebase.
+def _grant_store_access(
+    app: str,
+    sp: str,
+    owner: str,
+    session_store: Optional[str],
+    memory_database: Optional[str],
+    profile: Optional[str],
+) -> Optional[str]:
+    """Give the app's SP access to the deployed stores (best-effort, two steps).
 
-    Best-effort: returns None on success, or a human-readable reason if the grant couldn't be applied
-    (most commonly the caller lacks MANAGE on the service-owned Lakebase project). Deploy proceeds
-    regardless — the app runs, but durable sessions won't work until the grant exists.
+    Binds every store's database as a `postgres` app resource in one update (the update replaces the
+    whole resource array, so they must be applied together), then GRANTs the SP read/write on each
+    store's tables. Returns None on success or a human-readable reason on the first failure.
     """
-    branch = f"projects/{_SESSION_STORE_LAKEBASE_PROJECT}/branches/{_SESSION_STORE_LAKEBASE_BRANCH}"
-    resource = {
-        "resources": [
-            {
-                "name": "postgres",
-                "postgres": {
-                    "branch": branch,
-                    "database": f"{branch}/databases/{_SESSION_STORE_LAKEBASE_DB}",
-                    "permission": "CAN_CONNECT_AND_CREATE",
-                },
-            }
-        ]
-    }
-    result = _databricks(
-        ["apps", "update", name, "--json", json.dumps(resource)],
-        profile,
-        capture=True,
-        check=False,
-    )
-    if result.returncode == 0:
+    backends = []
+    if session_store:
+        backends.append(session_store_access.backend(session_store))
+    if memory_database:
+        backends.append(memory_store_access.backend(memory_database))
+    if not backends:
         return None
-    return (result.stderr or result.stdout or "").strip() or "unknown error"
+
+    error = apply_postgres_resources(app, backends, profile)
+    if error:
+        return error
+    for backend in backends:
+        error = grant_tables(backend, sp, owner, profile)
+        if error:
+            return error
+    return None
 
 
 # --- mason deploy -----------------------------------------------------------
@@ -234,7 +227,10 @@ def deploy(
             if create_stores
             else client.get_memory_store(memory_store)
         )
-        env_updates[_MEMORY_ENV] = field(store, "name") or memory_store
+        # The API's store name is `memory-stores/<id>`; the agent runtime wants the bare <id>
+        # (it re-adds the `memory-stores/` prefix when building the entries URL), so strip it.
+        store_name = field(store, "name") or memory_store
+        env_updates[_MEMORY_ENV] = store_name.split("/", 1)[-1]
         provisioned["Memory store"] = env_updates[_MEMORY_ENV]
     if session_store:
         if create_stores:
@@ -266,9 +262,20 @@ def deploy(
     _databricks(["sync", str(source_dir), ws_path, "--exclude", "uv.lock"], obj.profile)
     _databricks(["apps", "deploy", name, "--source-code-path", ws_path], obj.profile)
 
-    # 4. Grant the app's SP access to the session store's Lakebase (best-effort; needs MANAGE on the
-    #    service-owned project). Without it the app runs but durable sessions fail to authenticate.
-    grant_error = _grant_session_store_lakebase(name, obj.profile) if session_store else None
+    # 4. Give the app's SP access to its stores (best-effort, two steps): bind each store's database
+    #    as a `postgres` resource (CONNECT), then GRANT the SP read/write on its tables. Without
+    #    both, the app runs but the durable store path fails (can't connect, or can't read tables).
+    grants_stores = bool(session_store or memory_store)
+    grant_error: Optional[str] = None
+    if grants_stores:
+        sp = _app_service_principal(name, obj.profile)
+        if sp is None:
+            grant_error = "could not resolve the app's service principal."
+        else:
+            memory_database = _memory_store_database(client, memory_store) if memory_store else None
+            grant_error = _grant_store_access(
+                name, sp, client.current_user, session_store, memory_database, obj.profile
+            )
 
     if obj.output == "json":
         render.emit_json(
@@ -276,10 +283,10 @@ def deploy(
                 "deployment": name,
                 "workspace_path": ws_path,
                 "env": env_updates,
-                "session_store_lakebase_grant": "skipped"
-                if not session_store
+                "store_grant": "skipped"
+                if not grants_stores
                 else ("granted" if grant_error is None else "failed"),
-                "session_store_lakebase_grant_error": grant_error,
+                "store_grant_error": grant_error,
             }
         )
         return
@@ -289,15 +296,15 @@ def deploy(
         steps.insert(
             0, f"Set a real `command:` in {source_dir / 'app.yaml'} (a placeholder was written)"
         )
-    if session_store and grant_error is not None:
+    if grants_stores and grant_error is not None:
         steps.insert(
             0,
-            "Durable sessions need a Lakebase grant that couldn't be applied automatically "
-            "(need MANAGE on the managed session-store Lakebase — ask an admin or re-run as one). "
+            "The app's service principal needs read/write on its store tables; that grant couldn't "
+            "be applied automatically (it requires store ownership and psql). "
             f"Cause: {grant_error}",
         )
-    if session_store and grant_error is None:
-        provisioned["Session store Lakebase"] = "granted (postgres resource)"
+    if grants_stores and grant_error is None:
+        provisioned["Store access"] = "granted to app service principal"
     render.success(
         f"Deployed agent '{name}'",
         fields={"Workspace path": ws_path, **provisioned},

--- a/integrations/mason/src/databricks_mason/deploy.py
+++ b/integrations/mason/src/databricks_mason/deploy.py
@@ -23,7 +23,7 @@ from databricks_mason import memory_store_access, render, session_store_access, 
 from databricks_mason.errors import AgentCliError
 from databricks_mason.render import field
 from databricks_mason.store_access import _databricks, apply_postgres_resources, grant_tables
-from databricks_mason.tracing import _DEFAULT_EXPERIMENT, TRACES_DEST_ENV, TRACES_EXPERIMENT_ENV
+from databricks_mason.tracing import TRACES_DEST_ENV, TRACES_EXPERIMENT_ENV, default_experiment
 
 _MEMORY_ENV = "AGENT_MEMORY_STORE"
 _SESSION_ENV = "AGENT_SESSION_STORE"
@@ -147,6 +147,7 @@ def _memory_store_database(client, memory_store: str) -> Optional[str]:
 def resolve_store_env(
     client,
     *,
+    app: Optional[str],
     memory_store: Optional[str],
     session_store: Optional[str],
     traces_destination: Optional[str],
@@ -175,11 +176,10 @@ def resolve_store_env(
         env[_SESSION_ENV] = session_store
     if traces_destination:
         env[TRACES_DEST_ENV] = traces_destination
-        # The agent enables tracing only when BOTH a destination and an experiment are set. The
-        # destination's experiment is bound server-side by `mason tracing setup` (which defaults to
-        # _DEFAULT_EXPERIMENT), so default the experiment here too — otherwise --with-traces alone
-        # would ship a half-config that silently leaves tracing disabled.
-        env[TRACES_EXPERIMENT_ENV] = traces_experiment or _DEFAULT_EXPERIMENT
+        # The agent enables tracing only when BOTH a destination and an experiment are set, so
+        # default the experiment to this agent's per-app path (matching `mason tracing setup --app`),
+        # otherwise --with-traces alone would ship a half-config that silently disables tracing.
+        env[TRACES_EXPERIMENT_ENV] = traces_experiment or default_experiment(client.current_user, app)
     elif traces_experiment:
         env[TRACES_EXPERIMENT_ENV] = traces_experiment
     return env
@@ -291,6 +291,7 @@ def deploy(
     # 1. Provision / resolve stores and build the env to inject.
     env_updates = resolve_store_env(
         client,
+        app=name,
         memory_store=memory_store,
         session_store=session_store,
         traces_destination=traces_destination,

--- a/integrations/mason/src/databricks_mason/deploy.py
+++ b/integrations/mason/src/databricks_mason/deploy.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import json
 import pathlib
+import time
 from typing import Any, Optional
 
 import click
@@ -22,7 +23,7 @@ from databricks_mason import memory_store_access, render, session_store_access, 
 from databricks_mason.errors import AgentCliError
 from databricks_mason.render import field
 from databricks_mason.store_access import _databricks, apply_postgres_resources, grant_tables
-from databricks_mason.tracing import TRACES_DEST_ENV, TRACES_EXPERIMENT_ENV
+from databricks_mason.tracing import _DEFAULT_EXPERIMENT, TRACES_DEST_ENV, TRACES_EXPERIMENT_ENV
 
 _MEMORY_ENV = "AGENT_MEMORY_STORE"
 _SESSION_ENV = "AGENT_SESSION_STORE"
@@ -51,6 +52,34 @@ def _app_service_principal(name: str, profile: Optional[str]) -> Optional[str]:
         return json.loads(result.stdout).get("service_principal_client_id")
     except json.JSONDecodeError:
         return None
+
+
+def _app_compute_state(name: str, profile: Optional[str]) -> Optional[str]:
+    """The app's compute state (e.g. RUNNING), or None if it can't be read."""
+    result = _databricks(["apps", "get", name, "-o", "json"], profile, capture=True, check=False)
+    if result.returncode != 0:
+        return None
+    try:
+        return json.loads(result.stdout).get("compute_status", {}).get("state")
+    except json.JSONDecodeError:
+        return None
+
+
+def _wait_for_running(name: str, profile: Optional[str], timeout_s: int = 300) -> None:
+    """Block until a just-created app's compute is RUNNING (or raise on timeout).
+
+    `apps create` returns before compute is provisioned, but `apps deploy` requires RUNNING — so a
+    first deploy races without this wait.
+    """
+    deadline = time.monotonic() + timeout_s
+    while time.monotonic() < deadline:
+        if _app_compute_state(name, profile) == "ACTIVE":
+            return
+        time.sleep(5)
+    raise AgentCliError(
+        f"App '{name}' did not reach a running state within {timeout_s}s.",
+        hint=f"Check `mason deployments get {name}`, then re-run deploy once it's running.",
+    )
 
 
 # --- app.yaml manifest handling ---------------------------------------------
@@ -113,6 +142,47 @@ def _memory_store_database(client, memory_store: str) -> Optional[str]:
     store = client.get_memory_store(memory_store)
     backend_id = field(field(store, "storage_backend") or {}, "backend_id")
     return memory_store_access.database_from_backend_id(backend_id) if backend_id else None
+
+
+def resolve_store_env(
+    client,
+    *,
+    memory_store: Optional[str],
+    session_store: Optional[str],
+    traces_destination: Optional[str],
+    traces_experiment: Optional[str],
+    create_stores: bool,
+) -> dict[str, str]:
+    """Resolve store/trace references to the AGENT_*/MLFLOW_* env vars that wire them in.
+
+    Shared by `mason deploy` and `mason dev` so both wire an agent's stores into app.yaml the same
+    way. With `create_stores`, missing stores are created (idempotent); otherwise they must already
+    exist. The memory store resolves to its bare id (the runtime re-adds the `memory-stores/` prefix
+    when building the entries URL); the session store and trace destination are used verbatim.
+    """
+    env: dict[str, str] = {}
+    if memory_store:
+        store = (
+            _ensure_memory_store(client, memory_store)
+            if create_stores
+            else client.get_memory_store(memory_store)
+        )
+        store_name = field(store, "name") or memory_store
+        env[_MEMORY_ENV] = store_name.split("/", 1)[-1]
+    if session_store:
+        if create_stores:
+            _ensure_session_store(client, session_store)
+        env[_SESSION_ENV] = session_store
+    if traces_destination:
+        env[TRACES_DEST_ENV] = traces_destination
+        # The agent enables tracing only when BOTH a destination and an experiment are set. The
+        # destination's experiment is bound server-side by `mason tracing setup` (which defaults to
+        # _DEFAULT_EXPERIMENT), so default the experiment here too — otherwise --with-traces alone
+        # would ship a half-config that silently leaves tracing disabled.
+        env[TRACES_EXPERIMENT_ENV] = traces_experiment or _DEFAULT_EXPERIMENT
+    elif traces_experiment:
+        env[TRACES_EXPERIMENT_ENV] = traces_experiment
+    return env
 
 
 def _grant_store_access(
@@ -219,29 +289,21 @@ def deploy(
     client = obj.client()
 
     # 1. Provision / resolve stores and build the env to inject.
-    env_updates: dict[str, str] = {}
+    env_updates = resolve_store_env(
+        client,
+        memory_store=memory_store,
+        session_store=session_store,
+        traces_destination=traces_destination,
+        traces_experiment=traces_experiment,
+        create_stores=create_stores,
+    )
     provisioned: dict[str, Any] = {}
-    if memory_store:
-        store = (
-            _ensure_memory_store(client, memory_store)
-            if create_stores
-            else client.get_memory_store(memory_store)
-        )
-        # The API's store name is `memory-stores/<id>`; the agent runtime wants the bare <id>
-        # (it re-adds the `memory-stores/` prefix when building the entries URL), so strip it.
-        store_name = field(store, "name") or memory_store
-        env_updates[_MEMORY_ENV] = store_name.split("/", 1)[-1]
+    if _MEMORY_ENV in env_updates:
         provisioned["Memory store"] = env_updates[_MEMORY_ENV]
-    if session_store:
-        if create_stores:
-            _ensure_session_store(client, session_store)
-        env_updates[_SESSION_ENV] = session_store
-        provisioned["Session store"] = session_store
+    if _SESSION_ENV in env_updates:
+        provisioned["Session store"] = env_updates[_SESSION_ENV]
     if traces_destination:
-        env_updates[TRACES_DEST_ENV] = traces_destination
         provisioned["Traces"] = traces_destination
-    if traces_experiment:
-        env_updates[TRACES_EXPERIMENT_ENV] = traces_experiment
     if pip_index_url:
         for env in _PIP_INDEX_ENVS:
             env_updates[env] = pip_index_url
@@ -255,6 +317,9 @@ def deploy(
     # 3. Roll out the deployment (Databricks Apps runtime).
     if not _deployment_exists(name, obj.profile):
         _databricks(["apps", "create", name], obj.profile)
+        # `apps create` returns before the app's compute is up, but `apps deploy` requires it to be
+        # RUNNING — so wait for it, or the first deploy races and fails ("not in RUNNING state").
+        _wait_for_running(name, obj.profile)
     ws_path = workspace_path or f"/Workspace/Users/{client.current_user}/mason_deployments/{name}"
     # Don't ship uv.lock: it pins exact package URLs from whatever index the developer's machine
     # resolved against (often an internal proxy). The Apps build must resolve against its own

--- a/integrations/mason/src/databricks_mason/deploy.py
+++ b/integrations/mason/src/databricks_mason/deploy.py
@@ -154,9 +154,10 @@ def _grant_session_store_lakebase(name: str, profile: Optional[str]) -> Optional
 @click.argument("name")
 @click.option(
     "--source",
-    required=True,
+    default=".",
     type=click.Path(exists=True, file_okay=False),
-    help="Local source directory for the deployment (containing app.yaml).",
+    help="Local source directory for the deployment (containing app.yaml). Defaults to the "
+    "current directory.",
 )
 @click.option(
     "--with-memory-store",

--- a/integrations/mason/src/databricks_mason/deploy.py
+++ b/integrations/mason/src/databricks_mason/deploy.py
@@ -32,12 +32,17 @@ _SESSION_ENV = "AGENT_SESSION_STORE"
 
 
 def _databricks(
-    args: list[str], profile: Optional[str], *, capture: bool = False, check: bool = True
+    args: list[str],
+    profile: Optional[str],
+    *,
+    capture: bool = False,
+    check: bool = True,
+    cwd: Optional[str] = None,
 ) -> subprocess.CompletedProcess:
     cmd = ["databricks", *args]
     if profile:
         cmd += ["--profile", profile]
-    result = subprocess.run(cmd, text=True, capture_output=capture)
+    result = subprocess.run(cmd, text=True, capture_output=capture, cwd=cwd)
     if check and result.returncode != 0:
         detail = (result.stderr or result.stdout or "").strip() if capture else None
         raise AgentCliError(f"`{' '.join(cmd)}` failed (exit {result.returncode})", hint=detail)
@@ -195,7 +200,10 @@ def deploy(
     if not _deployment_exists(name, obj.profile):
         _databricks(["apps", "create", name], obj.profile)
     ws_path = workspace_path or f"/Workspace/Users/{client.current_user}/mason_deployments/{name}"
-    _databricks(["sync", str(source_dir), ws_path], obj.profile)
+    # Don't ship uv.lock: it pins exact package URLs from whatever index the developer's machine
+    # resolved against (often an internal proxy). The Apps build must resolve against its own
+    # configured index, so let it lock fresh in-sandbox instead of inheriting the local lock.
+    _databricks(["sync", str(source_dir), ws_path, "--exclude", "uv.lock"], obj.profile)
     _databricks(["apps", "deploy", name, "--source-code-path", ws_path], obj.profile)
 
     if obj.output == "json":

--- a/integrations/mason/src/databricks_mason/deploy.py
+++ b/integrations/mason/src/databricks_mason/deploy.py
@@ -27,6 +27,13 @@ from databricks_mason.tracing import TRACES_DEST_ENV, TRACES_EXPERIMENT_ENV
 _MEMORY_ENV = "AGENT_MEMORY_STORE"
 _SESSION_ENV = "AGENT_SESSION_STORE"
 
+# TEMPORARY: the Apps build environment currently can't reach the internal pypi proxy, so builds
+# time out installing dependencies. Point the build at public PyPI (sanctioned interim workaround)
+# until the proxy is reachable from the build sandbox again, then drop this default. pip reads
+# PIP_INDEX_URL; uv reads UV_INDEX_URL / UV_DEFAULT_INDEX — set all three to cover both build paths.
+_DEFAULT_PIP_INDEX_URL = "https://pypi.org/simple/"
+_PIP_INDEX_ENVS = ("PIP_INDEX_URL", "UV_INDEX_URL", "UV_DEFAULT_INDEX")
+
 
 # --- databricks CLI plumbing (the deployment runtime) -----------------------
 
@@ -189,6 +196,14 @@ def _grant_session_store_lakebase(name: str, profile: Optional[str]) -> Optional
     help="Create the referenced stores if they don't exist (idempotent).",
 )
 @click.option(
+    "--pip-index-url",
+    default=_DEFAULT_PIP_INDEX_URL,
+    show_default=True,
+    help="Package index the Apps build installs from. Defaults to public PyPI as a temporary "
+    "workaround: the Apps build environment currently can't reach the internal proxy. Pass an "
+    "empty string to use the build's default index.",
+)
+@click.option(
     "--workspace-path",
     default=None,
     help="Workspace destination for the synced source (defaults to a per-user path).",
@@ -203,6 +218,7 @@ def deploy(
     traces_destination,
     traces_experiment,
     create_stores,
+    pip_index_url,
     workspace_path,
 ) -> None:
     """Deploy an agent: provision its stores, wire them in, and roll out the deployment."""
@@ -230,6 +246,10 @@ def deploy(
         provisioned["Traces"] = traces_destination
     if traces_experiment:
         env_updates[TRACES_EXPERIMENT_ENV] = traces_experiment
+    if pip_index_url:
+        for env in _PIP_INDEX_ENVS:
+            env_updates[env] = pip_index_url
+        provisioned["Package index"] = pip_index_url
 
     # 2. Patch the app.yaml manifest with the store identifiers.
     scaffolded = False

--- a/integrations/mason/src/databricks_mason/deploy.py
+++ b/integrations/mason/src/databricks_mason/deploy.py
@@ -108,6 +108,45 @@ def _ensure_session_store(client, name: str) -> dict:
     return client.get_session_store(name)
 
 
+# Managed session stores are backed by a service-owned Lakebase project (shared, on its "production"
+# branch). The durable checkpointer connects to it as the app's service principal, so the SP needs a
+# Postgres grant — modeled as a `postgres` app resource. See agent/mason/session_store.py.
+_SESSION_STORE_LAKEBASE_PROJECT = "databricks-internal-lakebase-agent-session-store"
+_SESSION_STORE_LAKEBASE_BRANCH = "production"
+_SESSION_STORE_LAKEBASE_DB = "databricks-postgres"
+
+
+def _grant_session_store_lakebase(name: str, profile: Optional[str]) -> Optional[str]:
+    """Attach the `postgres` resource that grants the app's SP access to the session store's Lakebase.
+
+    Best-effort: returns None on success, or a human-readable reason if the grant couldn't be applied
+    (most commonly the caller lacks MANAGE on the service-owned Lakebase project). Deploy proceeds
+    regardless — the app runs, but durable sessions won't work until the grant exists.
+    """
+    branch = f"projects/{_SESSION_STORE_LAKEBASE_PROJECT}/branches/{_SESSION_STORE_LAKEBASE_BRANCH}"
+    resource = {
+        "resources": [
+            {
+                "name": "postgres",
+                "postgres": {
+                    "branch": branch,
+                    "database": f"{branch}/databases/{_SESSION_STORE_LAKEBASE_DB}",
+                    "permission": "CAN_CONNECT_AND_CREATE",
+                },
+            }
+        ]
+    }
+    result = _databricks(
+        ["apps", "update", name, "--json", json.dumps(resource)],
+        profile,
+        capture=True,
+        check=False,
+    )
+    if result.returncode == 0:
+        return None
+    return (result.stderr or result.stdout or "").strip() or "unknown error"
+
+
 # --- mason deploy -----------------------------------------------------------
 
 
@@ -206,8 +245,22 @@ def deploy(
     _databricks(["sync", str(source_dir), ws_path, "--exclude", "uv.lock"], obj.profile)
     _databricks(["apps", "deploy", name, "--source-code-path", ws_path], obj.profile)
 
+    # 4. Grant the app's SP access to the session store's Lakebase (best-effort; needs MANAGE on the
+    #    service-owned project). Without it the app runs but durable sessions fail to authenticate.
+    grant_error = _grant_session_store_lakebase(name, obj.profile) if session_store else None
+
     if obj.output == "json":
-        render.emit_json({"deployment": name, "workspace_path": ws_path, "env": env_updates})
+        render.emit_json(
+            {
+                "deployment": name,
+                "workspace_path": ws_path,
+                "env": env_updates,
+                "session_store_lakebase_grant": "skipped"
+                if not session_store
+                else ("granted" if grant_error is None else "failed"),
+                "session_store_lakebase_grant_error": grant_error,
+            }
+        )
         return
 
     steps = [f"mason deployments logs {name}", f"mason deployments get {name}"]
@@ -215,6 +268,15 @@ def deploy(
         steps.insert(
             0, f"Set a real `command:` in {source_dir / 'app.yaml'} (a placeholder was written)"
         )
+    if session_store and grant_error is not None:
+        steps.insert(
+            0,
+            "Durable sessions need a Lakebase grant that couldn't be applied automatically "
+            "(need MANAGE on the managed session-store Lakebase — ask an admin or re-run as one). "
+            f"Cause: {grant_error}",
+        )
+    if session_store and grant_error is None:
+        provisioned["Session store Lakebase"] = "granted (postgres resource)"
     render.success(
         f"Deployed agent '{name}'",
         fields={"Workspace path": ws_path, **provisioned},

--- a/integrations/mason/src/databricks_mason/deploy.py
+++ b/integrations/mason/src/databricks_mason/deploy.py
@@ -179,7 +179,9 @@ def resolve_store_env(
         # The agent enables tracing only when BOTH a destination and an experiment are set, so
         # default the experiment to this agent's per-app path (matching `mason tracing setup --app`),
         # otherwise --with-traces alone would ship a half-config that silently disables tracing.
-        env[TRACES_EXPERIMENT_ENV] = traces_experiment or default_experiment(client.current_user, app)
+        env[TRACES_EXPERIMENT_ENV] = traces_experiment or default_experiment(
+            client.current_user, app
+        )
     elif traces_experiment:
         env[TRACES_EXPERIMENT_ENV] = traces_experiment
     return env

--- a/integrations/mason/src/databricks_mason/dev.py
+++ b/integrations/mason/src/databricks_mason/dev.py
@@ -1,0 +1,55 @@
+"""`mason dev` — run a scaffolded agent locally, wrapping `databricks apps run-local`.
+
+Runs the app from its ``app.yaml`` exactly as the Databricks Apps runtime would locally: reads the
+manifest's command + env, and (with ``--prepare-environment``) builds the venv via uv. This is the
+local counterpart to ``mason deploy`` — same source dir, same manifest — so what runs here matches
+what ships. Delegating to ``apps run-local`` means mason inherits the Apps team's local-run behavior
+rather than re-implementing it.
+"""
+
+from __future__ import annotations
+
+import pathlib
+from typing import Optional
+
+import click
+
+from databricks_mason.deploy import _databricks
+from databricks_mason.errors import AgentCliError
+
+
+@click.command()
+@click.option(
+    "--source",
+    default=".",
+    type=click.Path(exists=True, file_okay=False),
+    help="Local source directory to run (containing app.yaml). Defaults to the current directory.",
+)
+@click.option(
+    "--prepare-environment/--no-prepare-environment",
+    default=True,
+    help="Build the app's environment with uv before running (default: on). Requires uv.",
+)
+@click.option("--app-port", type=int, default=None, help="Port to run the app on (default 8000).")
+@click.pass_obj
+def dev(obj, source: str, prepare_environment: bool, app_port: Optional[int]) -> None:
+    """Run a scaffolded agent locally from its app.yaml (wraps `databricks apps run-local`).
+
+    Reads the app's command + env from ``app.yaml`` and runs it the way the Apps runtime does — so
+    local behavior matches a deployment. Auth uses the profile (``-p`` / ``mason login``), same as
+    ``mason deploy``.
+    """
+    source_dir = pathlib.Path(source)
+    if not (source_dir / "app.yaml").exists():
+        raise AgentCliError(
+            f"No app.yaml in '{source_dir}'.",
+            hint="Run from a scaffolded project, or pass --source <dir> (see `mason init`).",
+        )
+
+    args = ["apps", "run-local"]
+    if prepare_environment:
+        args.append("--prepare-environment")
+    if app_port is not None:
+        args += ["--app-port", str(app_port)]
+    # Run in the project dir so run-local finds app.yaml; stream output (no capture).
+    _databricks(args, obj.profile, cwd=str(source_dir))

--- a/integrations/mason/src/databricks_mason/dev.py
+++ b/integrations/mason/src/databricks_mason/dev.py
@@ -15,6 +15,7 @@ from typing import Optional
 import click
 import yaml
 
+from databricks_mason.deploy import _upsert_manifest_env, resolve_store_env
 from databricks_mason.errors import AgentCliError
 from databricks_mason.store_access import _databricks
 
@@ -39,14 +40,57 @@ _BUILD_INDEX_ENVS = frozenset({"PIP_INDEX_URL", "UV_INDEX_URL", "UV_DEFAULT_INDE
     "exists yet, and reuse it otherwise. Requires uv.",
 )
 @click.option("--app-port", type=int, default=None, help="Port to run the app on (default 8000).")
+@click.option(
+    "--with-memory-store",
+    "memory_store",
+    default=None,
+    help="Memory store display name to wire in via AGENT_MEMORY_STORE (same as `mason deploy`).",
+)
+@click.option(
+    "--with-session-store",
+    "session_store",
+    default=None,
+    help="Session store name to wire in via AGENT_SESSION_STORE (same as `mason deploy`).",
+)
+@click.option(
+    "--with-traces",
+    "traces_destination",
+    default=None,
+    help="UC trace destination 'catalog.schema' to wire in via MLFLOW_TRACING_DESTINATION.",
+)
+@click.option(
+    "--traces-experiment",
+    default=None,
+    help="MLflow experiment path to wire in via MLFLOW_EXPERIMENT_NAME.",
+)
+@click.option(
+    "--create-stores",
+    is_flag=True,
+    help="Create the referenced stores if they don't exist (idempotent).",
+)
 @click.pass_obj
-def dev(obj, source: str, prepare_environment: Optional[bool], app_port: Optional[int]) -> None:
+def dev(
+    obj,
+    source: str,
+    prepare_environment: Optional[bool],
+    app_port: Optional[int],
+    memory_store: Optional[str],
+    session_store: Optional[str],
+    traces_destination: Optional[str],
+    traces_experiment: Optional[str],
+    create_stores: bool,
+) -> None:
     """Run a scaffolded agent locally from its app.yaml (wraps `databricks apps run-local`).
 
     Reads the app's command + env from ``app.yaml`` and runs it the way the Apps runtime does — so
     local behavior matches a deployment. Auth uses the profile (``-p`` / ``mason login``), same as
     ``mason deploy``. The environment is built on first run and reused after; pass
     ``--prepare-environment`` to force a rebuild (e.g. after changing dependencies).
+
+    The ``--with-*`` flags wire an agent's stores/traces into ``app.yaml`` before running, exactly as
+    ``mason deploy`` does — so you can iterate locally against a real store without hand-editing env.
+    Locally the store owner (you) already has access, so no service-principal grant is needed here;
+    that grant happens at ``mason deploy`` time.
     """
     source_dir = pathlib.Path(source)
     app_yaml = source_dir / "app.yaml"
@@ -55,6 +99,19 @@ def dev(obj, source: str, prepare_environment: Optional[bool], app_port: Optiona
             f"No app.yaml in '{source_dir}'.",
             hint="Run from a scaffolded project, or pass --source <dir> (see `mason init`).",
         )
+
+    # Wire any requested stores/traces into app.yaml first, so run-local reads the updated env.
+    if memory_store or session_store or traces_destination or traces_experiment:
+        env_updates = resolve_store_env(
+            obj.client(),
+            memory_store=memory_store,
+            session_store=session_store,
+            traces_destination=traces_destination,
+            traces_experiment=traces_experiment,
+            create_stores=create_stores,
+        )
+        if env_updates:
+            _upsert_manifest_env(source_dir, env_updates)
 
     # Default: prepare only when there's no venv yet, so repeat runs don't rebuild. Explicit
     # --prepare-environment / --no-prepare-environment overrides the auto-detect.

--- a/integrations/mason/src/databricks_mason/dev.py
+++ b/integrations/mason/src/databricks_mason/dev.py
@@ -102,8 +102,11 @@ def dev(
 
     # Wire any requested stores/traces into app.yaml first, so run-local reads the updated env.
     if memory_store or session_store or traces_destination or traces_experiment:
+        # The agent name defaults to the project dir name, so a per-app trace experiment here matches
+        # what `mason deploy <that-name>` derives.
         env_updates = resolve_store_env(
             obj.client(),
+            app=source_dir.resolve().name,
             memory_store=memory_store,
             session_store=session_store,
             traces_destination=traces_destination,

--- a/integrations/mason/src/databricks_mason/dev.py
+++ b/integrations/mason/src/databricks_mason/dev.py
@@ -27,17 +27,19 @@ from databricks_mason.errors import AgentCliError
 )
 @click.option(
     "--prepare-environment/--no-prepare-environment",
-    default=True,
-    help="Build the app's environment with uv before running (default: on). Requires uv.",
+    default=None,
+    help="Build the app's environment with uv before running. Default: build only if no .venv "
+    "exists yet, and reuse it otherwise. Requires uv.",
 )
 @click.option("--app-port", type=int, default=None, help="Port to run the app on (default 8000).")
 @click.pass_obj
-def dev(obj, source: str, prepare_environment: bool, app_port: Optional[int]) -> None:
+def dev(obj, source: str, prepare_environment: Optional[bool], app_port: Optional[int]) -> None:
     """Run a scaffolded agent locally from its app.yaml (wraps `databricks apps run-local`).
 
     Reads the app's command + env from ``app.yaml`` and runs it the way the Apps runtime does — so
     local behavior matches a deployment. Auth uses the profile (``-p`` / ``mason login``), same as
-    ``mason deploy``.
+    ``mason deploy``. The environment is built on first run and reused after; pass
+    ``--prepare-environment`` to force a rebuild (e.g. after changing dependencies).
     """
     source_dir = pathlib.Path(source)
     if not (source_dir / "app.yaml").exists():
@@ -45,6 +47,11 @@ def dev(obj, source: str, prepare_environment: bool, app_port: Optional[int]) ->
             f"No app.yaml in '{source_dir}'.",
             hint="Run from a scaffolded project, or pass --source <dir> (see `mason init`).",
         )
+
+    # Default: prepare only when there's no venv yet, so repeat runs don't rebuild. Explicit
+    # --prepare-environment / --no-prepare-environment overrides the auto-detect.
+    if prepare_environment is None:
+        prepare_environment = not (source_dir / ".venv").exists()
 
     args = ["apps", "run-local"]
     if prepare_environment:

--- a/integrations/mason/src/databricks_mason/dev.py
+++ b/integrations/mason/src/databricks_mason/dev.py
@@ -13,9 +13,16 @@ import pathlib
 from typing import Optional
 
 import click
+import yaml
 
-from databricks_mason.deploy import _databricks
 from databricks_mason.errors import AgentCliError
+from databricks_mason.store_access import _databricks
+
+# Env vars that pin a package index for the *deployed* Apps build (a cloud-only workaround, see
+# `mason deploy`). They point at an index the deploying environment can reach, which is not
+# necessarily reachable from the local dev machine — so `mason dev`'s local `uv` build must ignore
+# them and use the machine's own configured index instead.
+_BUILD_INDEX_ENVS = frozenset({"PIP_INDEX_URL", "UV_INDEX_URL", "UV_DEFAULT_INDEX"})
 
 
 @click.command()
@@ -42,7 +49,8 @@ def dev(obj, source: str, prepare_environment: Optional[bool], app_port: Optiona
     ``--prepare-environment`` to force a rebuild (e.g. after changing dependencies).
     """
     source_dir = pathlib.Path(source)
-    if not (source_dir / "app.yaml").exists():
+    app_yaml = source_dir / "app.yaml"
+    if not app_yaml.exists():
         raise AgentCliError(
             f"No app.yaml in '{source_dir}'.",
             hint="Run from a scaffolded project, or pass --source <dir> (see `mason init`).",
@@ -58,5 +66,35 @@ def dev(obj, source: str, prepare_environment: Optional[bool], app_port: Optiona
         args.append("--prepare-environment")
     if app_port is not None:
         args += ["--app-port", str(app_port)]
-    # Run in the project dir so run-local finds app.yaml; stream output (no capture).
+
+    # If the manifest carries a deploy-only package-index override, run against a filtered copy so
+    # the local build uses this machine's index instead of one it may not be able to reach.
+    entry_point = _dev_entry_point(app_yaml)
+    if entry_point is not None:
+        args += ["--entry-point", str(entry_point)]
+
+    # Run in the project dir so run-local finds the app; stream output (no capture).
     _databricks(args, obj.profile, cwd=str(source_dir))
+
+
+def _dev_entry_point(app_yaml: pathlib.Path) -> Optional[pathlib.Path]:
+    """Return a filtered manifest path when app.yaml pins a build index, else None.
+
+    Strips the deploy-only package-index env vars and writes the result next to app.yaml as
+    ``.mason-dev.app.yaml`` (so relative paths still resolve). Returns None when there's nothing to
+    strip, so the normal ``app.yaml`` is used unchanged.
+    """
+    try:
+        doc = yaml.safe_load(app_yaml.read_text()) or {}
+    except yaml.YAMLError:
+        return None
+    env = doc.get("env")
+    if not isinstance(env, list):
+        return None
+    filtered = [e for e in env if not (isinstance(e, dict) and e.get("name") in _BUILD_INDEX_ENVS)]
+    if len(filtered) == len(env):
+        return None  # no index override present — run-local can use app.yaml directly
+    doc["env"] = filtered
+    dev_yaml = app_yaml.parent / ".mason-dev.app.yaml"
+    dev_yaml.write_text(yaml.safe_dump(doc, sort_keys=False))
+    return dev_yaml

--- a/integrations/mason/src/databricks_mason/init.py
+++ b/integrations/mason/src/databricks_mason/init.py
@@ -1,11 +1,12 @@
-"""`mason init` — scaffold a local agent project from an app-templates template.
+"""`mason init` — scaffold a local agent project from a mason template.
 
-Fetches one template directory out of the `databricks/app-templates` repo (a sparse,
-blobless clone so only the chosen template is materialized) and drops it into a local
-target directory. That directory is then ready for `mason deploy --source <dir>`.
+Fetches one template directory out of its git repo (a sparse, blobless clone so only the
+chosen template is materialized) and drops it into a local target directory, ready for
+`mason deploy --source <dir>`.
 
-`--framework` selects which basic template to lay down; the repo and ref are overridable
-so the command can target a fork/branch before a template has merged to the canonical repo.
+`--framework` selects which template to lay down; each framework knows its own repo, ref, and
+path (see `_TEMPLATES`). `--repo` / `--ref` override those, e.g. to pull from a fork or branch
+before a template has merged to its canonical repo.
 """
 
 from __future__ import annotations
@@ -21,14 +22,20 @@ import click
 from databricks_mason import render
 from databricks_mason.errors import AgentCliError
 
-_DEFAULT_REPO = "https://github.com/databricks/app-templates.git"
-_DEFAULT_REF = "main"
-
-# Framework -> template directory in the app-templates repo. Add an entry here when a new
-# basic template lands.
+# Each framework's template has its own home: the git repo, ref, and path-within-repo to fetch.
+# (The two basic templates currently live in different repos; this keeps each pointed at its own.)
+# `--repo` / `--ref` override the repo/ref here, e.g. to pull from a fork or branch before merge.
 _TEMPLATES = {
-    "openai": "agent-openai-basic",
-    "langgraph": "agent-langgraph-basic",
+    "openai": {
+        "repo": "https://github.com/databricks/app-templates.git",
+        "ref": "main",
+        "path": "agent-openai-basic",
+    },
+    "langgraph": {
+        "repo": "https://github.com/databricks/databricks-ai-bridge.git",
+        "ref": "main",
+        "path": "integrations/mason/templates/agent-langgraph-scratch",
+    },
 }
 
 
@@ -98,13 +105,18 @@ def _write_env(dest: pathlib.Path, profile: str) -> bool:
     help="Seed a local .env with this DATABRICKS_CONFIG_PROFILE so `uv run start-server` works "
     "immediately (defaults to the profile from -p / `mason login`).",
 )
-@click.option("--repo", default=_DEFAULT_REPO, show_default=True, help="app-templates git repo URL.")
-@click.option("--ref", default=_DEFAULT_REF, show_default=True, help="Branch, tag, or ref to fetch.")
+@click.option("--repo", default=None, help="Override the git repo URL to fetch the template from.")
+@click.option("--ref", default=None, help="Override the branch, tag, or ref to fetch.")
 @click.pass_obj
 def init(
-    obj, directory: Optional[str], framework: str, profile: Optional[str], repo: str, ref: str
+    obj,
+    directory: Optional[str],
+    framework: str,
+    profile: Optional[str],
+    repo: Optional[str],
+    ref: Optional[str],
 ) -> None:
-    """Scaffold a local agent project from an app-templates template.
+    """Scaffold a local agent project from a mason template.
 
     DIRECTORY is the target path to create (defaults to the template's own name). The
     directory must not already exist. Once scaffolded, deploy it with
@@ -113,8 +125,9 @@ def init(
     Pass --profile (or set a default via `mason login` / -p) to seed a local `.env` so the
     scaffolded project runs with `uv run start-server` right away.
     """
-    template_dir = _TEMPLATES[framework]
-    dest = pathlib.Path(directory) if directory else pathlib.Path(template_dir)
+    spec = _TEMPLATES[framework]
+    template_path = spec["path"]
+    dest = pathlib.Path(directory) if directory else pathlib.Path(pathlib.PurePosixPath(template_path).name)
 
     if dest.exists():
         raise AgentCliError(
@@ -122,8 +135,9 @@ def init(
             hint="Choose a new directory or remove the existing one.",
         )
 
-    _fetch_template(repo, ref, template_dir, dest)
+    _fetch_template(repo or spec["repo"], ref or spec["ref"], template_path, dest)
 
+    template_name = pathlib.PurePosixPath(template_path).name
     env_profile = profile or obj.profile
     wrote_env = _write_env(dest, env_profile) if env_profile else False
 
@@ -131,7 +145,7 @@ def init(
         render.emit_json(
             {
                 "framework": framework,
-                "template": template_dir,
+                "template": template_name,
                 "directory": str(dest),
                 "env_profile": env_profile if wrote_env else None,
             }
@@ -150,4 +164,4 @@ def init(
             "Set DATABRICKS_CONFIG_PROFILE in .env (or re-run `mason init --profile <profile>`)",
         ]
     steps += ["uv run start-server        # run locally", f"mason deploy <name> --source {dest}"]
-    render.success(f"Scaffolded '{template_dir}'", fields=fields, next_steps=steps)
+    render.success(f"Scaffolded '{template_name}'", fields=fields, next_steps=steps)

--- a/integrations/mason/src/databricks_mason/init.py
+++ b/integrations/mason/src/databricks_mason/init.py
@@ -52,7 +52,7 @@ def _git(args: list[str], *, cwd: Optional[pathlib.Path] = None) -> subprocess.C
 def _fetch_template(repo: str, ref: str, template_dir: str, dest: pathlib.Path) -> None:
     """Sparse-clone `template_dir` from `repo`@`ref` into `dest` (must not already exist)."""
     with tempfile.TemporaryDirectory(prefix="mason-init-") as tmp:
-        clone = pathlib.Path(tmp) / "app-templates"
+        clone = pathlib.Path(tmp) / "repo"
         _git(["clone", "--depth", "1", "--filter=blob:none", "--sparse", "--branch", ref, repo, str(clone)])
         _git(["sparse-checkout", "set", template_dir], cwd=clone)
         src = clone / template_dir
@@ -158,10 +158,10 @@ def init(
         fields["Profile (.env)"] = env_profile
     else:
         # No profile resolved, so no .env was seeded — call out the auth step explicitly rather
-        # than burying it, since `uv run start-server` fails without a Databricks profile.
+        # than burying it, since running locally fails without a Databricks profile.
         steps += [
             "cp .env.example .env",
             "Set DATABRICKS_CONFIG_PROFILE in .env (or re-run `mason init --profile <profile>`)",
         ]
-    steps += ["uv run start-server        # run locally", f"mason deploy <name> --source {dest}"]
+    steps += ["mason dev        # run locally", f"mason deploy <name> --source {dest}"]
     render.success(f"Scaffolded '{template_name}'", fields=fields, next_steps=steps)

--- a/integrations/mason/src/databricks_mason/init.py
+++ b/integrations/mason/src/databricks_mason/init.py
@@ -138,16 +138,16 @@ def init(
         )
         return
 
-    run_step = (
-        "uv run start-server        # run locally"
-        if wrote_env
-        else "cp .env.example .env       # then set DATABRICKS_CONFIG_PROFILE, and: uv run start-server"
-    )
     fields = {"Framework": framework, "Directory": str(dest)}
+    steps = [f"cd {dest}"]
     if wrote_env:
         fields["Profile (.env)"] = env_profile
-    render.success(
-        f"Scaffolded '{template_dir}'",
-        fields=fields,
-        next_steps=[f"cd {dest}", run_step, f"mason deploy <name> --source {dest}"],
-    )
+    else:
+        # No profile resolved, so no .env was seeded — call out the auth step explicitly rather
+        # than burying it, since `uv run start-server` fails without a Databricks profile.
+        steps += [
+            "cp .env.example .env",
+            "Set DATABRICKS_CONFIG_PROFILE in .env (or re-run `mason init --profile <profile>`)",
+        ]
+    steps += ["uv run start-server        # run locally", f"mason deploy <name> --source {dest}"]
+    render.success(f"Scaffolded '{template_dir}'", fields=fields, next_steps=steps)

--- a/integrations/mason/src/databricks_mason/init.py
+++ b/integrations/mason/src/databricks_mason/init.py
@@ -95,7 +95,7 @@ def _write_env(dest: pathlib.Path, profile: str) -> bool:
 @click.option(
     "--framework",
     type=click.Choice(sorted(_TEMPLATES)),
-    default="openai",
+    default="langgraph",
     show_default=True,
     help="Which basic agent template to scaffold.",
 )

--- a/integrations/mason/src/databricks_mason/init.py
+++ b/integrations/mason/src/databricks_mason/init.py
@@ -40,12 +40,12 @@ _TEMPLATES = {
 
 
 def _git(args: list[str], *, cwd: Optional[pathlib.Path] = None) -> subprocess.CompletedProcess:
-    result = subprocess.run(
-        ["git", *args], cwd=cwd, text=True, capture_output=True, check=False
-    )
+    result = subprocess.run(["git", *args], cwd=cwd, text=True, capture_output=True, check=False)
     if result.returncode != 0:
         detail = (result.stderr or result.stdout or "").strip()
-        raise AgentCliError(f"`git {' '.join(args)}` failed (exit {result.returncode})", hint=detail)
+        raise AgentCliError(
+            f"`git {' '.join(args)}` failed (exit {result.returncode})", hint=detail
+        )
     return result
 
 
@@ -53,7 +53,19 @@ def _fetch_template(repo: str, ref: str, template_dir: str, dest: pathlib.Path) 
     """Sparse-clone `template_dir` from `repo`@`ref` into `dest` (must not already exist)."""
     with tempfile.TemporaryDirectory(prefix="mason-init-") as tmp:
         clone = pathlib.Path(tmp) / "repo"
-        _git(["clone", "--depth", "1", "--filter=blob:none", "--sparse", "--branch", ref, repo, str(clone)])
+        _git(
+            [
+                "clone",
+                "--depth",
+                "1",
+                "--filter=blob:none",
+                "--sparse",
+                "--branch",
+                ref,
+                repo,
+                str(clone),
+            ]
+        )
         _git(["sparse-checkout", "set", template_dir], cwd=clone)
         src = clone / template_dir
         if not src.is_dir():
@@ -127,7 +139,11 @@ def init(
     """
     spec = _TEMPLATES[framework]
     template_path = spec["path"]
-    dest = pathlib.Path(directory) if directory else pathlib.Path(pathlib.PurePosixPath(template_path).name)
+    dest = (
+        pathlib.Path(directory)
+        if directory
+        else pathlib.Path(pathlib.PurePosixPath(template_path).name)
+    )
 
     if dest.exists():
         raise AgentCliError(

--- a/integrations/mason/src/databricks_mason/init.py
+++ b/integrations/mason/src/databricks_mason/init.py
@@ -1,0 +1,105 @@
+"""`mason init` — scaffold a local agent project from an app-templates template.
+
+Fetches one template directory out of the `databricks/app-templates` repo (a sparse,
+blobless clone so only the chosen template is materialized) and drops it into a local
+target directory. That directory is then ready for `mason deploy --source <dir>`.
+
+`--framework` selects which basic template to lay down; the repo and ref are overridable
+so the command can target a fork/branch before a template has merged to the canonical repo.
+"""
+
+from __future__ import annotations
+
+import pathlib
+import shutil
+import subprocess
+import tempfile
+from typing import Optional
+
+import click
+
+from databricks_mason import render
+from databricks_mason.errors import AgentCliError
+
+_DEFAULT_REPO = "https://github.com/databricks/app-templates.git"
+_DEFAULT_REF = "main"
+
+# Framework -> template directory in the app-templates repo. Add an entry here when a new
+# basic template lands.
+_TEMPLATES = {
+    "openai": "agent-openai-basic",
+    "langgraph": "agent-langgraph-basic",
+}
+
+
+def _git(args: list[str], *, cwd: Optional[pathlib.Path] = None) -> subprocess.CompletedProcess:
+    result = subprocess.run(
+        ["git", *args], cwd=cwd, text=True, capture_output=True, check=False
+    )
+    if result.returncode != 0:
+        detail = (result.stderr or result.stdout or "").strip()
+        raise AgentCliError(f"`git {' '.join(args)}` failed (exit {result.returncode})", hint=detail)
+    return result
+
+
+def _fetch_template(repo: str, ref: str, template_dir: str, dest: pathlib.Path) -> None:
+    """Sparse-clone `template_dir` from `repo`@`ref` into `dest` (must not already exist)."""
+    with tempfile.TemporaryDirectory(prefix="mason-init-") as tmp:
+        clone = pathlib.Path(tmp) / "app-templates"
+        _git(["clone", "--depth", "1", "--filter=blob:none", "--sparse", "--branch", ref, repo, str(clone)])
+        _git(["sparse-checkout", "set", template_dir], cwd=clone)
+        src = clone / template_dir
+        if not src.is_dir():
+            raise AgentCliError(
+                f"Template '{template_dir}' not found in {repo}@{ref}.",
+                hint="It may not have merged yet — pass --repo/--ref to target a fork or branch.",
+            )
+        # Copy the template contents (not the .git) into the destination.
+        shutil.copytree(src, dest)
+
+
+@click.command(name="init")
+@click.argument("directory", required=False)
+@click.option(
+    "--framework",
+    type=click.Choice(sorted(_TEMPLATES)),
+    default="openai",
+    show_default=True,
+    help="Which basic agent template to scaffold.",
+)
+@click.option("--repo", default=_DEFAULT_REPO, show_default=True, help="app-templates git repo URL.")
+@click.option("--ref", default=_DEFAULT_REF, show_default=True, help="Branch, tag, or ref to fetch.")
+@click.pass_obj
+def init(obj, directory: Optional[str], framework: str, repo: str, ref: str) -> None:
+    """Scaffold a local agent project from an app-templates template.
+
+    DIRECTORY is the target path to create (defaults to the template's own name). The
+    directory must not already exist. Once scaffolded, deploy it with
+    `mason deploy <name> --source <directory>`.
+    """
+    template_dir = _TEMPLATES[framework]
+    dest = pathlib.Path(directory) if directory else pathlib.Path(template_dir)
+
+    if dest.exists():
+        raise AgentCliError(
+            f"Destination '{dest}' already exists.",
+            hint="Choose a new directory or remove the existing one.",
+        )
+
+    _fetch_template(repo, ref, template_dir, dest)
+
+    if obj.output == "json":
+        render.emit_json(
+            {"framework": framework, "template": template_dir, "directory": str(dest)}
+        )
+        return
+
+    render.success(
+        f"Scaffolded '{template_dir}'",
+        fields={"Framework": framework, "Directory": str(dest)},
+        next_steps=[
+            f"cd {dest}",
+            "uv run start-server        # run locally",
+            f"mason deploy <name> --source {dest}",
+        ],
+    )

--- a/integrations/mason/src/databricks_mason/init.py
+++ b/integrations/mason/src/databricks_mason/init.py
@@ -58,6 +58,31 @@ def _fetch_template(repo: str, ref: str, template_dir: str, dest: pathlib.Path) 
         shutil.copytree(src, dest)
 
 
+def _write_env(dest: pathlib.Path, profile: str) -> bool:
+    """Seed a local `.env` from `.env.example` with DATABRICKS_CONFIG_PROFILE=<profile>.
+
+    Returns True if a `.env` was written. Skips if `.env` already exists (never clobbers). The
+    template reads DATABRICKS_CONFIG_PROFILE for local model auth, so this makes the scaffolded
+    project runnable with `uv run start-server` without a manual `cp .env.example .env` step.
+    """
+    env_path = dest / ".env"
+    if env_path.exists():
+        return False
+    example = dest / ".env.example"
+    base = example.read_text() if example.exists() else ""
+    lines, replaced = [], False
+    for line in base.splitlines():
+        if line.startswith("DATABRICKS_CONFIG_PROFILE="):
+            lines.append(f"DATABRICKS_CONFIG_PROFILE={profile}")
+            replaced = True
+        else:
+            lines.append(line)
+    if not replaced:
+        lines.insert(0, f"DATABRICKS_CONFIG_PROFILE={profile}")
+    env_path.write_text("\n".join(lines) + "\n")
+    return True
+
+
 @click.command(name="init")
 @click.argument("directory", required=False)
 @click.option(
@@ -67,15 +92,26 @@ def _fetch_template(repo: str, ref: str, template_dir: str, dest: pathlib.Path) 
     show_default=True,
     help="Which basic agent template to scaffold.",
 )
+@click.option(
+    "--profile",
+    default=None,
+    help="Seed a local .env with this DATABRICKS_CONFIG_PROFILE so `uv run start-server` works "
+    "immediately (defaults to the profile from -p / `mason login`).",
+)
 @click.option("--repo", default=_DEFAULT_REPO, show_default=True, help="app-templates git repo URL.")
 @click.option("--ref", default=_DEFAULT_REF, show_default=True, help="Branch, tag, or ref to fetch.")
 @click.pass_obj
-def init(obj, directory: Optional[str], framework: str, repo: str, ref: str) -> None:
+def init(
+    obj, directory: Optional[str], framework: str, profile: Optional[str], repo: str, ref: str
+) -> None:
     """Scaffold a local agent project from an app-templates template.
 
     DIRECTORY is the target path to create (defaults to the template's own name). The
     directory must not already exist. Once scaffolded, deploy it with
     `mason deploy <name> --source <directory>`.
+
+    Pass --profile (or set a default via `mason login` / -p) to seed a local `.env` so the
+    scaffolded project runs with `uv run start-server` right away.
     """
     template_dir = _TEMPLATES[framework]
     dest = pathlib.Path(directory) if directory else pathlib.Path(template_dir)
@@ -88,18 +124,30 @@ def init(obj, directory: Optional[str], framework: str, repo: str, ref: str) -> 
 
     _fetch_template(repo, ref, template_dir, dest)
 
+    env_profile = profile or obj.profile
+    wrote_env = _write_env(dest, env_profile) if env_profile else False
+
     if obj.output == "json":
         render.emit_json(
-            {"framework": framework, "template": template_dir, "directory": str(dest)}
+            {
+                "framework": framework,
+                "template": template_dir,
+                "directory": str(dest),
+                "env_profile": env_profile if wrote_env else None,
+            }
         )
         return
 
+    run_step = (
+        "uv run start-server        # run locally"
+        if wrote_env
+        else "cp .env.example .env       # then set DATABRICKS_CONFIG_PROFILE, and: uv run start-server"
+    )
+    fields = {"Framework": framework, "Directory": str(dest)}
+    if wrote_env:
+        fields["Profile (.env)"] = env_profile
     render.success(
         f"Scaffolded '{template_dir}'",
-        fields={"Framework": framework, "Directory": str(dest)},
-        next_steps=[
-            f"cd {dest}",
-            "uv run start-server        # run locally",
-            f"mason deploy <name> --source {dest}",
-        ],
+        fields=fields,
+        next_steps=[f"cd {dest}", run_step, f"mason deploy <name> --source {dest}"],
     )

--- a/integrations/mason/src/databricks_mason/init.py
+++ b/integrations/mason/src/databricks_mason/init.py
@@ -34,7 +34,7 @@ _TEMPLATES = {
     "langgraph": {
         "repo": "https://github.com/databricks/databricks-ai-bridge.git",
         "ref": "main",
-        "path": "integrations/mason/templates/agent-langgraph-scratch",
+        "path": "integrations/mason/templates/agent-langgraph",
     },
 }
 

--- a/integrations/mason/src/databricks_mason/memory_store_access.py
+++ b/integrations/mason/src/databricks_mason/memory_store_access.py
@@ -1,0 +1,30 @@
+"""Memory-store Lakebase specifics for the deployed-app SP grant (see `store_access`)."""
+
+from __future__ import annotations
+
+from databricks_mason.store_access import LakebaseBackend
+
+_PROJECT = "databricks-internal-agent-memory-store"
+
+
+def backend(database: str) -> LakebaseBackend:
+    """The Lakebase backend for a memory store.
+
+    Unlike the session store, the per-store database is not the store id; it's the last segment of
+    the store's ``storage_backend.backend_id`` (e.g. ``memory-250cbddd``), so callers pass the
+    resolved database name. Memory entries live in the ``memory.memory_entries`` table.
+    """
+    return LakebaseBackend(
+        project=_PROJECT,
+        branch="production",
+        endpoint_id="primary",
+        database=database,
+        schema="memory",
+        tables=("memory_entries",),
+        resource_name="postgres-memory",
+    )
+
+
+def database_from_backend_id(backend_id: str) -> str:
+    """Extract the per-store database name from a store's ``storage_backend.backend_id`` path."""
+    return backend_id.split("/")[-1]

--- a/integrations/mason/src/databricks_mason/session_store_access.py
+++ b/integrations/mason/src/databricks_mason/session_store_access.py
@@ -1,0 +1,18 @@
+"""Session-store Lakebase specifics for the deployed-app SP grant (see `store_access`)."""
+
+from __future__ import annotations
+
+from databricks_mason.store_access import LakebaseBackend
+
+
+def backend(store: str) -> LakebaseBackend:
+    """The Lakebase backend for a session store. The per-store database is named after the store."""
+    return LakebaseBackend(
+        project="databricks-internal-agent-session-store",
+        branch="production",
+        endpoint_id="primary",
+        database=store,
+        schema="public",
+        tables=("sessions", "session_items"),
+        resource_name="postgres",
+    )

--- a/integrations/mason/src/databricks_mason/store_access.py
+++ b/integrations/mason/src/databricks_mason/store_access.py
@@ -78,7 +78,9 @@ class LakebaseBackend:
         }
 
 
-def apply_postgres_resources(app: str, backends: list[LakebaseBackend], profile: Optional[str]) -> Optional[str]:
+def apply_postgres_resources(
+    app: str, backends: list[LakebaseBackend], profile: Optional[str]
+) -> Optional[str]:
     """Bind each backend's database as a `postgres` app resource in one update.
 
     `apps update --json` replaces the whole resources array, so all needed backends must be applied

--- a/integrations/mason/src/databricks_mason/store_access.py
+++ b/integrations/mason/src/databricks_mason/store_access.py
@@ -1,0 +1,165 @@
+"""Shared Lakebase access plumbing for granting a deployed app's service principal store access.
+
+A managed store (session or memory) is backed by a per-store Lakebase database in a shared,
+service-managed project. The store's tables are owned by whoever created the store (the deploying
+user), so giving the deployed app's service principal access takes TWO steps:
+  1. a `postgres` app resource so the SP gets a Lakebase role and CONNECT on the database, and
+  2. a table GRANT (issued over psql as the store owner) so the SP can read/write the tables.
+With only (1) the SP connects but hits "permission denied" on the tables; with only (2) it can't
+connect at all. Both are best-effort — deploy proceeds and reports if either step can't be applied.
+
+This module holds the store-agnostic mechanics; `session_store_access` and `memory_store_access`
+supply the per-store project/schema/table specifics.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+from dataclasses import dataclass
+from typing import Optional
+
+from databricks_mason.errors import AgentCliError
+
+
+def _databricks(
+    args: list[str],
+    profile: Optional[str],
+    *,
+    capture: bool = False,
+    check: bool = True,
+    cwd: Optional[str] = None,
+) -> subprocess.CompletedProcess:
+    cmd = ["databricks", *args]
+    if profile:
+        cmd += ["--profile", profile]
+    result = subprocess.run(cmd, text=True, capture_output=capture, cwd=cwd)
+    if check and result.returncode != 0:
+        detail = (result.stderr or result.stdout or "").strip() if capture else None
+        raise AgentCliError(f"`{' '.join(cmd)}` failed (exit {result.returncode})", hint=detail)
+    return result
+
+
+@dataclass(frozen=True)
+class LakebaseBackend:
+    """A per-store Lakebase database: its shared project/branch, its endpoint, and its schema/tables."""
+
+    project: str
+    branch: str
+    endpoint_id: str
+    database: str
+    schema: str
+    tables: tuple[str, ...]
+    resource_name: str  # the app-resource name (must be unique across an app's resources)
+
+    @property
+    def branch_path(self) -> str:
+        return f"projects/{self.project}/branches/{self.branch}"
+
+    @property
+    def database_path(self) -> str:
+        return f"{self.branch_path}/databases/{self.database}"
+
+    @property
+    def endpoint_path(self) -> str:
+        return f"{self.branch_path}/endpoints/{self.endpoint_id}"
+
+    def postgres_resource(self) -> dict:
+        """The `postgres` app-resource entry that grants the SP a Lakebase role + CONNECT."""
+        return {
+            "name": self.resource_name,
+            "postgres": {
+                "branch": self.branch_path,
+                "database": self.database_path,
+                "permission": "CAN_CONNECT_AND_CREATE",
+            },
+        }
+
+
+def apply_postgres_resources(app: str, backends: list[LakebaseBackend], profile: Optional[str]) -> Optional[str]:
+    """Bind each backend's database as a `postgres` app resource in one update.
+
+    `apps update --json` replaces the whole resources array, so all needed backends must be applied
+    together. Returns None on success or a human-readable reason on failure.
+    """
+    payload = {"resources": [b.postgres_resource() for b in backends]}
+    result = _databricks(
+        ["apps", "update", app, "--json", json.dumps(payload)], profile, capture=True, check=False
+    )
+    if result.returncode == 0:
+        return None
+    return (result.stderr or result.stdout or "").strip() or "unknown error"
+
+
+def _resolve_pg_host(backend: LakebaseBackend, profile: Optional[str]) -> Optional[str]:
+    """Read the backend branch's read-write endpoint host, or None if it can't be resolved."""
+    result = _databricks(
+        ["postgres", "get-endpoint", backend.endpoint_path, "-o", "json"],
+        profile,
+        capture=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        return None
+    try:
+        hosts = json.loads(result.stdout).get("status", {}).get("hosts", {})
+    except (json.JSONDecodeError, AttributeError):
+        return None
+    return hosts.get("host") if isinstance(hosts, dict) else None
+
+
+def _mint_token(backend: LakebaseBackend, profile: Optional[str]) -> Optional[str]:
+    """Mint an owner OAuth token for the backend endpoint (used as the psql password)."""
+    result = _databricks(
+        ["postgres", "generate-database-credential", backend.endpoint_path, "-o", "json"],
+        profile,
+        capture=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        return None
+    try:
+        return json.loads(result.stdout).get("token")
+    except json.JSONDecodeError:
+        return None
+
+
+def grant_tables(
+    backend: LakebaseBackend, sp_client_id: str, owner: str, profile: Optional[str]
+) -> Optional[str]:
+    """Grant the app's SP read/write on the backend's tables (owner-issued, over psql).
+
+    Returns None on success, or a human-readable reason if the grant couldn't be applied. Deploy
+    proceeds regardless — the app runs, but the store's durable path fails until the SP has access.
+    """
+    if shutil.which("psql") is None:
+        return "psql not found on PATH (needed to grant the app SP access to the store)."
+    host = _resolve_pg_host(backend, profile)
+    if not host:
+        return "could not resolve the store's Lakebase endpoint."
+    token = _mint_token(backend, profile)
+    if not token:
+        return "could not mint a Lakebase credential for the store (need store ownership)."
+
+    # The SP's Postgres role is its application id, verbatim. Qualify tables with their schema (the
+    # SP's search_path may not include it), and add default privileges so tables the service creates
+    # later are covered too.
+    qualified = ", ".join(f"{backend.schema}.{t}" for t in backend.tables)
+    grants = (
+        f'GRANT USAGE ON SCHEMA {backend.schema} TO "{sp_client_id}";'
+        f' GRANT SELECT, INSERT, UPDATE, DELETE ON {qualified} TO "{sp_client_id}";'
+        f" ALTER DEFAULT PRIVILEGES IN SCHEMA {backend.schema}"
+        f' GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO "{sp_client_id}";'
+    )
+    conn = f"host={host} port=5432 dbname={backend.database} user={owner} sslmode=require"
+    result = subprocess.run(
+        ["psql", conn, "-v", "ON_ERROR_STOP=1", "-c", grants],
+        env={**os.environ, "PGPASSWORD": token},
+        text=True,
+        capture_output=True,
+    )
+    if result.returncode == 0:
+        return None
+    return (result.stderr or result.stdout or "").strip() or "unknown error"

--- a/integrations/mason/src/databricks_mason/tracing.py
+++ b/integrations/mason/src/databricks_mason/tracing.py
@@ -13,6 +13,7 @@ installed and lazily import it; `instrument` (and the deploy wiring) are pure an
 from __future__ import annotations
 
 import os
+import pathlib
 from typing import Any, Optional
 
 import click
@@ -21,7 +22,22 @@ from databricks_mason import render, timefmt
 from databricks_mason.errors import AgentCliError
 
 _BREADCRUMB = "Agent Tracing"
+# Fallback experiment when there's no agent context (e.g. `tracing setup` with no --app). Prefer a
+# per-agent experiment via `default_experiment` so each agent's traces are isolated, not commingled.
 _DEFAULT_EXPERIMENT = "/Shared/mason-agent-traces"
+
+
+def default_experiment(user: str, app: Optional[str]) -> str:
+    """The per-agent experiment path for `app`, under the user's workspace home.
+
+    Keeps each agent's traces in their own experiment (and out of other users' view), instead of the
+    single shared bucket. `mason tracing setup`, `dev`, and `deploy` all derive the same path for a
+    given agent, so the experiment `setup` links is the one the agent logs to. Falls back to the
+    shared default only when no app name is available.
+    """
+    if not app:
+        return _DEFAULT_EXPERIMENT
+    return f"/Users/{user}/mason-traces/{app}"
 
 # Env vars the deployed agent reads (see deploy.py). MLFLOW_TRACING_DESTINATION is MLflow's own
 # "catalog.schema" convention; MLFLOW_EXPERIMENT_NAME is the standard MLflow experiment selector.
@@ -142,7 +158,16 @@ def tracing() -> None:
 @click.option("--catalog", required=True, help="Unity Catalog catalog to store traces in.")
 @click.option("--schema", required=True, help="Unity Catalog schema to store traces in.")
 @click.option(
-    "--experiment", default=None, help=f"MLflow experiment path (default: {_DEFAULT_EXPERIMENT})."
+    "--app",
+    default=None,
+    help="Agent name — gives this agent its own experiment (/Users/<you>/mason-traces/<app>) so its "
+    "traces aren't commingled with other agents'. Defaults to the current directory name (matching "
+    "`mason dev`/`deploy`). Overridden by --experiment.",
+)
+@click.option(
+    "--experiment",
+    default=None,
+    help="MLflow experiment path (overrides the per-app default derived from --app).",
 )
 @click.option(
     "--warehouse-id",
@@ -155,11 +180,14 @@ def tracing() -> None:
     help="Replace an existing trace-location link on the experiment (unset, then re-link).",
 )
 @click.pass_obj
-def tracing_setup(obj, catalog, schema, experiment, warehouse_id, relink) -> None:
+def tracing_setup(obj, catalog, schema, app, experiment, warehouse_id, relink) -> None:
     """Link a UC schema to an MLflow experiment so agent traces land in Unity Catalog."""
     mlflow = _mlflow()
     _configure(mlflow, obj.profile, warehouse_id)
-    exp_name = experiment or _DEFAULT_EXPERIMENT
+    # Default the agent name to the current directory, matching `mason dev`/`deploy`, so running
+    # setup from a project dir needs no --app and still lands in that agent's own experiment.
+    app = app or pathlib.Path.cwd().name
+    exp_name = experiment or default_experiment(obj.client().current_user, app)
     exp_id = _ensure_experiment(mlflow, exp_name)
 
     UCSchemaLocation, set_location, unset_location = _uc_trace_symbols()
@@ -183,15 +211,16 @@ def tracing_setup(obj, catalog, schema, experiment, warehouse_id, relink) -> Non
             }
         )
         return
-    # --with-traces defaults the experiment to _DEFAULT_EXPERIMENT, so only spell out
-    # --traces-experiment when the user picked a non-default one.
-    exp_flag = "" if exp_name == _DEFAULT_EXPERIMENT else f" --traces-experiment {exp_name}"
+    # dev/deploy derive this same experiment from the agent name (dev: project dir, deploy: <name>),
+    # so only spell out --traces-experiment when the experiment was set explicitly (not per-app).
+    exp_flag = "" if experiment is None else f" --traces-experiment {exp_name}"
+    deploy_name = app
     render.success(
         f"Linked traces for '{exp_name}' to {destination}",
         fields={"Experiment": exp_name, "Destination": destination, "View traces": url},
         next_steps=[
             f"mason dev --with-traces {destination}{exp_flag}",
-            f"mason deploy <name> --with-traces {destination}{exp_flag}",
+            f"mason deploy {deploy_name} --with-traces {destination}{exp_flag}",
             f"mason tracing instrument --destination {destination}",
             f"mason tracing list --experiment {exp_name}",
         ],

--- a/integrations/mason/src/databricks_mason/tracing.py
+++ b/integrations/mason/src/databricks_mason/tracing.py
@@ -51,14 +51,37 @@ def _uc_trace_symbols():
     """
     try:
         from mlflow.entities import UCSchemaLocation  # noqa: PLC0415 - lazy, version-specific
-        from mlflow.tracing.enablement import set_experiment_trace_location  # noqa: PLC0415
+        from mlflow.tracing import (  # noqa: PLC0415
+            set_experiment_trace_location,
+            unset_experiment_trace_location,
+        )
 
-        return UCSchemaLocation, set_experiment_trace_location
+        return UCSchemaLocation, set_experiment_trace_location, unset_experiment_trace_location
     except ImportError as exc:
         raise AgentCliError(
             "This MLflow version is too old for `mason tracing setup` (UC trace destinations).",
             hint="Upgrade it: pip install 'mlflow[databricks]>=3.9.0'",
         ) from exc
+
+
+def _link_trace_location(set_location, unset_location, location, exp_id: str, relink: bool) -> None:
+    """Link the experiment to the UC schema, handling the already-linked case.
+
+    MLflow raises if the experiment is already bound to a storage location. With `relink`, unset the
+    existing binding first and re-link; otherwise surface a clean error pointing at `--relink`.
+    """
+    try:
+        set_location(location=location, experiment_id=exp_id)
+    except Exception as exc:  # noqa: BLE001 - mlflow raises a generic error when already linked
+        if "already" not in str(exc).lower():
+            raise
+        if not relink:
+            raise AgentCliError(
+                "This experiment is already linked to a trace storage location.",
+                hint="Re-run with --relink to replace the existing link.",
+            ) from exc
+        unset_location(location=location, experiment_id=exp_id)
+        set_location(location=location, experiment_id=exp_id)
 
 
 def _configure(mlflow, profile: Optional[str], warehouse_id: Optional[str]) -> None:
@@ -99,6 +122,11 @@ def _split_destination(destination: str) -> tuple[str, str]:
     return catalog, schema
 
 
+def _experiment_url(host: str, experiment_id: str) -> str:
+    """Workspace URL for an experiment's Traces tab."""
+    return f"{host.rstrip('/')}/ml/experiments/{experiment_id}?compareRunsMode=TRACES"
+
+
 # --- group ------------------------------------------------------------------
 
 
@@ -121,31 +149,50 @@ def tracing() -> None:
     default=None,
     help="SQL warehouse id for trace queries (MLFLOW_TRACING_SQL_WAREHOUSE_ID).",
 )
+@click.option(
+    "--relink",
+    is_flag=True,
+    help="Replace an existing trace-location link on the experiment (unset, then re-link).",
+)
 @click.pass_obj
-def tracing_setup(obj, catalog, schema, experiment, warehouse_id) -> None:
+def tracing_setup(obj, catalog, schema, experiment, warehouse_id, relink) -> None:
     """Link a UC schema to an MLflow experiment so agent traces land in Unity Catalog."""
     mlflow = _mlflow()
     _configure(mlflow, obj.profile, warehouse_id)
     exp_name = experiment or _DEFAULT_EXPERIMENT
     exp_id = _ensure_experiment(mlflow, exp_name)
 
-    UCSchemaLocation, set_experiment_trace_location = _uc_trace_symbols()
-    set_experiment_trace_location(
-        location=UCSchemaLocation(catalog_name=catalog, schema_name=schema), experiment_id=exp_id
+    UCSchemaLocation, set_location, unset_location = _uc_trace_symbols()
+    _link_trace_location(
+        set_location,
+        unset_location,
+        UCSchemaLocation(catalog_name=catalog, schema_name=schema),
+        exp_id,
+        relink,
     )
     destination = f"{catalog}.{schema}"
+    url = _experiment_url(obj.client().host, exp_id)
 
     if obj.output == "json":
         render.emit_json(
-            {"experiment": exp_name, "experiment_id": exp_id, "destination": destination}
+            {
+                "experiment": exp_name,
+                "experiment_id": exp_id,
+                "destination": destination,
+                "url": url,
+            }
         )
         return
+    # --with-traces defaults the experiment to _DEFAULT_EXPERIMENT, so only spell out
+    # --traces-experiment when the user picked a non-default one.
+    exp_flag = "" if exp_name == _DEFAULT_EXPERIMENT else f" --traces-experiment {exp_name}"
     render.success(
         f"Linked traces for '{exp_name}' to {destination}",
-        fields={"Experiment": exp_name, "Destination": destination},
+        fields={"Experiment": exp_name, "Destination": destination, "View traces": url},
         next_steps=[
+            f"mason dev --with-traces {destination}{exp_flag}",
+            f"mason deploy <name> --with-traces {destination}{exp_flag}",
             f"mason tracing instrument --destination {destination}",
-            f"mason deploy <name> --source ./app --with-traces {destination}",
             f"mason tracing list --experiment {exp_name}",
         ],
     )

--- a/integrations/mason/src/databricks_mason/tracing.py
+++ b/integrations/mason/src/databricks_mason/tracing.py
@@ -39,6 +39,7 @@ def default_experiment(user: str, app: Optional[str]) -> str:
         return _DEFAULT_EXPERIMENT
     return f"/Users/{user}/mason-traces/{app}"
 
+
 # Env vars the deployed agent reads (see deploy.py). MLFLOW_TRACING_DESTINATION is MLflow's own
 # "catalog.schema" convention; MLFLOW_EXPERIMENT_NAME is the standard MLflow experiment selector.
 TRACES_DEST_ENV = "MLFLOW_TRACING_DESTINATION"
@@ -107,9 +108,16 @@ def _configure(mlflow, profile: Optional[str], warehouse_id: Optional[str]) -> N
         os.environ["MLFLOW_TRACING_SQL_WAREHOUSE_ID"] = warehouse_id
 
 
-def _ensure_experiment(mlflow, name: str) -> str:
+def _ensure_experiment(mlflow, client, name: str) -> str:
     experiment = mlflow.get_experiment_by_name(name)
-    return experiment.experiment_id if experiment else mlflow.create_experiment(name)
+    if experiment:
+        return experiment.experiment_id
+    # create_experiment won't make the intermediate workspace folder for a nested path (e.g.
+    # /Users/<you>/mason-traces/<app>), so create the parent dir first.
+    parent = name.rsplit("/", 1)[0]
+    if parent:
+        client.ensure_workspace_dir(parent)
+    return mlflow.create_experiment(name)
 
 
 def _attr(obj: Any, *paths: str, default: Any = None) -> Any:
@@ -187,8 +195,9 @@ def tracing_setup(obj, catalog, schema, app, experiment, warehouse_id, relink) -
     # Default the agent name to the current directory, matching `mason dev`/`deploy`, so running
     # setup from a project dir needs no --app and still lands in that agent's own experiment.
     app = app or pathlib.Path.cwd().name
-    exp_name = experiment or default_experiment(obj.client().current_user, app)
-    exp_id = _ensure_experiment(mlflow, exp_name)
+    client = obj.client()
+    exp_name = experiment or default_experiment(client.current_user, app)
+    exp_id = _ensure_experiment(mlflow, client, exp_name)
 
     UCSchemaLocation, set_location, unset_location = _uc_trace_symbols()
     _link_trace_location(
@@ -199,7 +208,7 @@ def tracing_setup(obj, catalog, schema, app, experiment, warehouse_id, relink) -
         relink,
     )
     destination = f"{catalog}.{schema}"
-    url = _experiment_url(obj.client().host, exp_id)
+    url = _experiment_url(client.host, exp_id)
 
     if obj.output == "json":
         render.emit_json(

--- a/integrations/mason/tests/unit_tests/deploy_test.py
+++ b/integrations/mason/tests/unit_tests/deploy_test.py
@@ -127,6 +127,40 @@ def test_deploy_with_traces_injects_tracing_env(tmp_path: pathlib.Path, monkeypa
     assert env["MLFLOW_EXPERIMENT_NAME"] == "/Shared/x"
 
 
+def _run_deploy(src, monkeypatch, extra_args):
+    monkeypatch.setattr(deploy_mod, "_deployment_exists", lambda a, p: True)
+    monkeypatch.setattr(
+        deploy_mod,
+        "_databricks",
+        lambda args, profile, **kw: types.SimpleNamespace(returncode=0, stdout="", stderr=""),
+    )
+    return CliRunner().invoke(
+        deploy_mod.deploy, ["myapp", "--source", str(src), *extra_args], obj=_FakeCtx()
+    )
+
+
+def test_deploy_injects_public_pypi_index_by_default(tmp_path: pathlib.Path, monkeypatch):
+    src = tmp_path / "app"
+    src.mkdir()
+    (src / "app.yaml").write_text(yaml.safe_dump({"command": ["x"]}))
+    result = _run_deploy(src, monkeypatch, [])
+    assert result.exit_code == 0, result.output
+    env = {e["name"]: e["value"] for e in yaml.safe_load((src / "app.yaml").read_text())["env"]}
+    for name in ("PIP_INDEX_URL", "UV_INDEX_URL", "UV_DEFAULT_INDEX"):
+        assert env[name] == "https://pypi.org/simple/"
+
+
+def test_deploy_empty_pip_index_disables_override(tmp_path: pathlib.Path, monkeypatch):
+    src = tmp_path / "app"
+    src.mkdir()
+    (src / "app.yaml").write_text(yaml.safe_dump({"command": ["x"]}))
+    result = _run_deploy(src, monkeypatch, ["--pip-index-url", ""])
+    assert result.exit_code == 0, result.output
+    doc = yaml.safe_load((src / "app.yaml").read_text())
+    env = {e["name"]: e["value"] for e in (doc.get("env") or [])}
+    assert "PIP_INDEX_URL" not in env  # empty -> no override, use the build's default index
+
+
 class _JsonCtx:
     profile = "prof"
     output = "json"

--- a/integrations/mason/tests/unit_tests/deploy_test.py
+++ b/integrations/mason/tests/unit_tests/deploy_test.py
@@ -177,11 +177,13 @@ def test_deploy_with_traces_injects_tracing_env(tmp_path: pathlib.Path, monkeypa
     assert env["MLFLOW_EXPERIMENT_NAME"] == "/Shared/x"
 
 
-def test_with_traces_defaults_the_experiment():
+def test_with_traces_defaults_the_experiment_per_app():
     # --with-traces alone must still set the experiment, or the agent ships tracing half-configured
-    # (destination set, experiment missing) and silently disables it.
+    # (destination set, experiment missing) and silently disables it. The default is per-app, so
+    # each agent's traces are isolated instead of piling into one shared experiment.
     env = deploy_mod.resolve_store_env(
         _FakeClient(),
+        app="my-agent",
         memory_store=None,
         session_store=None,
         traces_destination="cat.schema",
@@ -189,7 +191,20 @@ def test_with_traces_defaults_the_experiment():
         create_stores=False,
     )
     assert env["MLFLOW_TRACING_DESTINATION"] == "cat.schema"
-    assert env["MLFLOW_EXPERIMENT_NAME"] == deploy_mod._DEFAULT_EXPERIMENT
+    assert env["MLFLOW_EXPERIMENT_NAME"] == "/Users/me@example.com/mason-traces/my-agent"
+
+
+def test_with_traces_explicit_experiment_wins_over_per_app():
+    env = deploy_mod.resolve_store_env(
+        _FakeClient(),
+        app="my-agent",
+        memory_store=None,
+        session_store=None,
+        traces_destination="cat.schema",
+        traces_experiment="/Shared/custom",
+        create_stores=False,
+    )
+    assert env["MLFLOW_EXPERIMENT_NAME"] == "/Shared/custom"
 
 
 def _run_deploy(src, monkeypatch, extra_args):

--- a/integrations/mason/tests/unit_tests/deploy_test.py
+++ b/integrations/mason/tests/unit_tests/deploy_test.py
@@ -97,6 +97,53 @@ def test_deploy_drives_sync_and_apps_deploy(tmp_path: pathlib.Path, monkeypatch)
     assert env["AGENT_MEMORY_STORE"] == "mem"
 
 
+def test_first_deploy_waits_for_running_before_deploying(tmp_path: pathlib.Path, monkeypatch):
+    # A brand-new app isn't RUNNING right after `apps create`; deploy must wait, or it races and
+    # fails ("not in RUNNING state"). Verify create -> wait -> sync/deploy ordering.
+    src = tmp_path / "app"
+    src.mkdir()
+    (src / "app.yaml").write_text(yaml.safe_dump({"command": ["x"]}))
+
+    calls: list[list[str]] = []
+    monkeypatch.setattr(deploy_mod, "_deployment_exists", lambda a, p: False)  # app doesn't exist yet
+    waited = {"called": False}
+    monkeypatch.setattr(
+        deploy_mod, "_wait_for_running", lambda name, profile: waited.__setitem__("called", True)
+    )
+    monkeypatch.setattr(deploy_mod, "_app_service_principal", lambda name, p: None)
+    monkeypatch.setattr(
+        deploy_mod,
+        "_databricks",
+        lambda args, profile, **kw: calls.append(args)
+        or types.SimpleNamespace(returncode=0, stdout="", stderr=""),
+    )
+
+    result = CliRunner().invoke(deploy_mod.deploy, ["myapp", "--source", str(src)], obj=_FakeCtx())
+
+    assert result.exit_code == 0, result.output
+    assert ["apps", "create", "myapp"] in calls
+    assert waited["called"], "must wait for the new app to be running before deploying"
+    # the wait happens after create and before sync/deploy
+    create_i = calls.index(["apps", "create", "myapp"])
+    sync_i = next(i for i, a in enumerate(calls) if a[:1] == ["sync"])
+    assert create_i < sync_i
+
+
+def test_wait_for_running_returns_when_compute_active(monkeypatch):
+    monkeypatch.setattr(deploy_mod, "_app_compute_state", lambda name, p: "ACTIVE")
+    deploy_mod._wait_for_running("app", "prof", timeout_s=1)  # returns without raising
+
+
+def test_wait_for_running_times_out(monkeypatch):
+    monkeypatch.setattr(deploy_mod, "_app_compute_state", lambda name, p: "STARTING")
+    monkeypatch.setattr(deploy_mod.time, "sleep", lambda s: None)  # don't actually wait
+    try:
+        deploy_mod._wait_for_running("app", "prof", timeout_s=0)
+        raise AssertionError("expected AgentCliError on timeout")
+    except AgentCliError:
+        pass
+
+
 def test_deploy_with_traces_injects_tracing_env(tmp_path: pathlib.Path, monkeypatch):
     src = tmp_path / "app"
     src.mkdir()
@@ -128,6 +175,21 @@ def test_deploy_with_traces_injects_tracing_env(tmp_path: pathlib.Path, monkeypa
     env = {e["name"]: e["value"] for e in doc["env"]}
     assert env["MLFLOW_TRACING_DESTINATION"] == "cat.schema"
     assert env["MLFLOW_EXPERIMENT_NAME"] == "/Shared/x"
+
+
+def test_with_traces_defaults_the_experiment():
+    # --with-traces alone must still set the experiment, or the agent ships tracing half-configured
+    # (destination set, experiment missing) and silently disables it.
+    env = deploy_mod.resolve_store_env(
+        _FakeClient(),
+        memory_store=None,
+        session_store=None,
+        traces_destination="cat.schema",
+        traces_experiment=None,
+        create_stores=False,
+    )
+    assert env["MLFLOW_TRACING_DESTINATION"] == "cat.schema"
+    assert env["MLFLOW_EXPERIMENT_NAME"] == deploy_mod._DEFAULT_EXPERIMENT
 
 
 def _run_deploy(src, monkeypatch, extra_args):

--- a/integrations/mason/tests/unit_tests/deploy_test.py
+++ b/integrations/mason/tests/unit_tests/deploy_test.py
@@ -105,7 +105,9 @@ def test_first_deploy_waits_for_running_before_deploying(tmp_path: pathlib.Path,
     (src / "app.yaml").write_text(yaml.safe_dump({"command": ["x"]}))
 
     calls: list[list[str]] = []
-    monkeypatch.setattr(deploy_mod, "_deployment_exists", lambda a, p: False)  # app doesn't exist yet
+    monkeypatch.setattr(
+        deploy_mod, "_deployment_exists", lambda a, p: False
+    )  # app doesn't exist yet
     waited = {"called": False}
     monkeypatch.setattr(
         deploy_mod, "_wait_for_running", lambda name, profile: waited.__setitem__("called", True)

--- a/integrations/mason/tests/unit_tests/deploy_test.py
+++ b/integrations/mason/tests/unit_tests/deploy_test.py
@@ -88,7 +88,8 @@ def test_deploy_drives_sync_and_apps_deploy(tmp_path: pathlib.Path, monkeypatch)
 
     assert result.exit_code == 0, result.output
     ws = "/Workspace/Users/me@example.com/mason_deployments/myapp"
-    assert ["sync", str(src), ws] in calls
+    # uv.lock is excluded so the build resolves fresh against its own index (not the dev machine's).
+    assert ["sync", str(src), ws, "--exclude", "uv.lock"] in calls
     assert ["apps", "deploy", "myapp", "--source-code-path", ws] in calls
     assert "AGENT_MEMORY_STORE" in (src / "app.yaml").read_text()
 

--- a/integrations/mason/tests/unit_tests/deploy_test.py
+++ b/integrations/mason/tests/unit_tests/deploy_test.py
@@ -91,7 +91,10 @@ def test_deploy_drives_sync_and_apps_deploy(tmp_path: pathlib.Path, monkeypatch)
     # uv.lock is excluded so the build resolves fresh against its own index (not the dev machine's).
     assert ["sync", str(src), ws, "--exclude", "uv.lock"] in calls
     assert ["apps", "deploy", "myapp", "--source-code-path", ws] in calls
-    assert "AGENT_MEMORY_STORE" in (src / "app.yaml").read_text()
+    env = {e["name"]: e["value"] for e in yaml.safe_load((src / "app.yaml").read_text())["env"]}
+    # The API returns `memory-stores/mem`, but the runtime re-adds that prefix, so the env var
+    # must carry the bare id.
+    assert env["AGENT_MEMORY_STORE"] == "mem"
 
 
 def test_deploy_with_traces_injects_tracing_env(tmp_path: pathlib.Path, monkeypatch):

--- a/integrations/mason/tests/unit_tests/dev_test.py
+++ b/integrations/mason/tests/unit_tests/dev_test.py
@@ -64,6 +64,45 @@ def test_dev_no_prepare_and_custom_port(tmp_path: pathlib.Path):
     assert cmd[-2:] == ["--app-port", "9000"]
 
 
+def test_dev_filters_build_index_env_via_entry_point(tmp_path: pathlib.Path):
+    import yaml
+
+    (tmp_path / "app.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "command": ["x"],
+                "env": [
+                    {"name": "AGENT_SESSION_STORE", "value": "s"},
+                    {"name": "PIP_INDEX_URL", "value": "https://pypi.org/simple/"},
+                    {"name": "UV_INDEX_URL", "value": "https://pypi.org/simple/"},
+                ],
+            }
+        )
+    )
+    with mock.patch.object(dev_mod, "_databricks") as db:
+        result = CliRunner().invoke(dev_mod.dev, ["--source", str(tmp_path)], obj=_Ctx())
+    assert result.exit_code == 0, result.output
+    cmd = db.call_args.args[0]
+    assert "--entry-point" in cmd  # a filtered manifest was used
+    dev_yaml = tmp_path / ".mason-dev.app.yaml"
+    assert str(dev_yaml) in cmd
+    names = {e["name"] for e in yaml.safe_load(dev_yaml.read_text())["env"]}
+    assert names == {"AGENT_SESSION_STORE"}  # index vars stripped, app env kept
+
+
+def test_dev_no_entry_point_when_no_index_override(tmp_path: pathlib.Path):
+    import yaml
+
+    (tmp_path / "app.yaml").write_text(
+        yaml.safe_dump({"command": ["x"], "env": [{"name": "AGENT_SESSION_STORE", "value": "s"}]})
+    )
+    with mock.patch.object(dev_mod, "_databricks") as db:
+        result = CliRunner().invoke(dev_mod.dev, ["--source", str(tmp_path)], obj=_Ctx())
+    assert result.exit_code == 0, result.output
+    assert "--entry-point" not in db.call_args.args[0]  # nothing to strip -> use app.yaml as-is
+    assert not (tmp_path / ".mason-dev.app.yaml").exists()
+
+
 def test_dev_requires_app_yaml(tmp_path: pathlib.Path):
     with mock.patch.object(dev_mod, "_databricks") as db:
         result = CliRunner().invoke(dev_mod.dev, ["--source", str(tmp_path)], obj=_Ctx())

--- a/integrations/mason/tests/unit_tests/dev_test.py
+++ b/integrations/mason/tests/unit_tests/dev_test.py
@@ -126,7 +126,9 @@ def test_dev_with_flags_wires_app_yaml_before_running(tmp_path: pathlib.Path):
         )
     assert result.exit_code == 0, result.output
     resolve.assert_called_once()  # same resolution path as deploy
-    env = {e["name"]: e["value"] for e in yaml.safe_load((tmp_path / "app.yaml").read_text())["env"]}
+    env = {
+        e["name"]: e["value"] for e in yaml.safe_load((tmp_path / "app.yaml").read_text())["env"]
+    }
     assert env == {"AGENT_SESSION_STORE": "s", "AGENT_MEMORY_STORE": "abc"}  # patched before run
     assert db.call_args.args[0][:2] == ["apps", "run-local"]
 

--- a/integrations/mason/tests/unit_tests/dev_test.py
+++ b/integrations/mason/tests/unit_tests/dev_test.py
@@ -15,6 +15,9 @@ class _Ctx:
         self.output = output
         self.profile = profile
 
+    def client(self):  # only used when --with-* flags are passed
+        return mock.Mock()
+
 
 def test_dev_prepares_when_no_venv(tmp_path: pathlib.Path):
     (tmp_path / "app.yaml").write_text("command: []\n")  # no .venv -> auto-prepare
@@ -101,6 +104,43 @@ def test_dev_no_entry_point_when_no_index_override(tmp_path: pathlib.Path):
     assert result.exit_code == 0, result.output
     assert "--entry-point" not in db.call_args.args[0]  # nothing to strip -> use app.yaml as-is
     assert not (tmp_path / ".mason-dev.app.yaml").exists()
+
+
+def test_dev_with_flags_wires_app_yaml_before_running(tmp_path: pathlib.Path):
+    import yaml
+
+    (tmp_path / "app.yaml").write_text(yaml.safe_dump({"command": ["x"]}))
+    (tmp_path / ".venv").mkdir()
+    with (
+        mock.patch.object(dev_mod, "_databricks") as db,
+        mock.patch.object(
+            dev_mod,
+            "resolve_store_env",
+            return_value={"AGENT_SESSION_STORE": "s", "AGENT_MEMORY_STORE": "abc"},
+        ) as resolve,
+    ):
+        result = CliRunner().invoke(
+            dev_mod.dev,
+            ["--source", str(tmp_path), "--with-session-store", "s", "--with-memory-store", "m"],
+            obj=_Ctx(),
+        )
+    assert result.exit_code == 0, result.output
+    resolve.assert_called_once()  # same resolution path as deploy
+    env = {e["name"]: e["value"] for e in yaml.safe_load((tmp_path / "app.yaml").read_text())["env"]}
+    assert env == {"AGENT_SESSION_STORE": "s", "AGENT_MEMORY_STORE": "abc"}  # patched before run
+    assert db.call_args.args[0][:2] == ["apps", "run-local"]
+
+
+def test_dev_without_flags_does_not_touch_app_yaml(tmp_path: pathlib.Path):
+    (tmp_path / "app.yaml").write_text("command: []\n")
+    (tmp_path / ".venv").mkdir()
+    with (
+        mock.patch.object(dev_mod, "_databricks"),
+        mock.patch.object(dev_mod, "resolve_store_env") as resolve,
+    ):
+        result = CliRunner().invoke(dev_mod.dev, ["--source", str(tmp_path)], obj=_Ctx())
+    assert result.exit_code == 0, result.output
+    resolve.assert_not_called()  # no --with-* -> no store resolution, app.yaml untouched
 
 
 def test_dev_requires_app_yaml(tmp_path: pathlib.Path):

--- a/integrations/mason/tests/unit_tests/dev_test.py
+++ b/integrations/mason/tests/unit_tests/dev_test.py
@@ -1,0 +1,52 @@
+"""Unit tests for `mason dev`: wraps `databricks apps run-local` from the project dir."""
+
+from __future__ import annotations
+
+import pathlib
+from unittest import mock
+
+from click.testing import CliRunner
+
+from databricks_mason import dev as dev_mod
+
+
+class _Ctx:
+    def __init__(self, output: str = "text", profile=None):
+        self.output = output
+        self.profile = profile
+
+
+def test_dev_runs_run_local_in_source_dir(tmp_path: pathlib.Path):
+    (tmp_path / "app.yaml").write_text("command: []\n")
+    with mock.patch.object(dev_mod, "_databricks") as db:
+        result = CliRunner().invoke(
+            dev_mod.dev, ["--source", str(tmp_path)], obj=_Ctx(profile="ml")
+        )
+    assert result.exit_code == 0, result.output
+    args, kwargs = db.call_args
+    assert args[0][:2] == ["apps", "run-local"]
+    assert "--prepare-environment" in args[0]  # on by default
+    assert args[1] == "ml"  # profile passed through
+    assert kwargs["cwd"] == str(tmp_path)  # runs in the project dir
+
+
+def test_dev_no_prepare_and_custom_port(tmp_path: pathlib.Path):
+    (tmp_path / "app.yaml").write_text("command: []\n")
+    with mock.patch.object(dev_mod, "_databricks") as db:
+        result = CliRunner().invoke(
+            dev_mod.dev,
+            ["--source", str(tmp_path), "--no-prepare-environment", "--app-port", "9000"],
+            obj=_Ctx(),
+        )
+    assert result.exit_code == 0, result.output
+    cmd = db.call_args.args[0]
+    assert "--prepare-environment" not in cmd
+    assert cmd[-2:] == ["--app-port", "9000"]
+
+
+def test_dev_requires_app_yaml(tmp_path: pathlib.Path):
+    with mock.patch.object(dev_mod, "_databricks") as db:
+        result = CliRunner().invoke(dev_mod.dev, ["--source", str(tmp_path)], obj=_Ctx())
+    assert result.exit_code != 0
+    assert "app.yaml" in result.output
+    db.assert_not_called()

--- a/integrations/mason/tests/unit_tests/dev_test.py
+++ b/integrations/mason/tests/unit_tests/dev_test.py
@@ -16,8 +16,8 @@ class _Ctx:
         self.profile = profile
 
 
-def test_dev_runs_run_local_in_source_dir(tmp_path: pathlib.Path):
-    (tmp_path / "app.yaml").write_text("command: []\n")
+def test_dev_prepares_when_no_venv(tmp_path: pathlib.Path):
+    (tmp_path / "app.yaml").write_text("command: []\n")  # no .venv -> auto-prepare
     with mock.patch.object(dev_mod, "_databricks") as db:
         result = CliRunner().invoke(
             dev_mod.dev, ["--source", str(tmp_path)], obj=_Ctx(profile="ml")
@@ -25,9 +25,29 @@ def test_dev_runs_run_local_in_source_dir(tmp_path: pathlib.Path):
     assert result.exit_code == 0, result.output
     args, kwargs = db.call_args
     assert args[0][:2] == ["apps", "run-local"]
-    assert "--prepare-environment" in args[0]  # on by default
+    assert "--prepare-environment" in args[0]  # no venv yet -> build it
     assert args[1] == "ml"  # profile passed through
     assert kwargs["cwd"] == str(tmp_path)  # runs in the project dir
+
+
+def test_dev_reuses_existing_venv(tmp_path: pathlib.Path):
+    (tmp_path / "app.yaml").write_text("command: []\n")
+    (tmp_path / ".venv").mkdir()  # env already there -> don't rebuild
+    with mock.patch.object(dev_mod, "_databricks") as db:
+        result = CliRunner().invoke(dev_mod.dev, ["--source", str(tmp_path)], obj=_Ctx())
+    assert result.exit_code == 0, result.output
+    assert "--prepare-environment" not in db.call_args.args[0]
+
+
+def test_dev_force_prepare_overrides_existing_venv(tmp_path: pathlib.Path):
+    (tmp_path / "app.yaml").write_text("command: []\n")
+    (tmp_path / ".venv").mkdir()
+    with mock.patch.object(dev_mod, "_databricks") as db:
+        result = CliRunner().invoke(
+            dev_mod.dev, ["--source", str(tmp_path), "--prepare-environment"], obj=_Ctx()
+        )
+    assert result.exit_code == 0, result.output
+    assert "--prepare-environment" in db.call_args.args[0]  # explicit flag forces rebuild
 
 
 def test_dev_no_prepare_and_custom_port(tmp_path: pathlib.Path):

--- a/integrations/mason/tests/unit_tests/init_test.py
+++ b/integrations/mason/tests/unit_tests/init_test.py
@@ -55,6 +55,15 @@ def test_init_scaffolds_default_directory(tmp_path: pathlib.Path):
     assert "agent-openai-basic" in result.output
 
 
+def test_init_defaults_to_langgraph_framework(tmp_path: pathlib.Path):
+    dest = tmp_path / "proj"
+    with mock.patch.object(init_mod, "_fetch_template", side_effect=lambda *a: a[3].mkdir()) as f:
+        result = CliRunner().invoke(init_mod.init, [str(dest)], obj=_Ctx())  # no --framework
+    assert result.exit_code == 0, result.output
+    # omitting --framework scaffolds the langgraph template
+    assert f.call_args.args[2] == init_mod._TEMPLATES["langgraph"]["path"]
+
+
 def test_init_langgraph_fetches_from_ai_bridge(tmp_path: pathlib.Path):
     dest = tmp_path / "lg"
 

--- a/integrations/mason/tests/unit_tests/init_test.py
+++ b/integrations/mason/tests/unit_tests/init_test.py
@@ -31,7 +31,7 @@ def test_framework_specs_have_repo_ref_path():
     assert init_mod._TEMPLATES["openai"]["path"] == "agent-openai-basic"
     assert (
         init_mod._TEMPLATES["langgraph"]["path"]
-        == "integrations/mason/templates/agent-langgraph-scratch"
+        == "integrations/mason/templates/agent-langgraph"
     )
 
 
@@ -68,7 +68,7 @@ def test_init_langgraph_fetches_from_ai_bridge(tmp_path: pathlib.Path):
     assert result.exit_code == 0, result.output
     # langgraph pulls the nested template from the ai-bridge repo
     assert "databricks-ai-bridge" in fetched.call_args.args[0]
-    assert fetched.call_args.args[2] == "integrations/mason/templates/agent-langgraph-scratch"
+    assert fetched.call_args.args[2] == "integrations/mason/templates/agent-langgraph"
 
 
 def test_init_repo_ref_override(tmp_path: pathlib.Path):
@@ -93,7 +93,7 @@ def test_init_json_output(tmp_path: pathlib.Path):
     assert result.exit_code == 0, result.output
     payload = json.loads(result.output)
     assert payload["framework"] == "langgraph"
-    assert payload["template"] == "agent-langgraph-scratch"
+    assert payload["template"] == "agent-langgraph"
     assert payload["directory"] == str(dest)
 
 

--- a/integrations/mason/tests/unit_tests/init_test.py
+++ b/integrations/mason/tests/unit_tests/init_test.py
@@ -24,15 +24,21 @@ class _Ctx:
         self.profile = profile
 
 
-def test_framework_maps_to_template_dir():
-    assert init_mod._TEMPLATES["openai"] == "agent-openai-basic"
-    assert init_mod._TEMPLATES["langgraph"] == "agent-langgraph-basic"
+def test_framework_specs_have_repo_ref_path():
+    for fw in ("openai", "langgraph"):
+        spec = init_mod._TEMPLATES[fw]
+        assert spec["repo"] and spec["ref"] and spec["path"]
+    assert init_mod._TEMPLATES["openai"]["path"] == "agent-openai-basic"
+    assert (
+        init_mod._TEMPLATES["langgraph"]["path"]
+        == "integrations/mason/templates/agent-langgraph-scratch"
+    )
 
 
 def test_init_scaffolds_default_directory(tmp_path: pathlib.Path):
     dest = tmp_path / "agent-openai-basic"
 
-    def fake_fetch(repo, ref, template_dir, target):
+    def fake_fetch(repo, ref, template_path, target):
         target.mkdir(parents=True)
         (target / "app.yaml").write_text("command: []\n")
 
@@ -42,10 +48,40 @@ def test_init_scaffolds_default_directory(tmp_path: pathlib.Path):
         )
     assert result.exit_code == 0, result.output
     fetched.assert_called_once()
-    # framework -> template dir passed through to the fetch
+    # framework's repo + path passed through to the fetch
+    assert fetched.call_args.args[0] == init_mod._TEMPLATES["openai"]["repo"]
     assert fetched.call_args.args[2] == "agent-openai-basic"
     assert (dest / "app.yaml").exists()
     assert "agent-openai-basic" in result.output
+
+
+def test_init_langgraph_fetches_from_ai_bridge(tmp_path: pathlib.Path):
+    dest = tmp_path / "lg"
+
+    def fake_fetch(repo, ref, template_path, target):
+        target.mkdir(parents=True)
+
+    with mock.patch.object(init_mod, "_fetch_template", side_effect=fake_fetch) as fetched:
+        result = CliRunner().invoke(
+            init_mod.init, ["--framework", "langgraph", str(dest)], obj=_Ctx()
+        )
+    assert result.exit_code == 0, result.output
+    # langgraph pulls the nested template from the ai-bridge repo
+    assert "databricks-ai-bridge" in fetched.call_args.args[0]
+    assert fetched.call_args.args[2] == "integrations/mason/templates/agent-langgraph-scratch"
+
+
+def test_init_repo_ref_override(tmp_path: pathlib.Path):
+    dest = tmp_path / "ov"
+    with mock.patch.object(init_mod, "_fetch_template", side_effect=lambda *a: a[3].mkdir()) as f:
+        result = CliRunner().invoke(
+            init_mod.init,
+            ["--framework", "langgraph", "--repo", "https://example.com/fork.git", "--ref", "wip", str(dest)],
+            obj=_Ctx(),
+        )
+    assert result.exit_code == 0, result.output
+    assert f.call_args.args[0] == "https://example.com/fork.git"  # override wins
+    assert f.call_args.args[1] == "wip"
 
 
 def test_init_json_output(tmp_path: pathlib.Path):
@@ -57,7 +93,7 @@ def test_init_json_output(tmp_path: pathlib.Path):
     assert result.exit_code == 0, result.output
     payload = json.loads(result.output)
     assert payload["framework"] == "langgraph"
-    assert payload["template"] == "agent-langgraph-basic"
+    assert payload["template"] == "agent-langgraph-scratch"
     assert payload["directory"] == str(dest)
 
 
@@ -98,7 +134,7 @@ def test_write_env_never_clobbers_existing(tmp_path: pathlib.Path):
 def test_init_profile_flag_writes_env(tmp_path: pathlib.Path):
     dest = tmp_path / "proj"
 
-    def fake_fetch(repo, ref, template_dir, target):
+    def fake_fetch(repo, ref, template_path, target):
         target.mkdir(parents=True)
         (target / ".env.example").write_text("DATABRICKS_CONFIG_PROFILE=DEFAULT\n")
 
@@ -113,7 +149,7 @@ def test_init_profile_flag_writes_env(tmp_path: pathlib.Path):
 def test_init_uses_ctx_profile_when_flag_absent(tmp_path: pathlib.Path):
     dest = tmp_path / "proj"
 
-    def fake_fetch(repo, ref, template_dir, target):
+    def fake_fetch(repo, ref, template_path, target):
         target.mkdir(parents=True)
         (target / ".env.example").write_text("DATABRICKS_CONFIG_PROFILE=DEFAULT\n")
 
@@ -126,7 +162,7 @@ def test_init_uses_ctx_profile_when_flag_absent(tmp_path: pathlib.Path):
 def test_init_no_profile_writes_no_env(tmp_path: pathlib.Path):
     dest = tmp_path / "proj"
 
-    def fake_fetch(repo, ref, template_dir, target):
+    def fake_fetch(repo, ref, template_path, target):
         target.mkdir(parents=True)
         (target / ".env.example").write_text("DATABRICKS_CONFIG_PROFILE=DEFAULT\n")
 

--- a/integrations/mason/tests/unit_tests/init_test.py
+++ b/integrations/mason/tests/unit_tests/init_test.py
@@ -30,8 +30,7 @@ def test_framework_specs_have_repo_ref_path():
         assert spec["repo"] and spec["ref"] and spec["path"]
     assert init_mod._TEMPLATES["openai"]["path"] == "agent-openai-basic"
     assert (
-        init_mod._TEMPLATES["langgraph"]["path"]
-        == "integrations/mason/templates/agent-langgraph"
+        init_mod._TEMPLATES["langgraph"]["path"] == "integrations/mason/templates/agent-langgraph"
     )
 
 
@@ -43,9 +42,7 @@ def test_init_scaffolds_default_directory(tmp_path: pathlib.Path):
         (target / "app.yaml").write_text("command: []\n")
 
     with mock.patch.object(init_mod, "_fetch_template", side_effect=fake_fetch) as fetched:
-        result = CliRunner().invoke(
-            init_mod.init, ["--framework", "openai", str(dest)], obj=_Ctx()
-        )
+        result = CliRunner().invoke(init_mod.init, ["--framework", "openai", str(dest)], obj=_Ctx())
     assert result.exit_code == 0, result.output
     fetched.assert_called_once()
     # framework's repo + path passed through to the fetch
@@ -85,7 +82,15 @@ def test_init_repo_ref_override(tmp_path: pathlib.Path):
     with mock.patch.object(init_mod, "_fetch_template", side_effect=lambda *a: a[3].mkdir()) as f:
         result = CliRunner().invoke(
             init_mod.init,
-            ["--framework", "langgraph", "--repo", "https://example.com/fork.git", "--ref", "wip", str(dest)],
+            [
+                "--framework",
+                "langgraph",
+                "--repo",
+                "https://example.com/fork.git",
+                "--ref",
+                "wip",
+                str(dest),
+            ],
             obj=_Ctx(),
         )
     assert result.exit_code == 0, result.output
@@ -112,7 +117,8 @@ def test_init_refuses_existing_destination(tmp_path: pathlib.Path):
     with mock.patch.object(init_mod, "_fetch_template") as fetched:
         result = CliRunner().invoke(init_mod.init, [str(dest)], obj=_Ctx())
     assert result.exit_code != 0
-    assert "already exists" in result.output
+    # Rich may wrap the message across lines on a narrow terminal, so match whitespace-insensitively.
+    assert "already exists" in " ".join(result.output.split())
     fetched.assert_not_called()
 
 
@@ -148,9 +154,7 @@ def test_init_profile_flag_writes_env(tmp_path: pathlib.Path):
         (target / ".env.example").write_text("DATABRICKS_CONFIG_PROFILE=DEFAULT\n")
 
     with mock.patch.object(init_mod, "_fetch_template", side_effect=fake_fetch):
-        result = CliRunner().invoke(
-            init_mod.init, ["--profile", "ml", str(dest)], obj=_Ctx()
-        )
+        result = CliRunner().invoke(init_mod.init, ["--profile", "ml", str(dest)], obj=_Ctx())
     assert result.exit_code == 0, result.output
     assert "DATABRICKS_CONFIG_PROFILE=ml" in (dest / ".env").read_text()
 

--- a/integrations/mason/tests/unit_tests/init_test.py
+++ b/integrations/mason/tests/unit_tests/init_test.py
@@ -1,0 +1,96 @@
+"""Unit tests for `mason init`: template mapping, destination guard, scaffold flow.
+
+The network-touching git clone (`_fetch_template`) is mocked; tests assert the command wires
+framework -> template dir, refuses an existing destination, and reports the scaffolded path.
+"""
+
+from __future__ import annotations
+
+import json
+import pathlib
+from unittest import mock
+
+from click.testing import CliRunner
+
+from databricks_mason import init as init_mod
+from databricks_mason.errors import AgentCliError
+
+
+class _Ctx:
+    """Stand-in for CliContext: init reads only .output."""
+
+    def __init__(self, output: str = "text"):
+        self.output = output
+
+
+def test_framework_maps_to_template_dir():
+    assert init_mod._TEMPLATES["openai"] == "agent-openai-basic"
+    assert init_mod._TEMPLATES["langgraph"] == "agent-langgraph-basic"
+
+
+def test_init_scaffolds_default_directory(tmp_path: pathlib.Path):
+    dest = tmp_path / "agent-openai-basic"
+
+    def fake_fetch(repo, ref, template_dir, target):
+        target.mkdir(parents=True)
+        (target / "app.yaml").write_text("command: []\n")
+
+    with mock.patch.object(init_mod, "_fetch_template", side_effect=fake_fetch) as fetched:
+        result = CliRunner().invoke(
+            init_mod.init, ["--framework", "openai", str(dest)], obj=_Ctx()
+        )
+    assert result.exit_code == 0, result.output
+    fetched.assert_called_once()
+    # framework -> template dir passed through to the fetch
+    assert fetched.call_args.args[2] == "agent-openai-basic"
+    assert (dest / "app.yaml").exists()
+    assert "agent-openai-basic" in result.output
+
+
+def test_init_json_output(tmp_path: pathlib.Path):
+    dest = tmp_path / "proj"
+    with mock.patch.object(init_mod, "_fetch_template", side_effect=lambda *a: a[3].mkdir()):
+        result = CliRunner().invoke(
+            init_mod.init, ["--framework", "langgraph", str(dest)], obj=_Ctx(output="json")
+        )
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload["framework"] == "langgraph"
+    assert payload["template"] == "agent-langgraph-basic"
+    assert payload["directory"] == str(dest)
+
+
+def test_init_refuses_existing_destination(tmp_path: pathlib.Path):
+    dest = tmp_path / "exists"
+    dest.mkdir()
+    with mock.patch.object(init_mod, "_fetch_template") as fetched:
+        result = CliRunner().invoke(init_mod.init, [str(dest)], obj=_Ctx())
+    assert result.exit_code != 0
+    assert "already exists" in result.output
+    fetched.assert_not_called()
+
+
+def test_init_rejects_unknown_framework(tmp_path: pathlib.Path):
+    result = CliRunner().invoke(
+        init_mod.init, ["--framework", "nope", str(tmp_path / "x")], obj=_Ctx()
+    )
+    assert result.exit_code != 0  # click.Choice rejects it
+
+
+def test_fetch_template_missing_dir_raises(tmp_path: pathlib.Path):
+    """When the sparse checkout yields no template dir, a clean AgentCliError is raised."""
+
+    def fake_git(args, cwd=None):
+        # simulate clone creating an empty repo dir, sparse-checkout adding nothing
+        if args[0] == "clone":
+            pathlib.Path(args[-1]).mkdir(parents=True, exist_ok=True)
+        return mock.Mock(returncode=0)
+
+    with mock.patch.object(init_mod, "_git", side_effect=fake_git):
+        try:
+            init_mod._fetch_template("repo", "main", "agent-missing", tmp_path / "out")
+            raised = False
+        except AgentCliError as e:
+            raised = True
+            assert "not found" in str(e)
+    assert raised

--- a/integrations/mason/tests/unit_tests/init_test.py
+++ b/integrations/mason/tests/unit_tests/init_test.py
@@ -17,10 +17,11 @@ from databricks_mason.errors import AgentCliError
 
 
 class _Ctx:
-    """Stand-in for CliContext: init reads only .output."""
+    """Stand-in for CliContext: init reads .output and .profile."""
 
-    def __init__(self, output: str = "text"):
+    def __init__(self, output: str = "text", profile=None):
         self.output = output
+        self.profile = profile
 
 
 def test_framework_maps_to_template_dir():
@@ -75,6 +76,64 @@ def test_init_rejects_unknown_framework(tmp_path: pathlib.Path):
         init_mod.init, ["--framework", "nope", str(tmp_path / "x")], obj=_Ctx()
     )
     assert result.exit_code != 0  # click.Choice rejects it
+
+
+def test_write_env_seeds_profile_from_example(tmp_path: pathlib.Path):
+    (tmp_path / ".env.example").write_text(
+        "DATABRICKS_CONFIG_PROFILE=DEFAULT\n# MLFLOW_EXPERIMENT_ID=\n"
+    )
+    wrote = init_mod._write_env(tmp_path, "ml")
+    assert wrote is True
+    body = (tmp_path / ".env").read_text()
+    assert "DATABRICKS_CONFIG_PROFILE=ml" in body
+    assert "# MLFLOW_EXPERIMENT_ID=" in body  # rest of the example preserved
+
+
+def test_write_env_never_clobbers_existing(tmp_path: pathlib.Path):
+    (tmp_path / ".env").write_text("DATABRICKS_CONFIG_PROFILE=keepme\n")
+    assert init_mod._write_env(tmp_path, "ml") is False
+    assert "keepme" in (tmp_path / ".env").read_text()
+
+
+def test_init_profile_flag_writes_env(tmp_path: pathlib.Path):
+    dest = tmp_path / "proj"
+
+    def fake_fetch(repo, ref, template_dir, target):
+        target.mkdir(parents=True)
+        (target / ".env.example").write_text("DATABRICKS_CONFIG_PROFILE=DEFAULT\n")
+
+    with mock.patch.object(init_mod, "_fetch_template", side_effect=fake_fetch):
+        result = CliRunner().invoke(
+            init_mod.init, ["--profile", "ml", str(dest)], obj=_Ctx()
+        )
+    assert result.exit_code == 0, result.output
+    assert "DATABRICKS_CONFIG_PROFILE=ml" in (dest / ".env").read_text()
+
+
+def test_init_uses_ctx_profile_when_flag_absent(tmp_path: pathlib.Path):
+    dest = tmp_path / "proj"
+
+    def fake_fetch(repo, ref, template_dir, target):
+        target.mkdir(parents=True)
+        (target / ".env.example").write_text("DATABRICKS_CONFIG_PROFILE=DEFAULT\n")
+
+    with mock.patch.object(init_mod, "_fetch_template", side_effect=fake_fetch):
+        result = CliRunner().invoke(init_mod.init, [str(dest)], obj=_Ctx(profile="from-login"))
+    assert result.exit_code == 0, result.output
+    assert "DATABRICKS_CONFIG_PROFILE=from-login" in (dest / ".env").read_text()
+
+
+def test_init_no_profile_writes_no_env(tmp_path: pathlib.Path):
+    dest = tmp_path / "proj"
+
+    def fake_fetch(repo, ref, template_dir, target):
+        target.mkdir(parents=True)
+        (target / ".env.example").write_text("DATABRICKS_CONFIG_PROFILE=DEFAULT\n")
+
+    with mock.patch.object(init_mod, "_fetch_template", side_effect=fake_fetch):
+        result = CliRunner().invoke(init_mod.init, [str(dest)], obj=_Ctx())
+    assert result.exit_code == 0, result.output
+    assert not (dest / ".env").exists()  # no profile -> scaffold-only, no .env
 
 
 def test_fetch_template_missing_dir_raises(tmp_path: pathlib.Path):

--- a/integrations/mason/tests/unit_tests/store_access_test.py
+++ b/integrations/mason/tests/unit_tests/store_access_test.py
@@ -1,0 +1,89 @@
+"""Unit tests for the store-access grant plumbing (postgres resource + owner-issued psql GRANT)."""
+
+from __future__ import annotations
+
+import json
+import types
+
+from databricks_mason import memory_store_access, session_store_access
+from databricks_mason import store_access as sa
+
+
+def test_session_backend_targets_sessions_tables():
+    b = session_store_access.backend("my-store")
+    assert b.database == "my-store"
+    assert b.schema == "public"
+    assert b.tables == ("sessions", "session_items")
+    assert b.resource_name == "postgres"
+    assert b.database_path == (
+        "projects/databricks-internal-agent-session-store/branches/production/databases/my-store"
+    )
+
+
+def test_memory_backend_targets_memory_entries():
+    db = memory_store_access.database_from_backend_id(
+        "projects/databricks-internal-agent-memory-store/branches/production/databases/memory-abc"
+    )
+    assert db == "memory-abc"
+    b = memory_store_access.backend(db)
+    assert b.schema == "memory"
+    assert b.tables == ("memory_entries",)
+    assert b.resource_name == "postgres-memory"  # distinct name so both stores coexist on one app
+
+
+def test_apply_postgres_resources_sends_all_backends_in_one_update(monkeypatch):
+    captured = {}
+
+    def fake_db(args, profile, **kw):
+        captured["args"] = args
+        return types.SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(sa, "_databricks", fake_db)
+    backends = [session_store_access.backend("s"), memory_store_access.backend("memory-x")]
+    assert sa.apply_postgres_resources("app", backends, "prof") is None
+    payload = json.loads(captured["args"][captured["args"].index("--json") + 1])
+    names = {r["name"] for r in payload["resources"]}
+    assert names == {"postgres", "postgres-memory"}  # one update carries both
+
+
+def test_grant_tables_runs_scoped_psql_grant(monkeypatch):
+    monkeypatch.setattr(sa.shutil, "which", lambda _: "/usr/bin/psql")
+    monkeypatch.setattr(sa, "_resolve_pg_host", lambda b, p: "ep-x.databricks.com")
+    monkeypatch.setattr(sa, "_mint_token", lambda b, p: "tok")
+    captured = {}
+
+    def fake_run(cmd, env=None, **kw):
+        captured["cmd"] = cmd
+        captured["pgpassword"] = (env or {}).get("PGPASSWORD")
+        return types.SimpleNamespace(returncode=0, stdout="GRANT", stderr="")
+
+    monkeypatch.setattr(sa.subprocess, "run", fake_run)
+
+    err = sa.grant_tables(memory_store_access.backend("memory-x"), "sp-1", "me@x.com", "prof")
+
+    assert err is None
+    assert captured["cmd"][0] == "psql"
+    assert "dbname=memory-x" in captured["cmd"][1]  # connects to the per-store database
+    assert captured["pgpassword"] == "tok"
+    sql = captured["cmd"][-1]
+    # tables are schema-qualified so the SP's search_path doesn't matter.
+    assert 'ON memory.memory_entries TO "sp-1"' in sql
+    assert "USAGE ON SCHEMA memory" in sql
+
+
+def test_grant_tables_reports_missing_psql(monkeypatch):
+    monkeypatch.setattr(sa.shutil, "which", lambda _: None)
+    err = sa.grant_tables(session_store_access.backend("s"), "sp", "me@x.com", "prof")
+    assert err is not None and "psql" in err
+
+
+def test_resolve_pg_host_reads_endpoint(monkeypatch):
+    endpoint_json = json.dumps({"status": {"hosts": {"host": "ep-plain.databricks.com"}}})
+    monkeypatch.setattr(
+        sa,
+        "_databricks",
+        lambda args, profile, **kw: types.SimpleNamespace(
+            returncode=0, stdout=endpoint_json, stderr=""
+        ),
+    )
+    assert sa._resolve_pg_host(session_store_access.backend("s"), "prof") == "ep-plain.databricks.com"

--- a/integrations/mason/tests/unit_tests/store_access_test.py
+++ b/integrations/mason/tests/unit_tests/store_access_test.py
@@ -86,4 +86,6 @@ def test_resolve_pg_host_reads_endpoint(monkeypatch):
             returncode=0, stdout=endpoint_json, stderr=""
         ),
     )
-    assert sa._resolve_pg_host(session_store_access.backend("s"), "prof") == "ep-plain.databricks.com"
+    assert (
+        sa._resolve_pg_host(session_store_access.backend("s"), "prof") == "ep-plain.databricks.com"
+    )

--- a/integrations/mason/tests/unit_tests/tracing_test.py
+++ b/integrations/mason/tests/unit_tests/tracing_test.py
@@ -71,6 +71,33 @@ def test_split_destination_invalid_raises():
             pass
 
 
+def test_ensure_experiment_creates_parent_dir_for_nested_path():
+    from unittest import mock
+
+    mlflow = mock.Mock()
+    mlflow.get_experiment_by_name.return_value = None  # doesn't exist yet
+    mlflow.create_experiment.return_value = "eid-1"
+    client = mock.Mock()
+
+    eid = tracing_mod._ensure_experiment(mlflow, client, "/Users/me@x.com/mason-traces/demo")
+
+    assert eid == "eid-1"
+    # the intermediate workspace folder is created before the experiment (mlflow won't make it)
+    client.ensure_workspace_dir.assert_called_once_with("/Users/me@x.com/mason-traces")
+
+
+def test_ensure_experiment_reuses_existing_without_mkdir():
+    from unittest import mock
+
+    mlflow = mock.Mock()
+    mlflow.get_experiment_by_name.return_value = mock.Mock(experiment_id="eid-2")
+    client = mock.Mock()
+
+    assert tracing_mod._ensure_experiment(mlflow, client, "/Shared/x") == "eid-2"
+    client.ensure_workspace_dir.assert_not_called()  # existing experiment -> no dir work
+    mlflow.create_experiment.assert_not_called()
+
+
 def test_default_experiment_is_per_app_under_user_home():
     assert (
         tracing_mod.default_experiment("me@x.com", "my-agent")
@@ -92,7 +119,9 @@ def test_link_trace_location_reports_already_linked_without_relink():
         raise RuntimeError("experiment is already linked to a storage location")
 
     try:
-        tracing_mod._link_trace_location(set_location, lambda **k: None, object(), "e1", relink=False)
+        tracing_mod._link_trace_location(
+            set_location, lambda **k: None, object(), "e1", relink=False
+        )
         raise AssertionError("expected AgentCliError")
     except AgentCliError as exc:
         assert "--relink" in (exc.hint or "")
@@ -118,7 +147,9 @@ def test_link_trace_location_propagates_unrelated_errors():
         raise RuntimeError("permission denied on catalog")
 
     try:
-        tracing_mod._link_trace_location(set_location, lambda **k: None, object(), "e1", relink=True)
+        tracing_mod._link_trace_location(
+            set_location, lambda **k: None, object(), "e1", relink=True
+        )
         raise AssertionError("expected the original error")
     except RuntimeError as exc:
         assert "permission denied" in str(exc)  # not swallowed as an already-linked case

--- a/integrations/mason/tests/unit_tests/tracing_test.py
+++ b/integrations/mason/tests/unit_tests/tracing_test.py
@@ -71,6 +71,17 @@ def test_split_destination_invalid_raises():
             pass
 
 
+def test_default_experiment_is_per_app_under_user_home():
+    assert (
+        tracing_mod.default_experiment("me@x.com", "my-agent")
+        == "/Users/me@x.com/mason-traces/my-agent"
+    )
+
+
+def test_default_experiment_falls_back_to_shared_without_app():
+    assert tracing_mod.default_experiment("me@x.com", None) == tracing_mod._DEFAULT_EXPERIMENT
+
+
 def test_experiment_url_builds_traces_tab_link():
     url = tracing_mod._experiment_url("https://ws.databricks.com/", "123")
     assert url == "https://ws.databricks.com/ml/experiments/123?compareRunsMode=TRACES"

--- a/integrations/mason/tests/unit_tests/tracing_test.py
+++ b/integrations/mason/tests/unit_tests/tracing_test.py
@@ -71,6 +71,48 @@ def test_split_destination_invalid_raises():
             pass
 
 
+def test_experiment_url_builds_traces_tab_link():
+    url = tracing_mod._experiment_url("https://ws.databricks.com/", "123")
+    assert url == "https://ws.databricks.com/ml/experiments/123?compareRunsMode=TRACES"
+
+
+def test_link_trace_location_reports_already_linked_without_relink():
+    def set_location(location, experiment_id):
+        raise RuntimeError("experiment is already linked to a storage location")
+
+    try:
+        tracing_mod._link_trace_location(set_location, lambda **k: None, object(), "e1", relink=False)
+        raise AssertionError("expected AgentCliError")
+    except AgentCliError as exc:
+        assert "--relink" in (exc.hint or "")
+
+
+def test_link_trace_location_relinks_when_requested():
+    calls = []
+
+    def set_location(location, experiment_id):
+        calls.append("set")
+        if calls.count("set") == 1:  # first attempt fails as already-linked
+            raise RuntimeError("already linked")
+
+    def unset_location(location, experiment_id):
+        calls.append("unset")
+
+    tracing_mod._link_trace_location(set_location, unset_location, object(), "e1", relink=True)
+    assert calls == ["set", "unset", "set"]  # try, unset existing, re-link
+
+
+def test_link_trace_location_propagates_unrelated_errors():
+    def set_location(location, experiment_id):
+        raise RuntimeError("permission denied on catalog")
+
+    try:
+        tracing_mod._link_trace_location(set_location, lambda **k: None, object(), "e1", relink=True)
+        raise AssertionError("expected the original error")
+    except RuntimeError as exc:
+        assert "permission denied" in str(exc)  # not swallowed as an already-linked case
+
+
 def test_setup_requires_mlflow_when_absent():
     # mlflow is not on the hermetic test deptree, so setup should surface a clean CLI error
     # (non-zero exit) rather than a traceback.


### PR DESCRIPTION
Builds out the Mason CLI beyond the initial skeleton (#472) into the full local-to-deployed agent workflow: scaffold a template, run it locally, and deploy it with its stores wired up.

## `mason init`
Sparse-clones a basic template (`--framework openai|langgraph`) into a local directory, ready to run. `--repo`/`--ref` override the source so a template can be fetched from a fork/branch before it merges. `--profile` seeds a local `.env` (`DATABRICKS_CONFIG_PROFILE`) so the scaffolded project runs immediately; the profile/`.env` step is surfaced in Next steps when no profile is set.

## `mason dev`
Runs a scaffolded agent locally by wrapping `databricks apps run-local` — same `app.yaml` command + env as a deployment, so local behavior matches what ships. Builds the venv on first run and reuses it after (`--prepare-environment` forces a rebuild). Strips the deploy-only package-index env vars for the local build so it uses the machine's own index.

## `mason deploy` — store access
When a deployment uses a managed session or memory store, the app runs as its service principal while the store's Lakebase tables are owned by the deploying user, and the SP has no access by default. `deploy` now grants it automatically (best-effort, two steps):
1. binds each store's per-store database as a `postgres` app resource (Lakebase role + CONNECT, past the project ACL), then
2. issues an owner-scoped `psql` GRANT on the store's tables (`public.sessions`/`session_items` for sessions; `memory.memory_entries` for memory).

Both stores' resources go in a single `apps update` (it replaces the whole resource array). The store-agnostic mechanics live in `store_access.py` (`LakebaseBackend` + `apply_postgres_resources` + `grant_tables`); `session_store_access` / `memory_store_access` supply per-store specifics. `AGENT_MEMORY_STORE` carries the bare store id (the runtime re-adds the `memory-stores/` prefix).

## Templates
`--framework langgraph` points at the merged `integrations/mason/templates/agent-langgraph` template.

Tested: unit suite green; store grants verified end-to-end against a deployed app (remember/recall round-trips through the memory store, durable sessions across restart).