### PR TITLE
feat(mason): add downscoped sandbox command

### DIFF
--- a/integrations/mason/README.md
+++ b/integrations/mason/README.md
@@ -59,7 +59,38 @@ mason [-p <profile>] [-o text|json]
   tracing
     setup      --catalog C --schema S [--experiment E]
     list | get | instrument
+  add-sandbox  --scope SCOPE [--scope SCOPE ...]
+               [--permission read_only|read_write] [--source PATH]
   deploy       <name> --source PATH [--with-memory-store N]
                [--with-session-store N] [--with-traces C.S] [--create-stores]
   deployments  list | get | logs | start | stop | delete
 ```
+
+## Add a downscoped sandbox
+
+From a Mason agent project, add the `system.ai.sandbox` MCP server and fix its
+allowed resources at configuration time:
+
+```sh
+mason add-sandbox --scope catalog.schema.volume
+```
+
+The command updates `agent/mcps.py`. Every sandbox call carries the selected
+downscope in MCP `_meta`, outside the tool arguments controlled by the model.
+Scopes default to read-only access. Repeat `--scope` to allow more than one
+resource, use `/Workspace/...` for a workspace path, or prefix a table with
+`table:`:
+
+```sh
+mason add-sandbox \
+  --scope catalog.schema.volume \
+  --scope /Workspace/Users/alice@example.com \
+  --scope table:catalog.schema.table
+```
+
+Pass `--permission read_write` to grant write access to every supplied scope,
+or `--source /path/to/project` when running outside the project root. Re-running
+the command with the same policy leaves the existing configuration unchanged;
+a different policy fails without modifying the file so it cannot silently report
+stale access. Edit or remove the generated block before intentionally changing
+the sandbox policy.

--- a/integrations/mason/pyproject.toml
+++ b/integrations/mason/pyproject.toml
@@ -40,6 +40,7 @@ build-backend = "hatchling.build"
 [tool.hatch.build]
 include = [
     "src/databricks_mason/*",
+    "src/databricks_mason/templates/**",
 ]
 
 [tool.hatch.build.targets.wheel]

--- a/integrations/mason/src/databricks_mason/cli.py
+++ b/integrations/mason/src/databricks_mason/cli.py
@@ -14,6 +14,7 @@ from databricks_mason.auth import load_default_profile, login, logout
 from databricks_mason.client import AgentApiClient
 from databricks_mason.deploy import deploy, deployments
 from databricks_mason.memory import memory
+from databricks_mason.sandbox import add_sandbox
 from databricks_mason.sessions import sessions
 from databricks_mason.tracing import tracing
 
@@ -62,6 +63,7 @@ mason.add_command(sessions)
 mason.add_command(tracing)
 mason.add_command(deploy)
 mason.add_command(deployments)
+mason.add_command(add_sandbox)
 
 
 def main() -> None:

--- a/integrations/mason/src/databricks_mason/sandbox.py
+++ b/integrations/mason/src/databricks_mason/sandbox.py
@@ -1,0 +1,581 @@
+"""``mason add-sandbox`` — attach a downscoped ``system.ai.sandbox`` MCP server."""
+
+from __future__ import annotations
+
+import ast
+import json
+import pathlib
+import stat
+import tempfile
+import textwrap
+from collections.abc import Sequence
+
+import click
+
+from databricks_mason import render
+from databricks_mason.errors import AgentCliError
+
+_BEGIN_MARKER = "# BEGIN: mason add-sandbox"
+_END_MARKER = "# END: mason add-sandbox"
+_SERVER_FACTORY = "_build_sandbox_mcp_server()"
+
+_GENERATED_TYPING_IMPORT = "from typing import Any"
+_GENERATED_MCP_IMPORT = "from databricks_openai.agents import McpServer"
+
+
+def _validate_uc_name(value: str, resource_type: str) -> str:
+    if (
+        len(value.split(".")) != 3
+        or any(not part for part in value.split("."))
+        or any(character.isspace() for character in value)
+    ):
+        raise AgentCliError(
+            f"Invalid {resource_type} scope '{value}'.",
+            hint=f"Use a three-part Unity Catalog name: catalog.schema.{resource_type}.",
+        )
+    return value
+
+
+def _parse_scopes(scopes: Sequence[str], permission: str) -> dict[str, list[dict[str, str]]]:
+    """Convert CLI scope values to the MCP ``_meta.downscope`` wire shape."""
+    parsed: dict[str, list[dict[str, str]]] = {
+        "volumes": [],
+        "tables": [],
+        "workspace_paths": [],
+    }
+    seen: set[tuple[str, str]] = set()
+
+    for original in scopes:
+        value = original.strip()
+        if not value:
+            raise AgentCliError("Sandbox scopes cannot be empty.")
+
+        prefix, separator, remainder = value.partition(":")
+        explicit_type = prefix if separator and prefix in {"volume", "table", "workspace"} else None
+        if explicit_type:
+            value = remainder.strip()
+
+        if explicit_type == "workspace" or (
+            explicit_type is None and value.startswith("/Workspace/")
+        ):
+            if not value.startswith("/Workspace/") or any(
+                character in value for character in ("\r", "\n", "\t")
+            ):
+                raise AgentCliError(
+                    f"Invalid workspace scope '{value}'.",
+                    hint="Workspace paths must begin with /Workspace/ and cannot contain tabs or newlines.",
+                )
+            key, field = "workspace_paths", "path"
+        else:
+            resource_type = explicit_type or "volume"
+            if resource_type == "workspace":  # Handled above; keeps the type narrow below.
+                raise AssertionError("unreachable")
+            value = _validate_uc_name(value, resource_type)
+            key, field = ("tables", "name") if resource_type == "table" else ("volumes", "name")
+
+        identity = (key, value)
+        if identity not in seen:
+            parsed[key].append({field: value, "permission": permission})
+            seen.add(identity)
+
+    return {key: values for key, values in parsed.items() if values}
+
+
+def _offset(lines: list[str], line: int, column: int) -> int:
+    try:
+        line_prefix = lines[line - 1].encode("utf-8")[:column].decode("utf-8")
+    except (IndexError, UnicodeDecodeError) as exc:
+        raise AgentCliError(
+            "Could not locate the generated Python syntax in agent/mcps.py."
+        ) from exc
+    return sum(len(part) for part in lines[: line - 1]) + len(line_prefix)
+
+
+def _end_position(node: ast.expr | ast.stmt) -> tuple[int, int]:
+    line = node.end_lineno
+    column = node.end_col_offset
+    if line is None or column is None:
+        raise AgentCliError("Could not locate the generated Python syntax in agent/mcps.py.")
+    return line, column
+
+
+def _find_server_list(tree: ast.Module) -> tuple[ast.FunctionDef, ast.List]:
+    functions = [
+        node
+        for node in tree.body
+        if isinstance(node, ast.FunctionDef) and node.name == "build_mcp_servers"
+    ]
+    if len(functions) != 1:
+        raise AgentCliError(
+            "Could not find one build_mcp_servers() function in agent/mcps.py.",
+            hint="Run this command from a Mason agent project generated from a supported template.",
+        )
+
+    direct_returns = [node for node in functions[0].body if isinstance(node, ast.Return)]
+    all_returns = [node for node in ast.walk(functions[0]) if isinstance(node, ast.Return)]
+    if (
+        len(direct_returns) != 1
+        or len(all_returns) != 1
+        or not isinstance(direct_returns[0].value, ast.List)
+    ):
+        raise AgentCliError(
+            "build_mcp_servers() must directly return a list before Mason can add the sandbox.",
+            hint="Change the function to `return [...]`, then retry.",
+        )
+    return functions[0], direct_returns[0].value
+
+
+def _append_server_to_list(source: str) -> str:
+    """Append the generated server factory while preserving the rest of ``mcps.py``."""
+    try:
+        tree = ast.parse(source)
+    except SyntaxError as exc:
+        raise AgentCliError(
+            f"Could not parse agent/mcps.py: {exc.msg} (line {exc.lineno})."
+        ) from exc
+
+    function, server_list = _find_server_list(tree)
+    lines = source.splitlines(keepends=True)
+    start = _offset(lines, server_list.lineno, server_list.col_offset)
+    list_end_line, list_end_column = _end_position(server_list)
+    end = _offset(lines, list_end_line, list_end_column)
+    item_indent = " " * (function.col_offset + 8)
+    closing_indent = " " * (function.col_offset + 4)
+
+    if not server_list.elts:
+        replacement = f"[\n{item_indent}{_SERVER_FACTORY},\n{closing_indent}]"
+        return source[:start] + replacement + source[end:]
+
+    if server_list.lineno == server_list.end_lineno:
+        existing = []
+        for element in server_list.elts:
+            segment = ast.get_source_segment(source, element)
+            if segment is None:
+                raise AgentCliError("Could not preserve the existing MCP server list.")
+            existing.append(textwrap.indent(textwrap.dedent(segment), item_indent))
+        replacement = (
+            "[\n" + ",\n".join(existing) + f",\n{item_indent}{_SERVER_FACTORY},\n{closing_indent}]"
+        )
+        return source[:start] + replacement + source[end:]
+
+    closing_line_start = _offset(lines, list_end_line, 0)
+    closing_prefix = source[closing_line_start : end - 1]
+    if closing_prefix.strip():
+        raise AgentCliError(
+            "The closing bracket of build_mcp_servers() must be on its own line.",
+            hint="Format the returned list as a standard multi-line Python list, then retry.",
+        )
+
+    last = server_list.elts[-1]
+    last_end_line, last_end_column = _end_position(last)
+    last_end = _offset(lines, last_end_line, last_end_column)
+    suffix = source[last_end:closing_line_start]
+    comma = "" if suffix.lstrip().startswith(",") else ","
+    with_item = (
+        source[:last_end]
+        + comma
+        + source[last_end:closing_line_start]
+        + f"{item_indent}{_SERVER_FACTORY},\n"
+        + source[closing_line_start:]
+    )
+    return with_item
+
+
+def _insert_imports(source: str) -> str:
+    tree = ast.parse(source)
+    lines = source.splitlines(keepends=True)
+
+    def has_from_import(module: str, name: str) -> bool:
+        return any(
+            isinstance(node, ast.ImportFrom)
+            and node.module == module
+            and any((alias.asname or alias.name) == name for alias in node.names)
+            for node in tree.body
+        )
+
+    protocol_imports = [
+        node
+        for node in tree.body
+        if isinstance(node, ast.ImportFrom)
+        and node.module == "agents.mcp"
+        and any((alias.asname or alias.name) == "MCPServer" for alias in node.names)
+    ]
+    if len(protocol_imports) != 1:
+        raise AgentCliError(
+            "agent/mcps.py must import MCPServer from agents.mcp before Mason can add the sandbox.",
+            hint="Start from the Mason agent template, then retry.",
+        )
+
+    insert_after: ast.stmt | None = None
+    if (
+        tree.body
+        and isinstance(tree.body[0], ast.Expr)
+        and isinstance(tree.body[0].value, ast.Constant)
+        and isinstance(tree.body[0].value.value, str)
+    ):
+        insert_after = tree.body[0]
+
+    for node in tree.body:
+        if isinstance(node, ast.ImportFrom) and node.module == "__future__":
+            insert_after = node
+        elif node is not insert_after and not (
+            isinstance(node, ast.Expr)
+            and isinstance(node.value, ast.Constant)
+            and isinstance(node.value.value, str)
+        ):
+            break
+
+    with_mcp_import = source
+    if not has_from_import("databricks_openai.agents", "McpServer"):
+        import_end_line, import_end_column = _end_position(protocol_imports[0])
+        import_end = _offset(lines, import_end_line, import_end_column)
+        with_mcp_import = source[:import_end] + "\n" + _GENERATED_MCP_IMPORT + source[import_end:]
+
+    if has_from_import("typing", "Any"):
+        return with_mcp_import
+
+    if insert_after is not None:
+        end_line, end_column = _end_position(insert_after)
+        insert_at = _offset(lines, end_line, end_column)
+        following = with_mcp_import[insert_at:].lstrip("\n")
+        return with_mcp_import[:insert_at] + "\n\n" + _GENERATED_TYPING_IMPORT + "\n\n" + following
+    return _GENERATED_TYPING_IMPORT + "\n\n" + with_mcp_import.lstrip("\n")
+
+
+def _format_policy(policy: dict[str, list[dict[str, str]]]) -> str:
+    lines = ["_SANDBOX_DOWNSCOPE: dict[str, list[dict[str, str]]] = {"]
+    for key, values in policy.items():
+        lines.append(f'    "{key}": [')
+        for value in values:
+            fields = ", ".join(f"{json.dumps(k)}: {json.dumps(v)}" for k, v in value.items())
+            lines.append(f"        {{{fields}}},")
+        lines.append("    ],")
+    lines.append("}")
+    return "\n".join(lines)
+
+
+def _existing_policy(source: str) -> dict[str, list[dict[str, str]]] | None:
+    begin_count = source.count(_BEGIN_MARKER)
+    end_count = source.count(_END_MARKER)
+    if begin_count == 0 and end_count == 0:
+        return None
+    if (
+        begin_count != 1
+        or end_count != 1
+        or source.index(_BEGIN_MARKER) > source.index(_END_MARKER)
+    ):
+        raise AgentCliError(
+            "The existing mason add-sandbox block has invalid markers.",
+            hint="Repair or remove the generated block in agent/mcps.py, then retry.",
+        )
+
+    try:
+        tree = ast.parse(source)
+    except SyntaxError as exc:
+        raise AgentCliError(
+            f"Could not parse agent/mcps.py: {exc.msg} (line {exc.lineno})."
+        ) from exc
+
+    _, server_list = _find_server_list(tree)
+    sandbox_classes = [
+        node
+        for node in tree.body
+        if isinstance(node, ast.ClassDef) and node.name == "_SandboxMcpServer"
+    ]
+    factory_functions = [
+        node
+        for node in tree.body
+        if isinstance(node, ast.FunctionDef) and node.name == "_build_sandbox_mcp_server"
+    ]
+    assignments = [
+        node
+        for node in tree.body
+        if isinstance(node, ast.AnnAssign)
+        and isinstance(node.target, ast.Name)
+        and node.target.id == "_SANDBOX_DOWNSCOPE"
+        and node.value is not None
+    ]
+    if len(assignments) != 1:
+        raise AgentCliError(
+            "The existing mason add-sandbox block is incomplete.",
+            hint="Repair or remove the generated block in agent/mcps.py, then retry.",
+        )
+
+    assignment_value = assignments[0].value
+    if assignment_value is None:
+        raise AgentCliError("The existing sandbox downscope has no policy value.")
+    try:
+        raw_policy = ast.literal_eval(assignment_value)
+    except (ValueError, TypeError, SyntaxError) as exc:
+        raise AgentCliError(
+            "The existing sandbox downscope is not a fixed literal policy.",
+            hint="Repair or remove the generated block in agent/mcps.py, then retry.",
+        ) from exc
+
+    if not isinstance(raw_policy, dict):
+        raise AgentCliError("The existing sandbox downscope is not a valid policy object.")
+
+    policy: dict[str, list[dict[str, str]]] = {}
+    for key, entries in raw_policy.items():
+        if not isinstance(key, str) or not isinstance(entries, list):
+            raise AgentCliError("The existing sandbox downscope has an invalid resource list.")
+        parsed_entries: list[dict[str, str]] = []
+        for entry in entries:
+            if not isinstance(entry, dict) or not all(
+                isinstance(field, str) and isinstance(value, str) for field, value in entry.items()
+            ):
+                raise AgentCliError("The existing sandbox downscope has an invalid resource entry.")
+            parsed_entries.append(entry)
+        policy[key] = parsed_entries
+
+    expected_fields = {
+        "volumes": "name",
+        "tables": "name",
+        "workspace_paths": "path",
+    }
+    if not policy or any(key not in expected_fields for key in policy):
+        raise AgentCliError("The existing sandbox downscope has an invalid resource type.")
+    for resource_type, entries in policy.items():
+        expected_field = expected_fields[resource_type]
+        if not entries:
+            raise AgentCliError("The existing sandbox downscope has an empty resource list.")
+        for entry in entries:
+            if set(entry) != {expected_field, "permission"}:
+                raise AgentCliError("The existing sandbox downscope has an invalid resource entry.")
+            if entry["permission"] not in {"read_only", "read_write"}:
+                raise AgentCliError("The existing sandbox downscope has an invalid permission.")
+            if resource_type == "workspace_paths":
+                path = entry[expected_field]
+                if not path.startswith("/Workspace/") or any(
+                    character in path for character in ("\r", "\n", "\t")
+                ):
+                    raise AgentCliError(
+                        "The existing sandbox downscope has an invalid workspace path."
+                    )
+            else:
+                _validate_uc_name(entry[expected_field], resource_type.removesuffix("s"))
+
+    begin_line = source[: source.index(_BEGIN_MARKER)].count("\n") + 1
+    end_line = source[: source.index(_END_MARKER)].count("\n") + 1
+
+    def inside_markers(node: ast.expr | ast.stmt) -> bool:
+        node_end_line, _ = _end_position(node)
+        return begin_line < node.lineno and node_end_line < end_line
+
+    if (
+        len(sandbox_classes) != 1
+        or len(factory_functions) != 1
+        or not inside_markers(assignments[0])
+        or not inside_markers(sandbox_classes[0])
+        or not inside_markers(factory_functions[0])
+    ):
+        raise AgentCliError(
+            "The existing mason add-sandbox block is incomplete.",
+            hint="Repair or remove the generated block in agent/mcps.py, then retry.",
+        )
+
+    expected_tree = ast.parse(_generated_block(policy))
+    expected_assignment = next(
+        node for node in expected_tree.body if isinstance(node, ast.AnnAssign)
+    )
+    expected_class = next(node for node in expected_tree.body if isinstance(node, ast.ClassDef))
+    expected_factory = next(
+        node
+        for node in expected_tree.body
+        if isinstance(node, ast.FunctionDef) and node.name == "_build_sandbox_mcp_server"
+    )
+    for actual, expected in (
+        (assignments[0], expected_assignment),
+        (sandbox_classes[0], expected_class),
+        (factory_functions[0], expected_factory),
+    ):
+        if ast.dump(actual, include_attributes=False) != ast.dump(
+            expected, include_attributes=False
+        ):
+            raise AgentCliError(
+                "The existing mason add-sandbox block does not match the generated security wrapper.",
+                hint="Repair or remove the generated block in agent/mcps.py, then retry.",
+            )
+
+    factory_calls = [
+        element
+        for element in server_list.elts
+        if isinstance(element, ast.Call)
+        and isinstance(element.func, ast.Name)
+        and element.func.id == "_build_sandbox_mcp_server"
+    ]
+    if len(factory_calls) != 1 or factory_calls[0].args or factory_calls[0].keywords:
+        raise AgentCliError(
+            "build_mcp_servers() must register exactly one generated sandbox server.",
+            hint="Repair the generated factory entry in agent/mcps.py, then retry.",
+        )
+    return policy
+
+
+def _policy_signature(
+    policy: dict[str, list[dict[str, str]]],
+) -> frozenset[tuple[str, str, str]]:
+    return frozenset(
+        (resource_type, entry.get("name", entry.get("path", "")), entry.get("permission", ""))
+        for resource_type, entries in policy.items()
+        for entry in entries
+    )
+
+
+def _policy_cli_values(
+    policy: dict[str, list[dict[str, str]]],
+) -> tuple[list[str], str]:
+    scopes: list[str] = []
+    permissions: set[str] = set()
+    for resource_type, entries in policy.items():
+        for entry in entries:
+            value = entry.get("path") or entry.get("name", "")
+            scopes.append(f"table:{value}" if resource_type == "tables" else value)
+            permissions.add(entry.get("permission", ""))
+    if len(permissions) != 1:
+        raise AgentCliError("The existing sandbox downscope has inconsistent permissions.")
+    return scopes, permissions.pop()
+
+
+def _write_text_atomic(target: pathlib.Path, content: str) -> None:
+    temporary: pathlib.Path | None = None
+    try:
+        mode = stat.S_IMODE(target.stat().st_mode)
+        with tempfile.NamedTemporaryFile(
+            "w",
+            encoding="utf-8",
+            dir=target.parent,
+            prefix=f".{target.name}.",
+            delete=False,
+        ) as output:
+            temporary = pathlib.Path(output.name)
+            output.write(content)
+        temporary.chmod(mode)
+        temporary.replace(target)
+        temporary = None
+    except OSError as exc:
+        raise AgentCliError(f"Could not update {target}: {exc}.") from exc
+    finally:
+        if temporary is not None:
+            try:
+                temporary.unlink(missing_ok=True)
+            except OSError:
+                pass
+
+
+def _generated_block(policy: dict[str, list[dict[str, str]]]) -> str:
+    return f"""{_BEGIN_MARKER}
+# The downscope is fixed when this file is generated. It is sent as MCP metadata,
+# outside model-controlled tool arguments, on every sandbox call.
+{_format_policy(policy)}
+
+
+class _SandboxMcpServer(McpServer):
+    async def call_tool(
+        self,
+        tool_name: str,
+        arguments: dict[str, Any] | None,
+        **kwargs: Any,
+    ) -> Any:
+        incoming_meta = kwargs.pop("meta", None)
+        meta = dict(incoming_meta) if isinstance(incoming_meta, dict) else {{}}
+        meta["downscope"] = _SANDBOX_DOWNSCOPE
+        return await super().call_tool(tool_name, arguments, meta=meta, **kwargs)
+
+
+def {_SERVER_FACTORY} -> McpServer:
+    return _SandboxMcpServer.from_uc_function(
+        catalog="system",
+        schema="ai",
+        function_name="sandbox",
+        name="system.ai.sandbox",
+    )
+
+
+{_END_MARKER}
+"""
+
+
+def _add_sandbox_to_source(source: str, policy: dict[str, list[dict[str, str]]]) -> str:
+    with_server = _append_server_to_list(source)
+    with_imports = _insert_imports(with_server)
+    generated = with_imports.rstrip() + "\n\n\n" + _generated_block(policy)
+    try:
+        ast.parse(generated)
+    except SyntaxError as exc:
+        raise AgentCliError(
+            f"Refusing to write invalid generated Python: {exc.msg} (line {exc.lineno})."
+        ) from exc
+    return generated
+
+
+@click.command("add-sandbox")
+@click.option(
+    "--scope",
+    "scopes",
+    multiple=True,
+    required=True,
+    help=(
+        "Allowed volume (catalog.schema.volume) or /Workspace/ path. Repeat for multiple scopes; "
+        "use table:catalog.schema.table for a table."
+    ),
+)
+@click.option(
+    "--permission",
+    type=click.Choice(["read_only", "read_write"]),
+    default="read_only",
+    show_default=True,
+)
+@click.option(
+    "--source",
+    type=click.Path(exists=True, file_okay=False, path_type=pathlib.Path),
+    default=pathlib.Path("."),
+    show_default=True,
+    help="Mason agent project containing agent/mcps.py.",
+)
+@click.pass_obj
+def add_sandbox(obj, scopes: tuple[str, ...], permission: str, source: pathlib.Path) -> None:
+    """Add the system.ai.sandbox MCP with a fixed downscope to an agent project."""
+    policy = _parse_scopes(scopes, permission)
+    target = source.resolve() / "agent" / "mcps.py"
+    if not target.is_file():
+        raise AgentCliError(
+            f"Could not find {target}.",
+            hint="Pass --source pointing to a Mason agent project containing agent/mcps.py.",
+        )
+
+    try:
+        current = target.read_text(encoding="utf-8")
+    except (OSError, UnicodeError) as exc:
+        raise AgentCliError(f"Could not read {target}: {exc}.") from exc
+
+    existing_policy = _existing_policy(current)
+    if existing_policy is not None and _policy_signature(existing_policy) != _policy_signature(
+        policy
+    ):
+        raise AgentCliError(
+            "system.ai.sandbox is already configured with a different downscope.",
+            hint="Edit or remove the generated add-sandbox block in agent/mcps.py before changing scopes.",
+        )
+
+    changed = existing_policy is None
+    if changed:
+        _write_text_atomic(target, _add_sandbox_to_source(current, policy))
+
+    effective_policy = existing_policy or policy
+    effective_scopes, effective_permission = _policy_cli_values(effective_policy)
+
+    status = "added" if changed else "already_configured"
+    result = {
+        "mcp_server": "system.ai.sandbox",
+        "path": str(target),
+        "permission": effective_permission,
+        "scopes": effective_scopes,
+        "status": status,
+    }
+    if getattr(obj, "output", "text") == "json":
+        render.emit_json(result)
+    elif changed:
+        click.echo(f"Added system.ai.sandbox with fixed downscoping to {target}")
+    else:
+        click.echo(f"system.ai.sandbox is already configured in {target}")

--- a/integrations/mason/src/databricks_mason/sandbox.py
+++ b/integrations/mason/src/databricks_mason/sandbox.py
@@ -487,8 +487,8 @@ def {_SERVER_FACTORY} -> McpServer:
     return _SandboxMcpServer.from_uc_function(
         catalog="system",
         schema="ai",
-        function_name="sandbox",
         name="system.ai.sandbox",
+        tool_filter={{"allowed_tool_names": ["sandbox"]}},
     )
 
 

--- a/integrations/mason/src/databricks_mason/sandbox.py
+++ b/integrations/mason/src/databricks_mason/sandbox.py
@@ -9,6 +9,7 @@ import stat
 import tempfile
 import textwrap
 from collections.abc import Sequence
+from importlib import resources
 
 import click
 
@@ -17,7 +18,9 @@ from databricks_mason.errors import AgentCliError
 
 _BEGIN_MARKER = "# BEGIN: mason add-sandbox"
 _END_MARKER = "# END: mason add-sandbox"
-_SERVER_FACTORY = "_build_sandbox_mcp_server()"
+_DOWNSCOPE_PLACEHOLDER = "# __MASON_SANDBOX_DOWNSCOPE__"
+_SERVER_FACTORY_CALL = "_build_sandbox_mcp_server()"
+_TEMPLATE_NAME = "sandbox_mcp.py.tmpl"
 
 _GENERATED_TYPING_IMPORT = "from typing import Any"
 _GENERATED_MCP_IMPORT = "from databricks_openai.agents import McpServer"
@@ -144,7 +147,7 @@ def _append_server_to_list(source: str) -> str:
     closing_indent = " " * (function.col_offset + 4)
 
     if not server_list.elts:
-        replacement = f"[\n{item_indent}{_SERVER_FACTORY},\n{closing_indent}]"
+        replacement = f"[\n{item_indent}{_SERVER_FACTORY_CALL},\n{closing_indent}]"
         return source[:start] + replacement + source[end:]
 
     if server_list.lineno == server_list.end_lineno:
@@ -155,7 +158,9 @@ def _append_server_to_list(source: str) -> str:
                 raise AgentCliError("Could not preserve the existing MCP server list.")
             existing.append(textwrap.indent(textwrap.dedent(segment), item_indent))
         replacement = (
-            "[\n" + ",\n".join(existing) + f",\n{item_indent}{_SERVER_FACTORY},\n{closing_indent}]"
+            "[\n"
+            + ",\n".join(existing)
+            + f",\n{item_indent}{_SERVER_FACTORY_CALL},\n{closing_indent}]"
         )
         return source[:start] + replacement + source[end:]
 
@@ -176,7 +181,7 @@ def _append_server_to_list(source: str) -> str:
         source[:last_end]
         + comma
         + source[last_end:closing_line_start]
-        + f"{item_indent}{_SERVER_FACTORY},\n"
+        + f"{item_indent}{_SERVER_FACTORY_CALL},\n"
         + source[closing_line_start:]
     )
     return with_item
@@ -479,41 +484,18 @@ def _write_text_atomic(target: pathlib.Path, content: str) -> None:
 
 
 def _generated_block(policy: dict[str, list[dict[str, str]]]) -> str:
-    return f"""{_BEGIN_MARKER}
-# The downscope is fixed when this file is generated. It is sent as MCP metadata,
-# outside model-controlled tool arguments, on every sandbox call.
-{_format_policy(policy)}
-
-
-class _SandboxMcpServer(McpServer):
-    async def call_tool(
-        self,
-        tool_name: str,
-        arguments: dict[str, Any] | None,
-        **kwargs: Any,
-    ) -> Any:
-        incoming_meta = kwargs.pop("meta", None)
-        meta = dict(incoming_meta) if isinstance(incoming_meta, dict) else {{}}
-        meta["downscope"] = _SANDBOX_DOWNSCOPE
-        return await super().call_tool(tool_name, arguments, meta=meta, **kwargs)
-
-
-def {_SERVER_FACTORY} -> McpServer:
-    workspace_client = WorkspaceClient()
-    return _SandboxMcpServer(
-        url=(
-            f"{{workspace_client.config.host.rstrip('/')}}"
-            "/ai-gateway/mcp-services/system.ai.sandbox"
-        ),
-        workspace_client=workspace_client,
-        timeout=120.0,
-        name="system.ai.sandbox",
-        tool_filter={{"allowed_tool_names": ["run_code"]}},
-    )
-
-
-{_END_MARKER}
-"""
+    try:
+        template = (
+            resources.files("databricks_mason")
+            .joinpath("templates")
+            .joinpath(_TEMPLATE_NAME)
+            .read_text(encoding="utf-8")
+        )
+    except (OSError, UnicodeError) as exc:
+        raise AgentCliError("Could not read the packaged sandbox MCP template.") from exc
+    if template.count(_DOWNSCOPE_PLACEHOLDER) != 1:
+        raise AgentCliError("The packaged sandbox MCP template is invalid.")
+    return template.replace(_DOWNSCOPE_PLACEHOLDER, _format_policy(policy))
 
 
 def _add_sandbox_to_source(source: str, policy: dict[str, list[dict[str, str]]]) -> str:

--- a/integrations/mason/src/databricks_mason/sandbox.py
+++ b/integrations/mason/src/databricks_mason/sandbox.py
@@ -21,6 +21,7 @@ _SERVER_FACTORY = "_build_sandbox_mcp_server()"
 
 _GENERATED_TYPING_IMPORT = "from typing import Any"
 _GENERATED_MCP_IMPORT = "from databricks_openai.agents import McpServer"
+_GENERATED_WORKSPACE_CLIENT_IMPORT = "from databricks.sdk import WorkspaceClient"
 
 
 def _validate_uc_name(value: str, resource_type: str) -> str:
@@ -225,21 +226,35 @@ def _insert_imports(source: str) -> str:
         ):
             break
 
-    with_mcp_import = source
+    missing_imports: list[str] = []
     if not has_from_import("databricks_openai.agents", "McpServer"):
+        missing_imports.append(_GENERATED_MCP_IMPORT)
+    if not has_from_import("databricks.sdk", "WorkspaceClient"):
+        missing_imports.append(_GENERATED_WORKSPACE_CLIENT_IMPORT)
+
+    with_runtime_imports = source
+    if missing_imports:
         import_end_line, import_end_column = _end_position(protocol_imports[0])
         import_end = _offset(lines, import_end_line, import_end_column)
-        with_mcp_import = source[:import_end] + "\n" + _GENERATED_MCP_IMPORT + source[import_end:]
+        with_runtime_imports = (
+            source[:import_end] + "\n" + "\n".join(missing_imports) + source[import_end:]
+        )
 
     if has_from_import("typing", "Any"):
-        return with_mcp_import
+        return with_runtime_imports
 
     if insert_after is not None:
         end_line, end_column = _end_position(insert_after)
         insert_at = _offset(lines, end_line, end_column)
-        following = with_mcp_import[insert_at:].lstrip("\n")
-        return with_mcp_import[:insert_at] + "\n\n" + _GENERATED_TYPING_IMPORT + "\n\n" + following
-    return _GENERATED_TYPING_IMPORT + "\n\n" + with_mcp_import.lstrip("\n")
+        following = with_runtime_imports[insert_at:].lstrip("\n")
+        return (
+            with_runtime_imports[:insert_at]
+            + "\n\n"
+            + _GENERATED_TYPING_IMPORT
+            + "\n\n"
+            + following
+        )
+    return _GENERATED_TYPING_IMPORT + "\n\n" + with_runtime_imports.lstrip("\n")
 
 
 def _format_policy(policy: dict[str, list[dict[str, str]]]) -> str:
@@ -484,11 +499,16 @@ class _SandboxMcpServer(McpServer):
 
 
 def {_SERVER_FACTORY} -> McpServer:
-    return _SandboxMcpServer.from_uc_function(
-        catalog="system",
-        schema="ai",
+    workspace_client = WorkspaceClient()
+    return _SandboxMcpServer(
+        url=(
+            f"{{workspace_client.config.host.rstrip('/')}}"
+            "/ai-gateway/mcp-services/system.ai.sandbox"
+        ),
+        workspace_client=workspace_client,
+        timeout=120.0,
         name="system.ai.sandbox",
-        tool_filter={{"allowed_tool_names": ["sandbox"]}},
+        tool_filter={{"allowed_tool_names": ["run_code"]}},
     )
 
 

--- a/integrations/mason/src/databricks_mason/sandbox.py
+++ b/integrations/mason/src/databricks_mason/sandbox.py
@@ -20,11 +20,7 @@ _BEGIN_MARKER = "# BEGIN: mason add-sandbox"
 _END_MARKER = "# END: mason add-sandbox"
 _DOWNSCOPE_PLACEHOLDER = "# __MASON_SANDBOX_DOWNSCOPE__"
 _SERVER_FACTORY_CALL = "_build_sandbox_mcp_server()"
-_TEMPLATE_NAME = "sandbox_mcp.py.tmpl"
-
-_GENERATED_TYPING_IMPORT = "from typing import Any"
-_GENERATED_MCP_IMPORT = "from databricks_openai.agents import McpServer"
-_GENERATED_WORKSPACE_CLIENT_IMPORT = "from databricks.sdk import WorkspaceClient"
+_TEMPLATE_NAME = "sandbox_mcp.py"
 
 
 def _validate_uc_name(value: str, resource_type: str) -> str:
@@ -187,8 +183,24 @@ def _append_server_to_list(source: str) -> str:
     return with_item
 
 
-def _insert_imports(source: str) -> str:
+def _read_template() -> str:
+    try:
+        return (
+            resources.files("databricks_mason")
+            .joinpath("templates")
+            .joinpath(_TEMPLATE_NAME)
+            .read_text(encoding="utf-8")
+        )
+    except (OSError, UnicodeError) as exc:
+        raise AgentCliError("Could not read the packaged sandbox MCP template.") from exc
+
+
+def _insert_imports(source: str, template: str) -> str:
     tree = ast.parse(source)
+    try:
+        template_tree = ast.parse(template)
+    except SyntaxError as exc:
+        raise AgentCliError("The packaged sandbox MCP template is invalid.") from exc
     lines = source.splitlines(keepends=True)
 
     def has_from_import(module: str, name: str) -> bool:
@@ -198,6 +210,29 @@ def _insert_imports(source: str) -> str:
             and any((alias.asname or alias.name) == name for alias in node.names)
             for node in tree.body
         )
+
+    template_imports = [
+        node
+        for node in template_tree.body
+        if isinstance(node, ast.ImportFrom) and node.module is not None
+    ]
+    if not template_imports or any(
+        node.level != 0 or len(node.names) != 1 or node.names[0].asname is not None
+        for node in template_imports
+    ):
+        raise AgentCliError("The packaged sandbox MCP template has invalid imports.")
+
+    missing_imports: list[tuple[str, str]] = []
+    for node in template_imports:
+        module = node.module
+        if module is None:
+            raise AgentCliError("The packaged sandbox MCP template has invalid imports.")
+        alias = node.names[0]
+        if not has_from_import(module, alias.name):
+            segment = ast.get_source_segment(template, node)
+            if segment is None:
+                raise AgentCliError("The packaged sandbox MCP template has invalid imports.")
+            missing_imports.append((module, segment))
 
     protocol_imports = [
         node
@@ -231,21 +266,17 @@ def _insert_imports(source: str) -> str:
         ):
             break
 
-    missing_imports: list[str] = []
-    if not has_from_import("databricks_openai.agents", "McpServer"):
-        missing_imports.append(_GENERATED_MCP_IMPORT)
-    if not has_from_import("databricks.sdk", "WorkspaceClient"):
-        missing_imports.append(_GENERATED_WORKSPACE_CLIENT_IMPORT)
-
     with_runtime_imports = source
-    if missing_imports:
+    runtime_imports = [segment for module, segment in missing_imports if module != "typing"]
+    if runtime_imports:
         import_end_line, import_end_column = _end_position(protocol_imports[0])
         import_end = _offset(lines, import_end_line, import_end_column)
         with_runtime_imports = (
-            source[:import_end] + "\n" + "\n".join(missing_imports) + source[import_end:]
+            source[:import_end] + "\n" + "\n".join(runtime_imports) + source[import_end:]
         )
 
-    if has_from_import("typing", "Any"):
+    typing_imports = [segment for module, segment in missing_imports if module == "typing"]
+    if not typing_imports:
         return with_runtime_imports
 
     if insert_after is not None:
@@ -255,11 +286,11 @@ def _insert_imports(source: str) -> str:
         return (
             with_runtime_imports[:insert_at]
             + "\n\n"
-            + _GENERATED_TYPING_IMPORT
+            + "\n".join(typing_imports)
             + "\n\n"
             + following
         )
-    return _GENERATED_TYPING_IMPORT + "\n\n" + with_runtime_imports.lstrip("\n")
+    return "\n".join(typing_imports) + "\n\n" + with_runtime_imports.lstrip("\n")
 
 
 def _format_policy(policy: dict[str, list[dict[str, str]]]) -> str:
@@ -483,25 +514,41 @@ def _write_text_atomic(target: pathlib.Path, content: str) -> None:
                 pass
 
 
-def _generated_block(policy: dict[str, list[dict[str, str]]]) -> str:
+def _generated_block(policy: dict[str, list[dict[str, str]]], template: str | None = None) -> str:
+    template = template if template is not None else _read_template()
     try:
-        template = (
-            resources.files("databricks_mason")
-            .joinpath("templates")
-            .joinpath(_TEMPLATE_NAME)
-            .read_text(encoding="utf-8")
-        )
-    except (OSError, UnicodeError) as exc:
-        raise AgentCliError("Could not read the packaged sandbox MCP template.") from exc
-    if template.count(_DOWNSCOPE_PLACEHOLDER) != 1:
+        tree = ast.parse(template)
+    except SyntaxError as exc:
+        raise AgentCliError("The packaged sandbox MCP template is invalid.") from exc
+    assignments = [
+        node
+        for node in tree.body
+        if isinstance(node, ast.AnnAssign)
+        and isinstance(node.target, ast.Name)
+        and node.target.id == "_SANDBOX_DOWNSCOPE"
+    ]
+    lines = template.splitlines(keepends=True)
+    if (
+        len(assignments) != 1
+        or assignments[0].lineno != assignments[0].end_lineno
+        or _DOWNSCOPE_PLACEHOLDER not in lines[assignments[0].lineno - 1]
+    ):
         raise AgentCliError("The packaged sandbox MCP template is invalid.")
-    return template.replace(_DOWNSCOPE_PLACEHOLDER, _format_policy(policy))
+    line_start = _offset(lines, assignments[0].lineno, 0)
+    line_end = line_start + len(lines[assignments[0].lineno - 1])
+    rendered = template[:line_start] + _format_policy(policy) + "\n" + template[line_end:]
+    if rendered.count(_BEGIN_MARKER) != 1 or rendered.count(_END_MARKER) != 1:
+        raise AgentCliError("The packaged sandbox MCP template has invalid markers.")
+    block_start = rendered.index(_BEGIN_MARKER)
+    block_end = rendered.index(_END_MARKER) + len(_END_MARKER)
+    return rendered[block_start:block_end] + "\n"
 
 
 def _add_sandbox_to_source(source: str, policy: dict[str, list[dict[str, str]]]) -> str:
+    template = _read_template()
     with_server = _append_server_to_list(source)
-    with_imports = _insert_imports(with_server)
-    generated = with_imports.rstrip() + "\n\n\n" + _generated_block(policy)
+    with_imports = _insert_imports(with_server, template)
+    generated = with_imports.rstrip() + "\n\n\n" + _generated_block(policy, template)
     try:
         ast.parse(generated)
     except SyntaxError as exc:

--- a/integrations/mason/src/databricks_mason/templates/sandbox_mcp.py
+++ b/integrations/mason/src/databricks_mason/templates/sandbox_mcp.py
@@ -31,7 +31,8 @@ def _build_sandbox_mcp_server() -> McpServer:
         workspace_client=workspace_client,
         timeout=120.0,
         name="system.ai.sandbox",
-        tool_filter={"allowed_tool_names": ["run_code"]},
+        # Production advertises ``sandbox``; older preview workspaces use ``run_code``.
+        tool_filter={"allowed_tool_names": ["sandbox", "run_code"]},
     )
 
 

--- a/integrations/mason/src/databricks_mason/templates/sandbox_mcp.py
+++ b/integrations/mason/src/databricks_mason/templates/sandbox_mcp.py
@@ -1,7 +1,12 @@
+from typing import Any
+
+from databricks.sdk import WorkspaceClient
+from databricks_openai.agents import McpServer  # ty: ignore[unresolved-import]
+
 # BEGIN: mason add-sandbox
 # The downscope is fixed when this file is generated. It is sent as MCP metadata,
 # outside model-controlled tool arguments, on every sandbox call.
-# __MASON_SANDBOX_DOWNSCOPE__
+_SANDBOX_DOWNSCOPE: dict[str, list[dict[str, str]]] = {}  # __MASON_SANDBOX_DOWNSCOPE__
 
 
 class _SandboxMcpServer(McpServer):
@@ -21,8 +26,7 @@ def _build_sandbox_mcp_server() -> McpServer:
     workspace_client = WorkspaceClient()
     return _SandboxMcpServer(
         url=(
-            f"{workspace_client.config.host.rstrip('/')}"
-            "/ai-gateway/mcp-services/system.ai.sandbox"
+            f"{workspace_client.config.host.rstrip('/')}/ai-gateway/mcp-services/system.ai.sandbox"
         ),
         workspace_client=workspace_client,
         timeout=120.0,

--- a/integrations/mason/src/databricks_mason/templates/sandbox_mcp.py.tmpl
+++ b/integrations/mason/src/databricks_mason/templates/sandbox_mcp.py.tmpl
@@ -1,0 +1,34 @@
+# BEGIN: mason add-sandbox
+# The downscope is fixed when this file is generated. It is sent as MCP metadata,
+# outside model-controlled tool arguments, on every sandbox call.
+# __MASON_SANDBOX_DOWNSCOPE__
+
+
+class _SandboxMcpServer(McpServer):
+    async def call_tool(
+        self,
+        tool_name: str,
+        arguments: dict[str, Any] | None,
+        **kwargs: Any,
+    ) -> Any:
+        incoming_meta = kwargs.pop("meta", None)
+        meta = dict(incoming_meta) if isinstance(incoming_meta, dict) else {}
+        meta["downscope"] = _SANDBOX_DOWNSCOPE
+        return await super().call_tool(tool_name, arguments, meta=meta, **kwargs)
+
+
+def _build_sandbox_mcp_server() -> McpServer:
+    workspace_client = WorkspaceClient()
+    return _SandboxMcpServer(
+        url=(
+            f"{workspace_client.config.host.rstrip('/')}"
+            "/ai-gateway/mcp-services/system.ai.sandbox"
+        ),
+        workspace_client=workspace_client,
+        timeout=120.0,
+        name="system.ai.sandbox",
+        tool_filter={"allowed_tool_names": ["run_code"]},
+    )
+
+
+# END: mason add-sandbox

--- a/integrations/mason/tests/unit_tests/cli_test.py
+++ b/integrations/mason/tests/unit_tests/cli_test.py
@@ -16,4 +16,13 @@ def test_sessions_verbs_are_flat_no_redundant_subgroup():
 
 def test_root_registers_login_and_logout():
     names = set(cli.mason.commands)
-    assert {"login", "logout", "memory", "sessions", "tracing", "deploy", "deployments"} <= names
+    assert {
+        "login",
+        "logout",
+        "memory",
+        "sessions",
+        "tracing",
+        "deploy",
+        "deployments",
+        "add-sandbox",
+    } <= names

--- a/integrations/mason/tests/unit_tests/sandbox_test.py
+++ b/integrations/mason/tests/unit_tests/sandbox_test.py
@@ -1,0 +1,457 @@
+"""Unit tests for ``mason add-sandbox`` source generation."""
+
+from __future__ import annotations
+
+import ast
+import asyncio
+import json
+import pathlib
+import sys
+import types
+from typing import Any
+
+import pytest
+from click.testing import CliRunner
+
+from databricks_mason import sandbox as sandbox_mod
+from databricks_mason.sandbox import add_sandbox
+
+_EMPTY_MCPS = '''"""MCP servers to offer the agent."""
+
+from agents.mcp import MCPServer
+
+
+def build_mcp_servers() -> list[MCPServer]:
+    """Return the configured MCP servers."""
+    return []
+'''
+
+
+class _TextCtx:
+    output = "text"
+
+
+class _JsonCtx:
+    output = "json"
+
+
+def _project(
+    tmp_path: pathlib.Path, content: str = _EMPTY_MCPS
+) -> tuple[pathlib.Path, pathlib.Path]:
+    project = tmp_path / "agent-project"
+    agent = project / "agent"
+    agent.mkdir(parents=True)
+    mcps = agent / "mcps.py"
+    mcps.write_text(content)
+    return project, mcps
+
+
+def test_add_sandbox_generates_fixed_volume_downscope(tmp_path: pathlib.Path):
+    project, mcps = _project(tmp_path)
+
+    result = CliRunner().invoke(
+        add_sandbox,
+        ["--source", str(project), "--scope", "catalog.schema.volume"],
+        obj=_TextCtx(),
+    )
+
+    assert result.exit_code == 0, result.output
+    generated = mcps.read_text()
+    ast.parse(generated)
+    assert '"name": "catalog.schema.volume"' in generated
+    assert '"permission": "read_only"' in generated
+    assert 'function_name="sandbox"' in generated
+    assert "return [\n        _build_sandbox_mcp_server(),\n    ]" in generated
+    assert 'meta["downscope"] = _SANDBOX_DOWNSCOPE' in generated
+    assert "super().call_tool(tool_name, arguments, meta=meta, **kwargs)" in generated
+    assert "arguments[" not in generated
+
+
+def test_generated_server_overrides_caller_downscope_without_changing_arguments(
+    tmp_path: pathlib.Path, monkeypatch
+):
+    project, mcps = _project(tmp_path)
+    result = CliRunner().invoke(
+        add_sandbox,
+        ["--source", str(project), "--scope", "catalog.schema.volume"],
+        obj=_TextCtx(),
+    )
+    assert result.exit_code == 0, result.output
+
+    class FakeMcpServer:
+        connection: dict[str, object]
+
+        def __init__(self):
+            self.connection = {}
+
+        @classmethod
+        def from_uc_function(cls, **kwargs):
+            instance = cls()
+            instance.connection = kwargs
+            return instance
+
+        async def call_tool(self, tool_name, arguments, **kwargs):
+            return tool_name, arguments, kwargs
+
+    agents = types.ModuleType("agents")
+    agents_mcp = types.ModuleType("agents.mcp")
+    agents_mcp.__dict__["MCPServer"] = object
+    databricks_openai = types.ModuleType("databricks_openai")
+    databricks_openai_agents = types.ModuleType("databricks_openai.agents")
+    databricks_openai_agents.__dict__["McpServer"] = FakeMcpServer
+    monkeypatch.setitem(sys.modules, "agents", agents)
+    monkeypatch.setitem(sys.modules, "agents.mcp", agents_mcp)
+    monkeypatch.setitem(sys.modules, "databricks_openai", databricks_openai)
+    monkeypatch.setitem(sys.modules, "databricks_openai.agents", databricks_openai_agents)
+
+    namespace: dict[str, Any] = {}
+    exec(compile(mcps.read_text(), str(mcps), "exec"), namespace)
+    server = namespace["build_mcp_servers"]()[0]
+    arguments = {"code": 'print("hello")'}
+    _, forwarded_arguments, kwargs = asyncio.run(
+        server.call_tool(
+            "sandbox",
+            arguments,
+            meta={"downscope": {"volumes": []}, "trace_id": "123"},
+        )
+    )
+
+    assert forwarded_arguments is arguments
+    assert kwargs["meta"] == {
+        "downscope": {
+            "volumes": [
+                {"name": "catalog.schema.volume", "permission": "read_only"},
+            ]
+        },
+        "trace_id": "123",
+    }
+    assert server.connection["function_name"] == "sandbox"
+
+
+def test_add_sandbox_supports_workspace_table_and_read_write_scopes(tmp_path: pathlib.Path):
+    project, mcps = _project(tmp_path)
+
+    result = CliRunner().invoke(
+        add_sandbox,
+        [
+            "--source",
+            str(project),
+            "--scope",
+            "/Workspace/Users/alice@example.com",
+            "--scope",
+            "table:catalog.schema.records",
+            "--permission",
+            "read_write",
+        ],
+        obj=_TextCtx(),
+    )
+
+    assert result.exit_code == 0, result.output
+    generated = mcps.read_text()
+    assert '"workspace_paths": [' in generated
+    assert '"path": "/Workspace/Users/alice@example.com"' in generated
+    assert '"tables": [' in generated
+    assert '"name": "catalog.schema.records"' in generated
+    assert generated.count('"permission": "read_write"') == 2
+
+
+def test_add_sandbox_appends_to_existing_server_list(tmp_path: pathlib.Path):
+    project, mcps = _project(
+        tmp_path,
+        _EMPTY_MCPS.replace(
+            "return []",
+            'return [\n        ExistingServer(name="existing"),\n    ]',
+        ),
+    )
+
+    result = CliRunner().invoke(
+        add_sandbox,
+        ["--source", str(project), "--scope", "catalog.schema.volume"],
+        obj=_TextCtx(),
+    )
+
+    assert result.exit_code == 0, result.output
+    generated = mcps.read_text()
+    assert 'ExistingServer(name="existing"),' in generated
+    assert generated.index('ExistingServer(name="existing"),') < generated.index(
+        "_build_sandbox_mcp_server(),"
+    )
+
+
+def test_add_sandbox_preserves_non_ascii_existing_server(tmp_path: pathlib.Path):
+    project, mcps = _project(
+        tmp_path,
+        _EMPTY_MCPS.replace(
+            "return []",
+            'return [\n        ExistingServer(name="café")\n    ]',
+        ),
+    )
+
+    result = CliRunner().invoke(
+        add_sandbox,
+        ["--source", str(project), "--scope", "catalog.schema.volume"],
+        obj=_TextCtx(),
+    )
+
+    assert result.exit_code == 0, result.output
+    generated = mcps.read_text()
+    ast.parse(generated)
+    assert 'ExistingServer(name="café"),' in generated
+
+
+def test_add_sandbox_keeps_future_import_at_top(tmp_path: pathlib.Path):
+    project, mcps = _project(
+        tmp_path,
+        _EMPTY_MCPS.replace(
+            "from agents.mcp import MCPServer",
+            "from __future__ import annotations\n\nfrom agents.mcp import MCPServer",
+        ),
+    )
+
+    result = CliRunner().invoke(
+        add_sandbox,
+        ["--source", str(project), "--scope", "catalog.schema.volume"],
+        obj=_TextCtx(),
+    )
+
+    assert result.exit_code == 0, result.output
+    ast.parse(mcps.read_text())
+
+
+def test_add_sandbox_does_not_treat_aliased_imports_as_required_bindings(tmp_path: pathlib.Path):
+    original = _EMPTY_MCPS.replace(
+        "from agents.mcp import MCPServer",
+        "from typing import Any as T\n\n"
+        "from agents.mcp import MCPServer\n"
+        "from databricks_openai.agents import McpServer as ExistingMcpServer",
+    )
+    project, mcps = _project(tmp_path, original)
+
+    result = CliRunner().invoke(
+        add_sandbox,
+        ["--source", str(project), "--scope", "catalog.schema.volume"],
+        obj=_TextCtx(),
+    )
+
+    assert result.exit_code == 0, result.output
+    generated = mcps.read_text()
+    assert "from typing import Any\n" in generated
+    assert "from databricks_openai.agents import McpServer\n" in generated
+
+
+def test_add_sandbox_is_idempotent(tmp_path: pathlib.Path):
+    project, mcps = _project(tmp_path)
+    runner = CliRunner()
+    args = ["--source", str(project), "--scope", "catalog.schema.volume"]
+
+    first = runner.invoke(add_sandbox, args, obj=_TextCtx())
+    first_content = mcps.read_text()
+    second = runner.invoke(add_sandbox, args, obj=_TextCtx())
+
+    assert first.exit_code == 0, first.output
+    assert second.exit_code == 0, second.output
+    assert "already configured" in second.output
+    assert mcps.read_text() == first_content
+
+
+def test_add_sandbox_rejects_policy_change_instead_of_reporting_stale_values(
+    tmp_path: pathlib.Path,
+):
+    project, mcps = _project(tmp_path)
+    runner = CliRunner()
+    first = runner.invoke(
+        add_sandbox,
+        [
+            "--source",
+            str(project),
+            "--scope",
+            "catalog.schema.volume",
+            "--permission",
+            "read_write",
+        ],
+        obj=_TextCtx(),
+    )
+    first_content = mcps.read_text()
+
+    second = runner.invoke(
+        add_sandbox,
+        ["--source", str(project), "--scope", "other.schema.volume"],
+        obj=_JsonCtx(),
+    )
+
+    assert first.exit_code == 0, first.output
+    assert second.exit_code != 0
+    assert "different downscope" in second.output
+    assert mcps.read_text() == first_content
+
+
+def test_add_sandbox_rejects_conditional_builder_without_touching_it(tmp_path: pathlib.Path):
+    original = _EMPTY_MCPS.replace(
+        "return []",
+        "if disabled:\n        return []\n    return []",
+    )
+    project, mcps = _project(tmp_path, original)
+
+    result = CliRunner().invoke(
+        add_sandbox,
+        ["--source", str(project), "--scope", "catalog.schema.volume"],
+        obj=_TextCtx(),
+    )
+
+    assert result.exit_code != 0
+    assert "directly return a list" in result.output
+    assert mcps.read_text() == original
+
+
+def test_add_sandbox_rejects_invalid_scope_without_touching_file(tmp_path: pathlib.Path):
+    project, mcps = _project(tmp_path)
+
+    result = CliRunner().invoke(
+        add_sandbox,
+        ["--source", str(project), "--scope", "not-a-volume"],
+        obj=_TextCtx(),
+    )
+
+    assert result.exit_code != 0
+    assert "catalog.schema.volume" in result.output
+    assert mcps.read_text() == _EMPTY_MCPS
+
+
+@pytest.mark.parametrize(
+    "scope",
+    ["catalog .schema.volume", "workspace:/Workspace/Users/alice\tinvalid"],
+)
+def test_add_sandbox_rejects_downstream_invalid_scope_without_touching_file(
+    tmp_path: pathlib.Path, scope: str
+):
+    project, mcps = _project(tmp_path)
+
+    result = CliRunner().invoke(
+        add_sandbox,
+        ["--source", str(project), "--scope", scope],
+        obj=_TextCtx(),
+    )
+
+    assert result.exit_code != 0
+    assert mcps.read_text() == _EMPTY_MCPS
+
+
+def test_add_sandbox_reports_missing_mason_project(tmp_path: pathlib.Path):
+    result = CliRunner().invoke(
+        add_sandbox,
+        ["--source", str(tmp_path), "--scope", "catalog.schema.volume"],
+        obj=_TextCtx(),
+    )
+
+    assert result.exit_code != 0
+    assert "agent/mcps.py" in result.output
+
+
+def test_add_sandbox_rejects_unsupported_mcps_file_without_touching_it(tmp_path: pathlib.Path):
+    original = _EMPTY_MCPS.replace("from agents.mcp import MCPServer", "import os")
+    project, mcps = _project(tmp_path, original)
+
+    result = CliRunner().invoke(
+        add_sandbox,
+        ["--source", str(project), "--scope", "catalog.schema.volume"],
+        obj=_TextCtx(),
+    )
+
+    assert result.exit_code != 0
+    assert "from agents.mcp" in result.output
+    assert mcps.read_text() == original
+
+
+def test_add_sandbox_rejects_partial_generated_block(tmp_path: pathlib.Path):
+    original = _EMPTY_MCPS + "\n# BEGIN: mason add-sandbox\n"
+    project, mcps = _project(tmp_path, original)
+
+    result = CliRunner().invoke(
+        add_sandbox,
+        ["--source", str(project), "--scope", "catalog.schema.volume"],
+        obj=_TextCtx(),
+    )
+
+    assert result.exit_code != 0
+    assert "invalid markers" in result.output
+    assert mcps.read_text() == original
+
+
+@pytest.mark.parametrize(
+    ("original_fragment", "tampered_fragment"),
+    [
+        (
+            '        meta["downscope"] = _SANDBOX_DOWNSCOPE',
+            '        # meta["downscope"] intentionally removed',
+        ),
+        (
+            '{"name": "catalog.schema.volume", "permission": "read_only"}',
+            '{"path": "catalog.schema.volume", "permission": "read_only"}',
+        ),
+        (
+            "        _build_sandbox_mcp_server(),",
+            "        _build_sandbox_mcp_server(),\n        _build_sandbox_mcp_server(),",
+        ),
+    ],
+)
+def test_add_sandbox_rejects_tampered_generated_security_block(
+    tmp_path: pathlib.Path, original_fragment: str, tampered_fragment: str
+):
+    project, mcps = _project(tmp_path)
+    first = CliRunner().invoke(
+        add_sandbox,
+        ["--source", str(project), "--scope", "catalog.schema.volume"],
+        obj=_TextCtx(),
+    )
+    assert first.exit_code == 0, first.output
+    tampered = mcps.read_text().replace(original_fragment, tampered_fragment)
+    assert tampered != mcps.read_text()
+    mcps.write_text(tampered)
+
+    second = CliRunner().invoke(
+        add_sandbox,
+        ["--source", str(project), "--scope", "catalog.schema.volume"],
+        obj=_TextCtx(),
+    )
+
+    assert second.exit_code != 0
+    assert mcps.read_text() == tampered
+
+
+def test_add_sandbox_reports_atomic_write_failure_without_touching_file(
+    tmp_path: pathlib.Path, monkeypatch
+):
+    project, mcps = _project(tmp_path)
+
+    def fail_to_create_temporary(*args, **kwargs):
+        raise OSError("disk full")
+
+    monkeypatch.setattr(sandbox_mod.tempfile, "NamedTemporaryFile", fail_to_create_temporary)
+    result = CliRunner().invoke(
+        add_sandbox,
+        ["--source", str(project), "--scope", "catalog.schema.volume"],
+        obj=_TextCtx(),
+    )
+
+    assert result.exit_code != 0
+    assert "disk full" in result.output
+    assert mcps.read_text() == _EMPTY_MCPS
+
+
+def test_add_sandbox_honors_json_output(tmp_path: pathlib.Path):
+    project, _ = _project(tmp_path)
+
+    result = CliRunner().invoke(
+        add_sandbox,
+        ["--source", str(project), "--scope", "catalog.schema.volume"],
+        obj=_JsonCtx(),
+    )
+
+    assert result.exit_code == 0, result.output
+    assert json.loads(result.output) == {
+        "mcp_server": "system.ai.sandbox",
+        "path": str(project / "agent" / "mcps.py"),
+        "permission": "read_only",
+        "scopes": ["catalog.schema.volume"],
+        "status": "added",
+    }

--- a/integrations/mason/tests/unit_tests/sandbox_test.py
+++ b/integrations/mason/tests/unit_tests/sandbox_test.py
@@ -124,7 +124,7 @@ def test_add_sandbox_generates_fixed_volume_downscope(tmp_path: pathlib.Path):
     assert '"permission": "read_only"' in generated
     assert "/ai-gateway/mcp-services/system.ai.sandbox" in generated
     assert "from_uc_function" not in generated
-    assert 'tool_filter={"allowed_tool_names": ["run_code"]}' in generated
+    assert 'tool_filter={"allowed_tool_names": ["sandbox", "run_code"]}' in generated
     assert "return [\n        _build_sandbox_mcp_server(),\n    ]" in generated
     assert 'meta["downscope"] = _SANDBOX_DOWNSCOPE' in generated
     assert "super().call_tool(tool_name, arguments, meta=meta, **kwargs)" in generated
@@ -195,7 +195,7 @@ def test_generated_server_overrides_caller_downscope_without_changing_arguments(
     )
     assert isinstance(server.connection["workspace_client"], FakeWorkspaceClient)
     assert server.connection["timeout"] == 120.0
-    assert server.connection["tool_filter"] == {"allowed_tool_names": ["run_code"]}
+    assert server.connection["tool_filter"] == {"allowed_tool_names": ["sandbox", "run_code"]}
 
 
 def test_add_sandbox_supports_workspace_table_and_read_write_scopes(tmp_path: pathlib.Path):

--- a/integrations/mason/tests/unit_tests/sandbox_test.py
+++ b/integrations/mason/tests/unit_tests/sandbox_test.py
@@ -60,8 +60,9 @@ def test_add_sandbox_generates_fixed_volume_downscope(tmp_path: pathlib.Path):
     ast.parse(generated)
     assert '"name": "catalog.schema.volume"' in generated
     assert '"permission": "read_only"' in generated
-    assert 'tool_filter={"allowed_tool_names": ["sandbox"]}' in generated
-    assert 'function_name="sandbox"' not in generated
+    assert '"/ai-gateway/mcp-services/system.ai.sandbox"' in generated
+    assert "from_uc_function" not in generated
+    assert 'tool_filter={"allowed_tool_names": ["run_code"]}' in generated
     assert "return [\n        _build_sandbox_mcp_server(),\n    ]" in generated
     assert 'meta["downscope"] = _SANDBOX_DOWNSCOPE' in generated
     assert "super().call_tool(tool_name, arguments, meta=meta, **kwargs)" in generated
@@ -82,17 +83,15 @@ def test_generated_server_overrides_caller_downscope_without_changing_arguments(
     class FakeMcpServer:
         connection: dict[str, object]
 
-        def __init__(self):
-            self.connection = {}
-
-        @classmethod
-        def from_uc_function(cls, **kwargs):
-            instance = cls()
-            instance.connection = kwargs
-            return instance
+        def __init__(self, **kwargs):
+            self.connection = kwargs
 
         async def call_tool(self, tool_name, arguments, **kwargs):
             return tool_name, arguments, kwargs
+
+    class FakeWorkspaceClient:
+        def __init__(self):
+            self.config = types.SimpleNamespace(host="https://tilefood.example.com")
 
     agents = types.ModuleType("agents")
     agents_mcp = types.ModuleType("agents.mcp")
@@ -100,10 +99,13 @@ def test_generated_server_overrides_caller_downscope_without_changing_arguments(
     databricks_openai = types.ModuleType("databricks_openai")
     databricks_openai_agents = types.ModuleType("databricks_openai.agents")
     databricks_openai_agents.__dict__["McpServer"] = FakeMcpServer
+    databricks_sdk = types.ModuleType("databricks.sdk")
+    databricks_sdk.__dict__["WorkspaceClient"] = FakeWorkspaceClient
     monkeypatch.setitem(sys.modules, "agents", agents)
     monkeypatch.setitem(sys.modules, "agents.mcp", agents_mcp)
     monkeypatch.setitem(sys.modules, "databricks_openai", databricks_openai)
     monkeypatch.setitem(sys.modules, "databricks_openai.agents", databricks_openai_agents)
+    monkeypatch.setitem(sys.modules, "databricks.sdk", databricks_sdk)
 
     namespace: dict[str, Any] = {}
     exec(compile(mcps.read_text(), str(mcps), "exec"), namespace)
@@ -126,10 +128,12 @@ def test_generated_server_overrides_caller_downscope_without_changing_arguments(
         },
         "trace_id": "123",
     }
-    assert server.connection["catalog"] == "system"
-    assert server.connection["schema"] == "ai"
-    assert server.connection["tool_filter"] == {"allowed_tool_names": ["sandbox"]}
-    assert "function_name" not in server.connection
+    assert server.connection["url"] == (
+        "https://tilefood.example.com/ai-gateway/mcp-services/system.ai.sandbox"
+    )
+    assert isinstance(server.connection["workspace_client"], FakeWorkspaceClient)
+    assert server.connection["timeout"] == 120.0
+    assert server.connection["tool_filter"] == {"allowed_tool_names": ["run_code"]}
 
 
 def test_add_sandbox_supports_workspace_table_and_read_write_scopes(tmp_path: pathlib.Path):

--- a/integrations/mason/tests/unit_tests/sandbox_test.py
+++ b/integrations/mason/tests/unit_tests/sandbox_test.py
@@ -60,7 +60,8 @@ def test_add_sandbox_generates_fixed_volume_downscope(tmp_path: pathlib.Path):
     ast.parse(generated)
     assert '"name": "catalog.schema.volume"' in generated
     assert '"permission": "read_only"' in generated
-    assert 'function_name="sandbox"' in generated
+    assert 'tool_filter={"allowed_tool_names": ["sandbox"]}' in generated
+    assert 'function_name="sandbox"' not in generated
     assert "return [\n        _build_sandbox_mcp_server(),\n    ]" in generated
     assert 'meta["downscope"] = _SANDBOX_DOWNSCOPE' in generated
     assert "super().call_tool(tool_name, arguments, meta=meta, **kwargs)" in generated
@@ -125,7 +126,10 @@ def test_generated_server_overrides_caller_downscope_without_changing_arguments(
         },
         "trace_id": "123",
     }
-    assert server.connection["function_name"] == "sandbox"
+    assert server.connection["catalog"] == "system"
+    assert server.connection["schema"] == "ai"
+    assert server.connection["tool_filter"] == {"allowed_tool_names": ["sandbox"]}
+    assert "function_name" not in server.connection
 
 
 def test_add_sandbox_supports_workspace_table_and_read_write_scopes(tmp_path: pathlib.Path):

--- a/integrations/mason/tests/unit_tests/sandbox_test.py
+++ b/integrations/mason/tests/unit_tests/sandbox_test.py
@@ -47,13 +47,14 @@ def _project(
     return project, mcps
 
 
-def test_generated_block_reads_packaged_template_at_render_time(
+def test_generated_block_reads_valid_python_template_at_render_time(
     tmp_path: pathlib.Path, monkeypatch
 ):
     template_dir = tmp_path / "templates"
     template_dir.mkdir()
-    (template_dir / "sandbox_mcp.py.tmpl").write_text(
+    (template_dir / "sandbox_mcp.py").write_text(
         "# BEGIN: mason add-sandbox\n"
+        "_SANDBOX_DOWNSCOPE: dict[str, list[dict[str, str]]] = {}  "
         "# __MASON_SANDBOX_DOWNSCOPE__\n"
         'TEMPLATE_SOURCE = "loaded"\n'
         "# END: mason add-sandbox\n"
@@ -78,6 +79,35 @@ def test_generated_block_reads_packaged_template_at_render_time(
     }
 
 
+def test_add_sandbox_inserts_imports_declared_by_template(tmp_path: pathlib.Path, monkeypatch):
+    template_dir = tmp_path / "templates"
+    template_dir.mkdir()
+    (template_dir / "sandbox_mcp.py").write_text(
+        "from custom_sandbox import CustomMcpServer\n\n"
+        "# BEGIN: mason add-sandbox\n"
+        "_SANDBOX_DOWNSCOPE: dict[str, list[dict[str, str]]] = {}  "
+        "# __MASON_SANDBOX_DOWNSCOPE__\n\n"
+        "def _build_sandbox_mcp_server():\n"
+        "    return CustomMcpServer(_SANDBOX_DOWNSCOPE)\n\n"
+        "# END: mason add-sandbox\n"
+    )
+    monkeypatch.setattr(resources, "files", lambda package: tmp_path)
+
+    generated = sandbox_mod._add_sandbox_to_source(
+        _EMPTY_MCPS,
+        {
+            "volumes": [
+                {"name": "catalog.schema.volume", "permission": "read_only"},
+            ]
+        },
+    )
+
+    assert generated.index("from custom_sandbox import CustomMcpServer") < generated.index(
+        "def build_mcp_servers"
+    )
+    assert generated.count("from custom_sandbox import CustomMcpServer") == 1
+
+
 def test_add_sandbox_generates_fixed_volume_downscope(tmp_path: pathlib.Path):
     project, mcps = _project(tmp_path)
 
@@ -92,7 +122,7 @@ def test_add_sandbox_generates_fixed_volume_downscope(tmp_path: pathlib.Path):
     ast.parse(generated)
     assert '"name": "catalog.schema.volume"' in generated
     assert '"permission": "read_only"' in generated
-    assert '"/ai-gateway/mcp-services/system.ai.sandbox"' in generated
+    assert "/ai-gateway/mcp-services/system.ai.sandbox" in generated
     assert "from_uc_function" not in generated
     assert 'tool_filter={"allowed_tool_names": ["run_code"]}' in generated
     assert "return [\n        _build_sandbox_mcp_server(),\n    ]" in generated

--- a/integrations/mason/tests/unit_tests/sandbox_test.py
+++ b/integrations/mason/tests/unit_tests/sandbox_test.py
@@ -8,6 +8,7 @@ import json
 import pathlib
 import sys
 import types
+from importlib import resources
 from typing import Any
 
 import pytest
@@ -44,6 +45,37 @@ def _project(
     mcps = agent / "mcps.py"
     mcps.write_text(content)
     return project, mcps
+
+
+def test_generated_block_reads_packaged_template_at_render_time(
+    tmp_path: pathlib.Path, monkeypatch
+):
+    template_dir = tmp_path / "templates"
+    template_dir.mkdir()
+    (template_dir / "sandbox_mcp.py.tmpl").write_text(
+        "# BEGIN: mason add-sandbox\n"
+        "# __MASON_SANDBOX_DOWNSCOPE__\n"
+        'TEMPLATE_SOURCE = "loaded"\n'
+        "# END: mason add-sandbox\n"
+    )
+    monkeypatch.setattr(resources, "files", lambda package: tmp_path)
+
+    rendered = sandbox_mod._generated_block(
+        {
+            "volumes": [
+                {"name": "catalog.schema.volume", "permission": "read_only"},
+            ]
+        }
+    )
+
+    assert 'TEMPLATE_SOURCE = "loaded"' in rendered
+    namespace: dict[str, Any] = {}
+    exec(compile(rendered, "sandbox_mcp.py", "exec"), namespace)
+    assert namespace["_SANDBOX_DOWNSCOPE"] == {
+        "volumes": [
+            {"name": "catalog.schema.volume", "permission": "read_only"},
+        ]
+    }
 
 
 def test_add_sandbox_generates_fixed_volume_downscope(tmp_path: pathlib.Path):


### PR DESCRIPTION
## What

Adds `mason add-sandbox`, a focused source-generation command that attaches only
`system.ai.sandbox` to a Mason agent project and fixes its resource downscope in
MCP `_meta`, outside model-controlled tool arguments.

The command supports repeatable Unity Catalog volume, table, and Workspace path
scopes, read-only/read-write permissions, idempotent reruns, strict template
validation, and atomic updates to `agent/mcps.py`.

The generated client targets the public managed MCP route
`/ai-gateway/mcp-services/system.ai.sandbox`, uses a 120-second response timeout,
and accepts both advertised tool names during rollout: production `sandbox` and
older preview `run_code`.

## Template structure

The generated implementation now lives in the valid Python resource
`templates/sandbox_mcp.py`. That file owns its imports, fixed-downscope wrapper,
public endpoint, and server factory, so the implementation is readable and can be
syntax-checked directly.

The CLI reads the resource once and uses Python AST nodes only to locate the
template imports, the marked downscope assignment, and safe edit points in
`agent/mcps.py`. The large embedded Python string is gone.

This is still source generation today: the app framework calls its MCP runtime,
which calls `build_mcp_servers()`, which calls the generated
`_build_sandbox_mcp_server()`. The follow-up `agent.toml` direction can remove
per-MCP Python generation: a shared framework loader reads declarative MCP and
downscope entries at runtime, constructs the downscoped server, and appends it
before tool discovery. Mason would then edit TOML only; the generic loader/factory
would ship once.

## Why

Agent authors need a small, explicit path to add the shared sandbox MCP without
exposing downscope selection as an LLM-controlled tool argument.

## Design doc

[Mason CLI CUJ](https://docs.google.com/document/d/1Oi8k63r8-wJbJn5TFdDqjndDiveOkRm5aGlqE6e2AlQ)

## Proof of work

[df1 E2E metric report](https://metric-reports-viewer-6051921418418893.staging.aws.databricksapps.com/20260828_mason-add-sandbox-df1-e2e.html)

Production `df1` flow against the existing OpenAI agent app:

1. Built the `99cf0da` Mason wheel and verified that it contains and can read/compile
   `databricks_mason/templates/sandbox_mcp.py`.
2. Reset only the existing app's generated sandbox section; did not rerun
   `mason init`.
3. Ran the packaged `mason add-sandbox --scope table:samples.nyctaxi.trips`;
   generated `agent/mcps.py` compiled successfully.
4. Public `system.ai.sandbox` `tools/list` returned exactly `["sandbox"]`.
5. Called `sandbox` with
   `SELECT COUNT(*) AS trip_count FROM samples.nyctaxi.trips`.
6. The live result was `is_error=false`, content `[[21932]]`.

This proves the positive read path for the fixed read-only table scope. An
out-of-scope negative denial test was not run, so the report does not claim proof
of denial behavior.

The first df1 attempt also caught rollout skew: production advertises `sandbox`
while Tilefood previously advertised `run_code`. Incremental commit `99cf0da`
allows both names while keeping the endpoint fixed to `system.ai.sandbox`.

## Testing

- PR head: `99cf0da`; base: `0c53897` on `main`.
- 25/25 focused sandbox and CLI tests pass (JUnit: 0 errors, 0 failures).
- 60/60 broader Mason tests pass; one unrelated environment-dependent tracing
  test was deselected because this environment loads MLflow and attempts live setup.
- Ruff check, Ruff format check, and `ty check` pass.
- Wheel resource inclusion plus installed-resource read/compile pass.
- Production df1 `tools/list` and downscoped SQL `tools/call` pass.
- GitHub Actions: 49/50 checks pass, including every Mason check. The only
  failure is Ty typechecking—not Ruff lint—in untouched `integrations/openai`
  files ([job](https://github.com/databricks/databricks-ai-bridge/actions/runs/33130367239/job/98718211223)).
  The exact CI command reproduces identically on PR head `99cf0da` and base SHA
  `0c53897`: both resolve `openai 3.3.1`, whose client types use `httpx2`, while
  the existing integration passes `httpx 0.28.1`. This PR changes only
  `integrations/mason/**`.

This pull request and its description were written by Isaac.
