### PR TITLE
mason deploy: fix memory-store resolution 

### DIFF
--- a/integrations/mason/src/databricks_mason/deploy.py
+++ b/integrations/mason/src/databricks_mason/deploy.py
@@ -160,8 +160,13 @@ def _ensure_session_store(client, name: str) -> dict:
 
 
 def _memory_store_database(client, memory_store: str) -> Optional[str]:
-    """Resolve the memory store's per-store Lakebase database name from its storage backend."""
-    store = client.get_memory_store(memory_store)
+    """Resolve the memory store's per-store Lakebase database name from its storage backend.
+
+    Resolves by display name (what the deploy flag carries), not get_memory_store (which is by id).
+    """
+    store = _resolve_memory_store(client, memory_store)
+    if store is None:
+        return None
     backend_id = field(field(store, "storage_backend") or {}, "backend_id")
     return memory_store_access.database_from_backend_id(backend_id) if backend_id else None
 

--- a/integrations/mason/src/databricks_mason/deploy.py
+++ b/integrations/mason/src/databricks_mason/deploy.py
@@ -115,17 +115,39 @@ def _upsert_manifest_env(source: pathlib.Path, updates: dict[str, str]) -> bool:
 # --- store provisioning -----------------------------------------------------
 
 
+_MEMORY_STORE_PAGE_SIZE = 100  # the memory-stores list API caps page_size at 100
+
+
+def _resolve_memory_store(client, display_name: str) -> Optional[dict]:
+    """Find a memory store by display name, paging through the list, or None if none matches.
+
+    `get_memory_store` looks up by resource id (`memory-stores/<uuid>`), not the display name users
+    pass, so resolving a name means listing and matching on `display_name`. The list API caps
+    `page_size` at 100, so page through with the `next_page_token` rather than requesting all at once.
+    """
+    page_token: Optional[str] = None
+    while True:
+        listing = client.list_memory_stores(
+            page_size=_MEMORY_STORE_PAGE_SIZE, page_token=page_token
+        )
+        for store in field(listing, "managed_memory_stores") or []:
+            if field(store, "display_name") == display_name:
+                return store
+        page_token = field(listing, "next_page_token")
+        if not page_token:
+            return None
+
+
 def _ensure_memory_store(client, display_name: str) -> dict:
     try:
         return client.create_memory_store(display_name)
     except AgentCliError as exc:
         if exc.error_code != "ALREADY_EXISTS":
             raise
-    listing = client.list_memory_stores(page_size=1000)
-    for store in field(listing, "managed_memory_stores") or []:
-        if field(store, "display_name") == display_name:
-            return store
-    raise AgentCliError(f"Memory store '{display_name}' exists but could not be resolved.")
+    store = _resolve_memory_store(client, display_name)
+    if store is None:
+        raise AgentCliError(f"Memory store '{display_name}' exists but could not be resolved.")
+    return store
 
 
 def _ensure_session_store(client, name: str) -> dict:
@@ -163,11 +185,16 @@ def resolve_store_env(
     """
     env: dict[str, str] = {}
     if memory_store:
-        store = (
-            _ensure_memory_store(client, memory_store)
-            if create_stores
-            else client.get_memory_store(memory_store)
-        )
+        # Resolve by display name (what users pass) in both cases: get_memory_store looks up by
+        # resource id, so it can't resolve a display name on the non-create path.
+        if create_stores:
+            store = _ensure_memory_store(client, memory_store)
+        else:
+            store = _resolve_memory_store(client, memory_store)
+            if store is None:
+                raise AgentCliError(
+                    f"Memory store '{memory_store}' does not exist (create it with --create-stores)."
+                )
         store_name = field(store, "name") or memory_store
         env[_MEMORY_ENV] = store_name.split("/", 1)[-1]
     if session_store:

--- a/integrations/mason/tests/unit_tests/deploy_test.py
+++ b/integrations/mason/tests/unit_tests/deploy_test.py
@@ -57,6 +57,14 @@ class _FakeClient:
     def get_memory_store(self, name):
         return {"name": f"memory-stores/{name}"}
 
+    def list_memory_stores(self, page_size=None, page_token=None):
+        # One page; the store's resource name is an id distinct from its display name (as the real
+        # API returns), so resolution must match on display_name, not id.
+        return {
+            "managed_memory_stores": [{"name": "memory-stores/mem-id-123", "display_name": "mem"}],
+            "next_page_token": "",
+        }
+
 
 class _FakeCtx:
     profile = "prof"
@@ -92,9 +100,9 @@ def test_deploy_drives_sync_and_apps_deploy(tmp_path: pathlib.Path, monkeypatch)
     assert ["sync", str(src), ws, "--exclude", "uv.lock"] in calls
     assert ["apps", "deploy", "myapp", "--source-code-path", ws] in calls
     env = {e["name"]: e["value"] for e in yaml.safe_load((src / "app.yaml").read_text())["env"]}
-    # The API returns `memory-stores/mem`, but the runtime re-adds that prefix, so the env var
-    # must carry the bare id.
-    assert env["AGENT_MEMORY_STORE"] == "mem"
+    # Display name "mem" resolves to store id memory-stores/mem-id-123; the runtime re-adds the
+    # `memory-stores/` prefix, so the env var must carry the bare id.
+    assert env["AGENT_MEMORY_STORE"] == "mem-id-123"
 
 
 def test_first_deploy_waits_for_running_before_deploying(tmp_path: pathlib.Path, monkeypatch):
@@ -177,6 +185,62 @@ def test_deploy_with_traces_injects_tracing_env(tmp_path: pathlib.Path, monkeypa
     env = {e["name"]: e["value"] for e in doc["env"]}
     assert env["MLFLOW_TRACING_DESTINATION"] == "cat.schema"
     assert env["MLFLOW_EXPERIMENT_NAME"] == "/Shared/x"
+
+
+def test_resolve_memory_store_pages_at_100_and_matches_display_name():
+    # The list API caps page_size at 100, so resolution must page (not request 1000) and match the
+    # display name across pages.
+    class _PagingClient:
+        def __init__(self):
+            self.calls = []
+
+        def list_memory_stores(self, page_size=None, page_token=None):
+            self.calls.append((page_size, page_token))
+            if page_token is None:
+                return {
+                    "managed_memory_stores": [{"name": "memory-stores/a", "display_name": "other"}],
+                    "next_page_token": "p2",
+                }
+            return {
+                "managed_memory_stores": [{"name": "memory-stores/b", "display_name": "wanted"}],
+                "next_page_token": "",
+            }
+
+    client = _PagingClient()
+    store = deploy_mod._resolve_memory_store(client, "wanted")
+    assert store["name"] == "memory-stores/b"  # found on page 2
+    assert all(ps == 100 for ps, _ in client.calls)  # never exceeds the API cap
+    assert [pt for _, pt in client.calls] == [None, "p2"]  # followed the page token
+
+
+def test_resolve_memory_store_returns_none_when_absent():
+    class _EmptyClient:
+        def list_memory_stores(self, page_size=None, page_token=None):
+            return {"managed_memory_stores": [], "next_page_token": ""}
+
+    assert deploy_mod._resolve_memory_store(_EmptyClient(), "nope") is None
+
+
+def test_deploy_without_create_resolves_memory_by_display_name(tmp_path: pathlib.Path, monkeypatch):
+    # Non-create path must resolve by display name (list+match), not get_memory_store (by id).
+    src = tmp_path / "app"
+    src.mkdir()
+    (src / "app.yaml").write_text(yaml.safe_dump({"command": ["x"]}))
+    monkeypatch.setattr(deploy_mod, "_deployment_exists", lambda a, p: True)
+    monkeypatch.setattr(deploy_mod, "_app_service_principal", lambda name, p: None)
+    monkeypatch.setattr(
+        deploy_mod,
+        "_databricks",
+        lambda args, profile, **kw: types.SimpleNamespace(returncode=0, stdout="", stderr=""),
+    )
+    result = CliRunner().invoke(
+        deploy_mod.deploy,
+        ["myapp", "--source", str(src), "--with-memory-store", "mem"],
+        obj=_FakeCtx(),
+    )
+    assert result.exit_code == 0, result.output
+    env = {e["name"]: e["value"] for e in yaml.safe_load((src / "app.yaml").read_text())["env"]}
+    assert env["AGENT_MEMORY_STORE"] == "mem-id-123"  # resolved by display name, bare id
 
 
 def test_with_traces_defaults_the_experiment_per_app():

--- a/integrations/mason/tests/unit_tests/deploy_test.py
+++ b/integrations/mason/tests/unit_tests/deploy_test.py
@@ -221,6 +221,27 @@ def test_resolve_memory_store_returns_none_when_absent():
     assert deploy_mod._resolve_memory_store(_EmptyClient(), "nope") is None
 
 
+def test_memory_store_database_resolves_by_display_name():
+    # The grant step derives the Lakebase db from the store; it must resolve by display name
+    # (list+match), not get_memory_store (by id), or it 404s on the deploy flag's value.
+    class _Client:
+        def list_memory_stores(self, page_size=None, page_token=None):
+            return {
+                "managed_memory_stores": [
+                    {
+                        "name": "memory-stores/uuid-x",
+                        "display_name": "mem",
+                        "storage_backend": {
+                            "backend_id": "projects/p/branches/production/databases/memory-uuidx"
+                        },
+                    }
+                ],
+                "next_page_token": "",
+            }
+
+    assert deploy_mod._memory_store_database(_Client(), "mem") == "memory-uuidx"
+
+
 def test_deploy_without_create_resolves_memory_by_display_name(tmp_path: pathlib.Path, monkeypatch):
     # Non-create path must resolve by display name (list+match), not get_memory_store (by id).
     src = tmp_path / "app"

--- a/integrations/mason/tests/unit_tests/deploy_test.py
+++ b/integrations/mason/tests/unit_tests/deploy_test.py
@@ -208,6 +208,7 @@ def test_resolve_memory_store_pages_at_100_and_matches_display_name():
 
     client = _PagingClient()
     store = deploy_mod._resolve_memory_store(client, "wanted")
+    assert store is not None
     assert store["name"] == "memory-stores/b"  # found on page 2
     assert all(ps == 100 for ps, _ in client.calls)  # never exceeds the API cap
     assert [pt for _, pt in client.calls] == [None, "p2"]  # followed the page token


### PR DESCRIPTION
Two bugs in the --with-memory-store deploy path:
- Resolving an existing store listed with page_size=1000, which the memory-stores list API rejects (INVALID_PARAMETER_VALUE: page_size must be between 1 and 100). Page through with page_size=100 and the next_page_token instead.
- Without --create-stores, resolution used get_memory_store(name), which looks up by resource id and so can't find a store by its display name (NOT_FOUND). Resolve by display name (list + match) on both paths.