### PR TITLE
mason: expose a public MasonClient Python SDK

### DIFF
--- a/integrations/mason/README.md
+++ b/integrations/mason/README.md
@@ -56,13 +56,18 @@ from databricks_mason import MasonClient
 client = MasonClient(profile="my-workspace")  # or MasonClient() for default auth
 
 store = client.create_memory_store("my-store")
-client.create_memory_entry("my-store", actor_id="alice", path="notes/1.md", content="hi")
-entries = client.list_memory_entries("my-store", actor_id="alice")
+print(store.name, store.display_name)  # typed attribute access
+
+client.create_memory_entry("my-store", actor_id="alice", path="/notes/1.md", content="hi")
+for entry in client.list_memory_entries("my-store", actor_id="alice").entries:
+    print(entry.path, entry.content)
 ```
 
-Each method maps to one `/api/agents/v1` operation and returns the raw JSON response
-dict. API errors raise `databricks_mason.AgentCliError`. Deployment, sandbox, and
-tracing remain CLI-only.
+Each method maps to one `/api/agents/v1` operation. Responses come back as typed
+models (`MemoryStore`, `Session`, `SessionItemList`, ...) that expose attribute
+accessors (`store.name`) while remaining plain dicts underneath — so `store["name"]`,
+`json.dumps(store)`, and any new server-side fields keep working. API errors raise
+`databricks_mason.AgentCliError`. Deployment, sandbox, and tracing remain CLI-only.
 
 ## Commands
 

--- a/integrations/mason/README.md
+++ b/integrations/mason/README.md
@@ -44,6 +44,26 @@ underlying credentials. If Databricks SDK default authentication is already conf
 you can skip `mason login`. You can also pass `--profile/-p` for an individual command.
 Use `--output json` for scripting.
 
+## Python SDK
+
+The same memory and session APIs are available programmatically through
+`MasonClient`, which authenticates exactly like the CLI (a `.databrickscfg` profile
+or the SDK's default resolution):
+
+```python
+from databricks_mason import MasonClient
+
+client = MasonClient(profile="my-workspace")  # or MasonClient() for default auth
+
+store = client.create_memory_store("my-store")
+client.create_memory_entry("my-store", actor_id="alice", path="notes/1.md", content="hi")
+entries = client.list_memory_entries("my-store", actor_id="alice")
+```
+
+Each method maps to one `/api/agents/v1` operation and returns the raw JSON response
+dict. API errors raise `databricks_mason.AgentCliError`. Deployment, sandbox, and
+tracing remain CLI-only.
+
 ## Commands
 
 ```text

--- a/integrations/mason/pyproject.toml
+++ b/integrations/mason/pyproject.toml
@@ -40,6 +40,7 @@ build-backend = "hatchling.build"
 [tool.hatch.build]
 include = [
     "src/databricks_mason/*",
+    "src/databricks_mason/py.typed",
     "src/databricks_mason/templates/**",
 ]
 

--- a/integrations/mason/src/databricks_mason/__init__.py
+++ b/integrations/mason/src/databricks_mason/__init__.py
@@ -1,1 +1,25 @@
-"""Databricks integration for Mason."""
+"""Databricks integration for Mason.
+
+Mason ships a `mason` CLI and this Python SDK over the same agents/v1 preview APIs.
+Construct a `MasonClient` and call one method per API operation:
+
+    from databricks_mason import MasonClient
+
+    client = MasonClient(profile="my-workspace")
+    client.create_memory_store("my-store")
+    for entry in client.list_memory_entries("my-store", actor_id="alice").get("entries", []):
+        ...
+
+Auth resolves through the Databricks SDK: pass a `.databrickscfg` profile or rely on
+its default resolution. API errors surface as `AgentCliError`.
+"""
+
+from databricks_mason.client import MasonClient, memory_entry_path, memory_store_path
+from databricks_mason.errors import AgentCliError
+
+__all__ = [
+    "MasonClient",
+    "AgentCliError",
+    "memory_store_path",
+    "memory_entry_path",
+]

--- a/integrations/mason/src/databricks_mason/__init__.py
+++ b/integrations/mason/src/databricks_mason/__init__.py
@@ -16,10 +16,40 @@ its default resolution. API errors surface as `AgentCliError`.
 
 from databricks_mason.client import MasonClient, memory_entry_path, memory_store_path
 from databricks_mason.errors import AgentCliError
+from databricks_mason.models import (
+    MemoryEntry,
+    MemoryEntryList,
+    MemorySearchHit,
+    MemorySearchResult,
+    MemoryStore,
+    MemoryStoreList,
+    PoppedSessionItem,
+    Session,
+    SessionItem,
+    SessionItemList,
+    SessionList,
+    SessionStore,
+    SessionStoreList,
+    StorageBackend,
+)
 
 __all__ = [
     "MasonClient",
     "AgentCliError",
     "memory_store_path",
     "memory_entry_path",
+    "MemoryStore",
+    "MemoryStoreList",
+    "MemoryEntry",
+    "MemoryEntryList",
+    "MemorySearchResult",
+    "MemorySearchHit",
+    "StorageBackend",
+    "SessionStore",
+    "SessionStoreList",
+    "Session",
+    "SessionList",
+    "SessionItem",
+    "SessionItemList",
+    "PoppedSessionItem",
 ]

--- a/integrations/mason/src/databricks_mason/auth.py
+++ b/integrations/mason/src/databricks_mason/auth.py
@@ -17,7 +17,7 @@ from typing import Optional
 import click
 
 from databricks_mason import render
-from databricks_mason.client import AgentApiClient
+from databricks_mason.client import MasonClient
 from databricks_mason.errors import AgentCliError
 
 
@@ -57,7 +57,7 @@ def login(obj, profile) -> None:
             "No profile to save.",
             hint="Pass one to remember, e.g. `mason login --profile my-workspace`.",
         )
-    client = AgentApiClient(profile)
+    client = MasonClient(profile)
     user = client.current_user  # round-trips current_user.me(), so a bad profile fails here
     _save_default_profile(profile)
     if obj.output == "json":

--- a/integrations/mason/src/databricks_mason/cli.py
+++ b/integrations/mason/src/databricks_mason/cli.py
@@ -1,7 +1,7 @@
 """`mason` — the Databricks CLI for agent deployment, memory, and sessions.
 
 Root Click group. Global `--profile` and `--output` flow to every subcommand via
-`CliContext` on `ctx.obj`; subcommands build an `AgentApiClient` from it on demand.
+`CliContext` on `ctx.obj`; subcommands build a `MasonClient` from it on demand.
 """
 
 from __future__ import annotations
@@ -11,7 +11,7 @@ from typing import Optional
 import click
 
 from databricks_mason.auth import load_default_profile, login, logout
-from databricks_mason.client import AgentApiClient
+from databricks_mason.client import MasonClient
 from databricks_mason.deploy import deploy, deployments
 from databricks_mason.memory import memory
 from databricks_mason.sandbox import add_sandbox
@@ -25,11 +25,11 @@ class CliContext:
     def __init__(self, profile: Optional[str], output: str):
         self.profile = profile
         self.output = output
-        self._client: Optional[AgentApiClient] = None
+        self._client: Optional[MasonClient] = None
 
-    def client(self) -> AgentApiClient:
+    def client(self) -> MasonClient:
         if self._client is None:
-            self._client = AgentApiClient(self.profile)
+            self._client = MasonClient(self.profile)
         return self._client
 
 

--- a/integrations/mason/src/databricks_mason/client.py
+++ b/integrations/mason/src/databricks_mason/client.py
@@ -13,6 +13,7 @@ from typing import Any, Optional
 
 from databricks.sdk import WorkspaceClient
 
+from databricks_mason import models
 from databricks_mason.errors import AgentCliError, wrap_api_error
 
 _BASE = "/api/agents/v1"
@@ -21,6 +22,11 @@ _BASE = "/api/agents/v1"
 def _query(**kwargs: Any) -> dict[str, Any]:
     """Build a query dict, dropping None and empty values."""
     return {k: v for k, v in kwargs.items() if v is not None and v != ""}
+
+
+def _as(cls: type, resp: Any) -> Any:
+    """Wrap a JSON response in a typed model, passing non-dicts through unchanged."""
+    return cls(resp) if isinstance(resp, dict) else resp
 
 
 def memory_store_path(name: str) -> str:
@@ -75,29 +81,40 @@ class MasonClient:
 
     # --- memory stores -------------------------------------------------------
 
-    def create_memory_store(self, display_name: str, description: Optional[str] = None) -> dict:
+    def create_memory_store(
+        self, display_name: str, description: Optional[str] = None
+    ) -> models.MemoryStore:
         body = _query(display_name=display_name, description=description)
-        return self._do("POST", f"{_BASE}/memory-stores", body=body)
+        return _as(models.MemoryStore, self._do("POST", f"{_BASE}/memory-stores", body=body))
 
-    def get_memory_store(self, name: str) -> dict:
-        return self._do("GET", f"{_BASE}/{memory_store_path(name)}")
+    def get_memory_store(self, name: str) -> models.MemoryStore:
+        return _as(models.MemoryStore, self._do("GET", f"{_BASE}/{memory_store_path(name)}"))
 
     def list_memory_stores(
         self, page_size: Optional[int] = None, page_token: Optional[str] = None
-    ) -> dict:
-        return self._do(
-            "GET",
-            f"{_BASE}/memory-stores",
-            query=_query(page_size=page_size, page_token=page_token),
+    ) -> models.MemoryStoreList:
+        return _as(
+            models.MemoryStoreList,
+            self._do(
+                "GET",
+                f"{_BASE}/memory-stores",
+                query=_query(page_size=page_size, page_token=page_token),
+            ),
         )
 
     def update_memory_store(
         self, name: str, display_name: Optional[str] = None, description: Optional[str] = None
-    ) -> dict:
+    ) -> models.MemoryStore:
         body = _query(display_name=display_name, description=description)
         mask = ",".join(body.keys())
-        return self._do(
-            "PATCH", f"{_BASE}/{memory_store_path(name)}", query=_query(update_mask=mask), body=body
+        return _as(
+            models.MemoryStore,
+            self._do(
+                "PATCH",
+                f"{_BASE}/{memory_store_path(name)}",
+                query=_query(update_mask=mask),
+                body=body,
+            ),
         )
 
     def delete_memory_store(self, name: str) -> dict:
@@ -114,7 +131,7 @@ class MasonClient:
         description: Optional[str] = None,
         session_id: Optional[str] = None,
         source_type: Optional[str] = None,
-    ) -> dict:
+    ) -> models.MemoryEntry:
         body = _query(
             actor_id=actor_id,
             path=path,
@@ -123,10 +140,15 @@ class MasonClient:
             session_id=session_id,
             source_type=source_type,
         )
-        return self._do("POST", f"{_BASE}/{memory_store_path(store)}/entries", body=body)
+        return _as(
+            models.MemoryEntry,
+            self._do("POST", f"{_BASE}/{memory_store_path(store)}/entries", body=body),
+        )
 
-    def get_memory_entry(self, store: str, entry: str) -> dict:
-        return self._do("GET", f"{_BASE}/{memory_entry_path(store, entry)}")
+    def get_memory_entry(self, store: str, entry: str) -> models.MemoryEntry:
+        return _as(
+            models.MemoryEntry, self._do("GET", f"{_BASE}/{memory_entry_path(store, entry)}")
+        )
 
     def list_memory_entries(
         self,
@@ -136,24 +158,30 @@ class MasonClient:
         session_id: Optional[str] = None,
         page_size: Optional[int] = None,
         page_token: Optional[str] = None,
-    ) -> dict:
-        return self._do(
-            "GET",
-            f"{_BASE}/{memory_store_path(store)}/entries",
-            query=_query(
-                actor_id=actor_id,
-                path_prefix=path_prefix,
-                session_id=session_id,
-                page_size=page_size,
-                page_token=page_token,
+    ) -> models.MemoryEntryList:
+        return _as(
+            models.MemoryEntryList,
+            self._do(
+                "GET",
+                f"{_BASE}/{memory_store_path(store)}/entries",
+                query=_query(
+                    actor_id=actor_id,
+                    path_prefix=path_prefix,
+                    session_id=session_id,
+                    page_size=page_size,
+                    page_token=page_token,
+                ),
             ),
         )
 
     def search_memory_entries(
         self, store: str, actor_id: str, query: str, limit: Optional[int] = None
-    ) -> dict:
+    ) -> models.MemorySearchResult:
         body = _query(actor_id=actor_id, query=query, limit=limit)
-        return self._do("POST", f"{_BASE}/{memory_store_path(store)}/entries:search", body=body)
+        return _as(
+            models.MemorySearchResult,
+            self._do("POST", f"{_BASE}/{memory_store_path(store)}/entries:search", body=body),
+        )
 
     def update_memory_entry(
         self,
@@ -161,9 +189,12 @@ class MasonClient:
         entry: str,
         content: Optional[str] = None,
         description: Optional[str] = None,
-    ) -> dict:
+    ) -> models.MemoryEntry:
         body = _query(content=content, description=description)
-        return self._do("PATCH", f"{_BASE}/{memory_entry_path(store, entry)}", body=body)
+        return _as(
+            models.MemoryEntry,
+            self._do("PATCH", f"{_BASE}/{memory_entry_path(store, entry)}", body=body),
+        )
 
     def delete_memory_entry(self, store: str, entry: str) -> dict:
         return self._do("DELETE", f"{_BASE}/{memory_entry_path(store, entry)}")
@@ -172,31 +203,40 @@ class MasonClient:
 
     def create_session_store(
         self, name: str, description: Optional[str] = None, metadata: Optional[dict] = None
-    ) -> dict:
+    ) -> models.SessionStore:
         body = _query(description=description, metadata=metadata)
-        return self._do(
-            "POST", f"{_BASE}/session-stores", query={"session_store_name": name}, body=body
+        return _as(
+            models.SessionStore,
+            self._do(
+                "POST", f"{_BASE}/session-stores", query={"session_store_name": name}, body=body
+            ),
         )
 
-    def get_session_store(self, name: str) -> dict:
-        return self._do("GET", f"{_BASE}/session-stores/{name}")
+    def get_session_store(self, name: str) -> models.SessionStore:
+        return _as(models.SessionStore, self._do("GET", f"{_BASE}/session-stores/{name}"))
 
     def list_session_stores(
         self, page_size: Optional[int] = None, page_token: Optional[str] = None
-    ) -> dict:
-        return self._do(
-            "GET",
-            f"{_BASE}/session-stores",
-            query=_query(page_size=page_size, page_token=page_token),
+    ) -> models.SessionStoreList:
+        return _as(
+            models.SessionStoreList,
+            self._do(
+                "GET",
+                f"{_BASE}/session-stores",
+                query=_query(page_size=page_size, page_token=page_token),
+            ),
         )
 
     def update_session_store(
         self, name: str, description: Optional[str] = None, metadata: Optional[dict] = None
-    ) -> dict:
+    ) -> models.SessionStore:
         body = _query(description=description, metadata=metadata)
         mask = ",".join(body.keys())
-        return self._do(
-            "PATCH", f"{_BASE}/session-stores/{name}", query=_query(update_mask=mask), body=body
+        return _as(
+            models.SessionStore,
+            self._do(
+                "PATCH", f"{_BASE}/session-stores/{name}", query=_query(update_mask=mask), body=body
+            ),
         )
 
     def delete_session_store(self, name: str) -> dict:
@@ -211,13 +251,16 @@ class MasonClient:
         session_id: Optional[str] = None,
         parent_session_id: Optional[str] = None,
         metadata: Optional[dict] = None,
-    ) -> dict:
+    ) -> models.Session:
         body = _query(actor_id=actor_id, parent_session_id=parent_session_id, metadata=metadata)
-        return self._do(
-            "POST",
-            f"{_BASE}/session-stores/{store}/sessions",
-            query=_query(session_id=session_id),
-            body=body,
+        return _as(
+            models.Session,
+            self._do(
+                "POST",
+                f"{_BASE}/session-stores/{store}/sessions",
+                query=_query(session_id=session_id),
+                body=body,
+            ),
         )
 
     def list_sessions(
@@ -227,26 +270,34 @@ class MasonClient:
         order_by: Optional[str] = None,
         page_size: Optional[int] = None,
         page_token: Optional[str] = None,
-    ) -> dict:
-        return self._do(
-            "GET",
-            f"{_BASE}/session-stores/{store}/sessions",
-            query=_query(
-                filter=filter, order_by=order_by, page_size=page_size, page_token=page_token
+    ) -> models.SessionList:
+        return _as(
+            models.SessionList,
+            self._do(
+                "GET",
+                f"{_BASE}/session-stores/{store}/sessions",
+                query=_query(
+                    filter=filter, order_by=order_by, page_size=page_size, page_token=page_token
+                ),
             ),
         )
 
-    def get_session(self, session_id: str, store: Optional[str] = None) -> dict:
+    def get_session(self, session_id: str, store: Optional[str] = None) -> models.Session:
         if store:
-            return self._do("GET", f"{_BASE}/session-stores/{store}/sessions/{session_id}")
-        return self._do("GET", f"{_BASE}/sessions/{session_id}")
+            path = f"{_BASE}/session-stores/{store}/sessions/{session_id}"
+        else:
+            path = f"{_BASE}/sessions/{session_id}"
+        return _as(models.Session, self._do("GET", path))
 
-    def update_session(self, store: str, session_id: str, metadata: dict) -> dict:
-        return self._do(
-            "PATCH",
-            f"{_BASE}/session-stores/{store}/sessions/{session_id}",
-            query={"update_mask": "metadata"},
-            body=_query(metadata=metadata),
+    def update_session(self, store: str, session_id: str, metadata: dict) -> models.Session:
+        return _as(
+            models.Session,
+            self._do(
+                "PATCH",
+                f"{_BASE}/session-stores/{store}/sessions/{session_id}",
+                query={"update_mask": "metadata"},
+                body=_query(metadata=metadata),
+            ),
         )
 
     def delete_session(self, store: str, session_id: str, force: bool = False) -> dict:
@@ -264,7 +315,7 @@ class MasonClient:
         up_to_item_id: Optional[str] = None,
         session_id: Optional[str] = None,
         metadata: Optional[dict] = None,
-    ) -> dict:
+    ) -> models.Session:
         body = _query(
             source_session_id=source_session_id,
             actor_id=actor_id,
@@ -272,7 +323,10 @@ class MasonClient:
             session_id=session_id,
             metadata=metadata,
         )
-        return self._do("POST", f"{_BASE}/session-stores/{store}/sessions:fork", body=body)
+        return _as(
+            models.Session,
+            self._do("POST", f"{_BASE}/session-stores/{store}/sessions:fork", body=body),
+        )
 
     # --- session items -------------------------------------------------------
 
@@ -283,22 +337,35 @@ class MasonClient:
         order_by: Optional[str] = None,
         page_size: Optional[int] = None,
         page_token: Optional[str] = None,
-    ) -> dict:
-        return self._do(
-            "GET",
-            f"{_BASE}/session-stores/{store}/sessions/{session_id}/items",
-            query=_query(order_by=order_by, page_size=page_size, page_token=page_token),
+    ) -> models.SessionItemList:
+        return _as(
+            models.SessionItemList,
+            self._do(
+                "GET",
+                f"{_BASE}/session-stores/{store}/sessions/{session_id}/items",
+                query=_query(order_by=order_by, page_size=page_size, page_token=page_token),
+            ),
         )
 
-    def append_session_items(self, store: str, session_id: str, items: list[dict]) -> dict:
+    def append_session_items(
+        self, store: str, session_id: str, items: list[dict]
+    ) -> models.SessionItemList:
         body = {"items": [{"data": item} for item in items]}
-        return self._do(
-            "POST", f"{_BASE}/session-stores/{store}/sessions/{session_id}/items:append", body=body
+        return _as(
+            models.SessionItemList,
+            self._do(
+                "POST",
+                f"{_BASE}/session-stores/{store}/sessions/{session_id}/items:append",
+                body=body,
+            ),
         )
 
-    def pop_session_item(self, store: str, session_id: str) -> dict:
-        return self._do(
-            "POST", f"{_BASE}/session-stores/{store}/sessions/{session_id}/items:pop", body={}
+    def pop_session_item(self, store: str, session_id: str) -> models.PoppedSessionItem:
+        return _as(
+            models.PoppedSessionItem,
+            self._do(
+                "POST", f"{_BASE}/session-stores/{store}/sessions/{session_id}/items:pop", body={}
+            ),
         )
 
     def clear_session_items(self, store: str, session_id: str) -> dict:

--- a/integrations/mason/src/databricks_mason/client.py
+++ b/integrations/mason/src/databricks_mason/client.py
@@ -1,7 +1,9 @@
-"""Authenticated REST client for the agents/v1 memory and session APIs.
+"""Authenticated client for the agents/v1 memory and session APIs.
 
-Wraps a databricks-sdk `WorkspaceClient` so auth/host come from a `.databrickscfg`
-profile. Each method maps to one API operation.
+`MasonClient` is Mason's public Python entry point: construct it with a
+`.databrickscfg` profile (or rely on the SDK's default auth) and call one method per
+API operation. It wraps a databricks-sdk `WorkspaceClient` and returns the raw JSON
+response dicts from `/api/agents/v1`.
 Deployment is handled separately (deploy.py) since it wraps the `databricks apps` CLI.
 """
 
@@ -34,8 +36,15 @@ def memory_entry_path(store: str, entry: str) -> str:
     return f"{memory_store_path(store)}/entries/{entry}"
 
 
-class AgentApiClient:
-    """Thin, authenticated wrapper over the agents/v1 REST surface."""
+class MasonClient:
+    """Thin, authenticated wrapper over the agents/v1 REST surface.
+
+    Example:
+        >>> from databricks_mason import MasonClient
+        >>> client = MasonClient(profile="my-workspace")
+        >>> store = client.create_memory_store("my-store")
+        >>> client.list_memory_stores()
+    """
 
     def __init__(self, profile: Optional[str] = None):
         try:
@@ -296,3 +305,7 @@ class AgentApiClient:
         return self._do(
             "POST", f"{_BASE}/session-stores/{store}/sessions/{session_id}/items:clear", body={}
         )
+
+
+# Backwards-compatible alias for the pre-1.0 internal name.
+AgentApiClient = MasonClient

--- a/integrations/mason/src/databricks_mason/models.py
+++ b/integrations/mason/src/databricks_mason/models.py
@@ -1,0 +1,270 @@
+"""Typed, forward-compatible views over agents/v1 JSON responses.
+
+Every model subclasses `dict` and holds the complete raw response, so mapping
+access (`store["name"]`), `json.dumps`, and any new/unknown server fields keep
+working. Subclasses add typed `@property` accessors as a convenience layer;
+they never mutate the stored data, so nothing is lost as the preview API grows.
+
+Accessors are intentionally named to avoid shadowing `dict` methods (e.g. list
+models expose `.stores` / `.session_items`, never `.items`).
+"""
+
+from __future__ import annotations
+
+from typing import Any, Optional
+
+
+class _Model(dict):
+    """A dict-backed API response with typed accessors over the raw JSON."""
+
+    def to_dict(self) -> dict:
+        """A plain-dict shallow copy of the raw response."""
+        return dict(self)
+
+
+def _wrap(value: Any, cls: type) -> Any:
+    return cls(value) if isinstance(value, dict) else None
+
+
+def _wrap_list(value: Any, cls: type) -> list:
+    return [cls(v) for v in value if isinstance(v, dict)] if isinstance(value, list) else []
+
+
+class StorageBackend(_Model):
+    @property
+    def backend_type(self) -> Optional[str]:
+        return self.get("backend_type")
+
+    @property
+    def backend_id(self) -> Optional[str]:
+        return self.get("backend_id")
+
+
+class MemoryStore(_Model):
+    @property
+    def name(self) -> Optional[str]:
+        return self.get("name")
+
+    @property
+    def display_name(self) -> Optional[str]:
+        return self.get("display_name")
+
+    @property
+    def workspace_id(self) -> Optional[str]:
+        return self.get("workspace_id")
+
+    @property
+    def owner_user_id(self) -> Optional[str]:
+        return self.get("owner_user_id")
+
+    @property
+    def description(self) -> Optional[str]:
+        return self.get("description")
+
+    @property
+    def storage_backend(self) -> Optional[StorageBackend]:
+        return _wrap(self.get("storage_backend"), StorageBackend)
+
+    @property
+    def create_time(self) -> Optional[str]:
+        return self.get("create_time")
+
+    @property
+    def update_time(self) -> Optional[str]:
+        return self.get("update_time")
+
+
+class MemoryEntry(_Model):
+    @property
+    def name(self) -> Optional[str]:
+        return self.get("name")
+
+    @property
+    def actor_id(self) -> Optional[str]:
+        return self.get("actor_id")
+
+    @property
+    def path(self) -> Optional[str]:
+        return self.get("path")
+
+    @property
+    def content(self) -> Optional[str]:
+        return self.get("content")
+
+    @property
+    def description(self) -> Optional[str]:
+        return self.get("description")
+
+    @property
+    def session_id(self) -> Optional[str]:
+        return self.get("session_id")
+
+    @property
+    def source_type(self) -> Optional[str]:
+        return self.get("source_type")
+
+    @property
+    def create_time(self) -> Optional[str]:
+        return self.get("create_time")
+
+    @property
+    def update_time(self) -> Optional[str]:
+        return self.get("update_time")
+
+
+class MemoryStoreList(_Model):
+    @property
+    def stores(self) -> list[MemoryStore]:
+        return _wrap_list(self.get("managed_memory_stores"), MemoryStore)
+
+    @property
+    def next_page_token(self) -> Optional[str]:
+        return self.get("next_page_token")
+
+
+class MemoryEntryList(_Model):
+    @property
+    def entries(self) -> list[MemoryEntry]:
+        return _wrap_list(self.get("managed_memory_entries"), MemoryEntry)
+
+    @property
+    def next_page_token(self) -> Optional[str]:
+        return self.get("next_page_token")
+
+
+class MemorySearchHit(_Model):
+    @property
+    def entry(self) -> Optional[MemoryEntry]:
+        return _wrap(self.get("managed_memory_entry"), MemoryEntry)
+
+    @property
+    def score(self) -> Optional[float]:
+        return self.get("score")
+
+
+class MemorySearchResult(_Model):
+    @property
+    def entries(self) -> list[MemoryEntry]:
+        return _wrap_list(self.get("managed_memory_entries"), MemoryEntry)
+
+    @property
+    def results(self) -> list[MemorySearchHit]:
+        return _wrap_list(self.get("results"), MemorySearchHit)
+
+    @property
+    def next_page_token(self) -> Optional[str]:
+        return self.get("next_page_token")
+
+
+class SessionStore(_Model):
+    @property
+    def session_store_name(self) -> Optional[str]:
+        return self.get("session_store_name")
+
+    @property
+    def session_store_id(self) -> Optional[str]:
+        return self.get("session_store_id")
+
+    @property
+    def creator_user_id(self) -> Optional[str]:
+        return self.get("creator_user_id")
+
+    @property
+    def description(self) -> Optional[str]:
+        return self.get("description")
+
+    @property
+    def create_time(self) -> Optional[str]:
+        return self.get("create_time")
+
+    @property
+    def update_time(self) -> Optional[str]:
+        return self.get("update_time")
+
+
+class SessionStoreList(_Model):
+    @property
+    def stores(self) -> list[SessionStore]:
+        return _wrap_list(self.get("session_stores"), SessionStore)
+
+    @property
+    def next_page_token(self) -> Optional[str]:
+        return self.get("next_page_token")
+
+
+class Session(_Model):
+    @property
+    def session_store_name(self) -> Optional[str]:
+        return self.get("session_store_name")
+
+    @property
+    def session_id(self) -> Optional[str]:
+        return self.get("session_id")
+
+    @property
+    def actor_id(self) -> Optional[str]:
+        return self.get("actor_id")
+
+    @property
+    def root_session_id(self) -> Optional[str]:
+        return self.get("root_session_id")
+
+    @property
+    def parent_session_id(self) -> Optional[str]:
+        return self.get("parent_session_id")
+
+    @property
+    def metadata(self) -> Optional[dict]:
+        return self.get("metadata")
+
+    @property
+    def create_time(self) -> Optional[str]:
+        return self.get("create_time")
+
+    @property
+    def update_time(self) -> Optional[str]:
+        return self.get("update_time")
+
+    @property
+    def last_activity_time(self) -> Optional[str]:
+        return self.get("last_activity_time")
+
+
+class SessionList(_Model):
+    @property
+    def sessions(self) -> list[Session]:
+        return _wrap_list(self.get("sessions"), Session)
+
+    @property
+    def next_page_token(self) -> Optional[str]:
+        return self.get("next_page_token")
+
+
+class SessionItem(_Model):
+    @property
+    def item_id(self) -> Optional[str]:
+        return self.get("item_id")
+
+    @property
+    def data(self) -> Any:
+        return self.get("data")
+
+    @property
+    def create_time(self) -> Optional[str]:
+        return self.get("create_time")
+
+
+class SessionItemList(_Model):
+    @property
+    def session_items(self) -> list[SessionItem]:
+        return _wrap_list(self.get("session_items"), SessionItem)
+
+    @property
+    def next_page_token(self) -> Optional[str]:
+        return self.get("next_page_token")
+
+
+class PoppedSessionItem(_Model):
+    @property
+    def item(self) -> Optional[SessionItem]:
+        return _wrap(self.get("item"), SessionItem)

--- a/integrations/mason/tests/unit_tests/auth_test.py
+++ b/integrations/mason/tests/unit_tests/auth_test.py
@@ -1,6 +1,6 @@
 """Unit tests for `mason login` / `logout` and the saved-profile helpers.
 
-`MASON_CONFIG_HOME` redirects the config file into a tmp dir, and `AgentApiClient`
+`MASON_CONFIG_HOME` redirects the config file into a tmp dir, and `MasonClient`
 is stubbed so login never touches the network.
 """
 
@@ -26,7 +26,7 @@ def _stub_client(monkeypatch, user="me@example.com", host="https://ws"):
     fake = mock.Mock()
     fake.current_user = user
     fake.host = host
-    monkeypatch.setattr(auth, "AgentApiClient", lambda profile: fake)
+    monkeypatch.setattr(auth, "MasonClient", lambda profile: fake)
 
 
 def test_load_default_profile_missing_returns_none(tmp_path, monkeypatch):

--- a/integrations/mason/tests/unit_tests/client_test.py
+++ b/integrations/mason/tests/unit_tests/client_test.py
@@ -1,10 +1,10 @@
-"""Unit tests for AgentApiClient paths, verbs, bodies, and error mapping."""
+"""Unit tests for MasonClient paths, verbs, bodies, and error mapping."""
 
 from __future__ import annotations
 
 from unittest import mock
 
-from databricks_mason.client import AgentApiClient, memory_entry_path, memory_store_path
+from databricks_mason.client import MasonClient, memory_entry_path, memory_store_path
 from databricks_mason.errors import AgentCliError
 
 
@@ -12,7 +12,7 @@ def _client(workspace_client):
     inst = workspace_client.return_value
     inst.config.host = "https://ws.example.com"
     inst.api_client.do.return_value = {}
-    return AgentApiClient(profile="p"), inst.api_client.do
+    return MasonClient(profile="p"), inst.api_client.do
 
 
 @mock.patch("databricks_mason.client.WorkspaceClient")

--- a/integrations/mason/tests/unit_tests/models_test.py
+++ b/integrations/mason/tests/unit_tests/models_test.py
@@ -1,0 +1,94 @@
+"""Tests for the dict-backed typed models over real captured response shapes."""
+
+from __future__ import annotations
+
+import json
+
+from databricks_mason import models
+
+# Shapes captured from a live agents/v1 workspace.
+STORE = {
+    "name": "memory-stores/abc",
+    "display_name": "my-store",
+    "workspace_id": "123",
+    "storage_backend": {"backend_type": "STORAGE_BACKEND_TYPE_LAKEBASE", "backend_id": "b1"},
+    "owner_user_id": "u1",
+    "description": "d",
+    "create_time": "2026-08-28T07:10:59.794Z",
+    "update_time": "2026-08-28T07:10:59.794Z",
+}
+ENTRY = {
+    "name": "memory-stores/abc/entries/e1",
+    "actor_id": "alice",
+    "path": "/notes/1.md",
+    "content": "hello",
+    "create_time": "t",
+    "update_time": "t",
+}
+
+
+def test_typed_and_dict_access_coexist():
+    s = models.MemoryStore(STORE)
+    assert s.name == "memory-stores/abc"
+    assert s.display_name == "my-store"
+    assert s["name"] == "memory-stores/abc"  # still a dict
+    backend = s.storage_backend
+    assert backend is not None
+    assert backend.backend_type == "STORAGE_BACKEND_TYPE_LAKEBASE"
+    assert backend.backend_id == "b1"
+
+
+def test_forward_compatible_unknown_fields_preserved():
+    s = models.MemoryStore({**STORE, "brand_new_field": 42})
+    assert s["brand_new_field"] == 42
+    assert s.to_dict()["brand_new_field"] == 42
+    assert s.name == "memory-stores/abc"
+
+
+def test_json_serializable():
+    s = models.MemoryStore(STORE)
+    assert json.loads(json.dumps(s)) == STORE
+
+
+def test_dict_methods_not_shadowed():
+    # `.items()` must remain dict.items(), not a list accessor.
+    s = models.MemoryStore(STORE)
+    assert callable(s.items)
+    assert ("name", "memory-stores/abc") in list(s.items())
+
+
+def test_list_models():
+    lst = models.MemoryStoreList({"managed_memory_stores": [STORE], "next_page_token": "tok"})
+    assert len(lst.stores) == 1
+    assert isinstance(lst.stores[0], models.MemoryStore)
+    assert lst.stores[0].display_name == "my-store"
+    assert lst.next_page_token == "tok"
+
+    empty = models.MemoryStoreList({})  # API omits the key when empty
+    assert empty.stores == []
+    assert empty.next_page_token is None
+
+
+def test_search_result():
+    r = models.MemorySearchResult(
+        {
+            "managed_memory_entries": [ENTRY],
+            "results": [{"managed_memory_entry": ENTRY, "score": 0.69}],
+        }
+    )
+    assert r.entries[0].path == "/notes/1.md"
+    assert r.results[0].score == 0.69
+    hit_entry = r.results[0].entry
+    assert hit_entry is not None
+    assert hit_entry.actor_id == "alice"
+
+
+def test_session_item_list_and_pop():
+    item = {"item_id": "i1", "data": {"role": "user"}, "create_time": "t"}
+    lst = models.SessionItemList({"session_items": [item]})
+    assert lst.session_items[0].item_id == "i1"
+    assert lst.session_items[0].data == {"role": "user"}
+
+    popped = models.PoppedSessionItem({"item": item})
+    assert popped.item is not None
+    assert popped.item.item_id == "i1"

--- a/integrations/mason/tests/unit_tests/test_imports.py
+++ b/integrations/mason/tests/unit_tests/test_imports.py
@@ -2,3 +2,18 @@ def test_package_import() -> None:
     import databricks_mason
 
     assert databricks_mason.__doc__
+
+
+def test_public_surface() -> None:
+    import databricks_mason
+
+    for name in ("MasonClient", "AgentCliError", "memory_store_path", "memory_entry_path"):
+        assert name in databricks_mason.__all__
+        assert hasattr(databricks_mason, name)
+
+
+def test_agentapiclient_alias() -> None:
+    from databricks_mason import MasonClient
+    from databricks_mason.client import AgentApiClient
+
+    assert AgentApiClient is MasonClient


### PR DESCRIPTION
## Summary

Turns Mason's agents/v1 client into a supported, typed Python SDK alongside the `mason` CLI, with **no change to CLI behavior**. Two commits:

**1. Public `MasonClient` surface**
- Rename `AgentApiClient` → **`MasonClient`** as the canonical public name (backwards-compatible alias kept).
- Export `MasonClient`, `AgentCliError`, and path helpers via `__all__`.
- Ship a `py.typed` marker (included in the wheel).

**2. Typed return models**
- Responses come back as typed models (`MemoryStore`, `MemoryEntry`, `Session`, `SessionItemList`, `MemorySearchResult`, ...) with attribute accessors (`store.name`, `page.stores`, `hit.score`).
- Models **subclass `dict`** and hold the complete raw response, so `store["name"]`, `json.dumps(store)`, and any new/unknown server fields keep working — and the CLI's `field()` / `emit_json` paths are untouched. Accessors are named to avoid shadowing `dict` methods (`.stores` / `.session_items`, never `.items`).

Usage:

```python
from databricks_mason import MasonClient

client = MasonClient(profile="my-workspace")   # or MasonClient() for default auth
store = client.create_memory_store("my-store")
print(store.name, store.display_name)          # typed
for entry in client.list_memory_entries("my-store", actor_id="alice").entries:
    print(entry.path, entry.content)
```

Scope: deploy/sandbox/tracing remain CLI-only.

## Test plan
E2E testing notebook: https://eng-ml-inference.staging.cloud.databricks.com/editor/notebooks/3095193216884544?o=1653573648247579

- [x] `pytest` — 70 passed
- [x] `ruff check` + `ruff format --check` — clean
- [x] `ty check` — clean
- [x] **Live smoke test** against `eng-ml-agent-bricks-us-east-1` (staging): full CRUD across memory stores/entries/search and session stores/sessions/items, all typed accessors verified against real responses, temp resources cleaned up.
- [x] **CLI regression check** against the live API: text tables + `--output json` render correctly through the dict-backed models.

This pull request and its description were written by Isaac.