### PR TITLE
Add session creation and browsing to Mason chat UI

### DIFF
--- a/integrations/mason/src/databricks_mason/templates/mcp_runtime_langgraph.py
+++ b/integrations/mason/src/databricks_mason/templates/mcp_runtime_langgraph.py
@@ -10,8 +10,11 @@ from agent.mason.tool_manifest import (  # ty: ignore[unresolved-import]
     downscope_wire,
     load_tools,
 )
+from agent.mason.workspace import (  # ty: ignore[unresolved-import]
+    workspace_client,
+    workspace_headers,
+)
 from agent.mcps import build_mcp_servers  # ty: ignore[unresolved-import]
-from databricks.sdk import WorkspaceClient
 from databricks_langchain import (  # ty: ignore[unresolved-import]
     DatabricksMCPServer,
     DatabricksMultiServerMCPClient,
@@ -22,13 +25,14 @@ logger = logging.getLogger(__name__)
 
 
 def _server_from_tool(tool: ToolRecord) -> DatabricksMCPServer | None:
-    workspace_client = WorkspaceClient()
-    host = workspace_client.config.host.rstrip("/")
+    client = workspace_client()
+    host = client.config.host.rstrip("/")
     if tool.kind in {"sandbox", "mcp"}:
         return DatabricksMCPServer(
             name=tool.id,
             url=f"{host}/ai-gateway/mcp-services/{tool.service}",
-            workspace_client=workspace_client,
+            headers=workspace_headers() or None,
+            workspace_client=client,
             timeout=120.0,
         )
     if tool.kind == "uc_function":
@@ -38,7 +42,8 @@ def _server_from_tool(tool: ToolRecord) -> DatabricksMCPServer | None:
             schema=schema,
             function_name=function_name,
             name=tool.id,
-            workspace_client=workspace_client,
+            headers=workspace_headers() or None,
+            workspace_client=client,
             timeout=120.0,
         )
     return None

--- a/integrations/mason/templates/agent-langgraph/README.md
+++ b/integrations/mason/templates/agent-langgraph/README.md
@@ -146,7 +146,13 @@ poll reaches the same replica, but the run itself does not survive a restart.
 
 When initialized with `mason init --framework langgraph --enable-chat-app`, the browser also calls:
 
+- `POST /api/session/new` to generate a fresh session id and replace the routing cookie. The request
+  has no body-level `session_id`; the response includes the new and previous ids.
 - `POST /api/demo/sessions` to create or resolve the current cookie-backed managed session.
+- `GET /api/demo/sessions` to list recent sessions for the configured actor. In local in-memory mode
+  it returns only the current browser session.
+- `POST /api/demo/sessions/{session_id}/open` to verify an actor-scoped managed session, replace the
+  routing cookie, and load that session's transcript and pending state.
 - `GET /api/demo/session/items` to load the current transcript. Without a managed Session Store it
   reconstructs messages and pending interrupts from the in-process LangGraph checkpoint.
 - `POST /api/demo/session/items` to mirror user, assistant, tool, and human-decision items into the

--- a/integrations/mason/templates/agent-langgraph/README.md
+++ b/integrations/mason/templates/agent-langgraph/README.md
@@ -154,7 +154,8 @@ When initialized with `mason init --framework langgraph --enable-chat-app`, the 
 - `POST /api/demo/sessions/{session_id}/open` to verify an actor-scoped managed session, replace the
   routing cookie, and load that session's transcript and pending state.
 - `GET /api/demo/session/items` to load the current transcript. Without a managed Session Store it
-  reconstructs messages and pending interrupts from the in-process LangGraph checkpoint.
+  reconstructs messages and pending interrupts from the in-process LangGraph checkpoint. Managed
+  responses filter out checkpoint fragments and durability events before returning items to the UI.
 - `POST /api/demo/session/items` to mirror user, assistant, tool, and human-decision items into the
   managed Session Store.
 - `GET /api/demo/memory/entries`, `POST /api/demo/memory/entries`, and

--- a/integrations/mason/templates/agent-langgraph/agent/agent.py
+++ b/integrations/mason/templates/agent-langgraph/agent/agent.py
@@ -3,7 +3,6 @@ import os
 from collections.abc import AsyncGenerator, AsyncIterator
 from typing import Any
 
-from databricks.sdk import WorkspaceClient
 from databricks_langchain import ChatDatabricks
 from langchain.agents import create_agent
 from langchain.agents.middleware import HumanInTheLoopMiddleware
@@ -13,6 +12,7 @@ from langgraph.types import Command
 from agent.mason import mcp_runtime, tracing
 from agent.mason.memory import memory_tools
 from agent.mason.session_store import checkpointer, thread_config
+from agent.mason.workspace import workspace_client, workspace_headers
 
 # Importing the tools package auto-registers every tool module.
 from agent.tools import all_tools
@@ -26,6 +26,16 @@ MODEL = "databricks-gpt-5-2"
 # When a listed tool is about to run, the agent pauses and emits an `interrupt` event; the client
 # resumes by sending `resume` with the same session id. Empty this dict to disable approval gating.
 REQUIRE_APPROVAL = {"send_message": True}
+
+
+class _RoutedChatDatabricks(ChatDatabricks):
+    """Forward account-host workspace routing to the underlying OpenAI clients."""
+
+    def _get_client_kwargs(self) -> dict[str, Any]:
+        kwargs = super()._get_client_kwargs()
+        if headers := workspace_headers():
+            kwargs["default_headers"] = headers
+        return kwargs
 
 
 def configure() -> None:
@@ -42,7 +52,7 @@ def _check_databricks_auth() -> None:
     the model client uses, so the failure is immediate and actionable.
     """
     try:
-        WorkspaceClient()
+        workspace_client()
     except Exception as e:
         profile = os.getenv("DATABRICKS_CONFIG_PROFILE")
         target = (
@@ -65,7 +75,7 @@ async def create_agent_graph():
         [HumanInTheLoopMiddleware(interrupt_on=REQUIRE_APPROVAL)] if REQUIRE_APPROVAL else []
     )
     return create_agent(
-        model=ChatDatabricks(endpoint=MODEL),
+        model=_RoutedChatDatabricks(endpoint=MODEL, workspace_client=workspace_client()),
         tools=tools,
         middleware=middleware,
         checkpointer=checkpointer(),

--- a/integrations/mason/templates/agent-langgraph/agent/mason/durability.py
+++ b/integrations/mason/templates/agent-langgraph/agent/mason/durability.py
@@ -13,6 +13,8 @@ from typing import Any, cast
 
 from databricks.sdk import WorkspaceClient
 
+from agent.mason.workspace import workspace_client as default_workspace_client
+
 _EVENT_TYPE = "mason_demo_durability"
 _SESSION_STORE_ENV = "AGENT_SESSION_STORE"
 _SESSION_ACTOR_ENV = "AGENT_SESSION_ACTOR_ID"
@@ -35,7 +37,7 @@ class _SessionStoreClient:
     """Minimal Session Store client kept local to the generated durability demo."""
 
     def __init__(self, workspace_client: WorkspaceClient | None = None) -> None:
-        self._workspace = workspace_client or WorkspaceClient()
+        self._workspace = workspace_client or default_workspace_client()
         self._store_name = ""
 
     def set_session_store(self, session_store_name: str) -> "_SessionStoreClient":

--- a/integrations/mason/templates/agent-langgraph/agent/mason/mcp_runtime.py
+++ b/integrations/mason/templates/agent-langgraph/agent/mason/mcp_runtime.py
@@ -5,24 +5,25 @@ from __future__ import annotations
 import logging
 from typing import Any
 
-from databricks.sdk import WorkspaceClient
 from databricks_langchain import DatabricksMCPServer, DatabricksMultiServerMCPClient
 from langchain_mcp_adapters.sessions import create_session
 
 from agent.mason.tool_manifest import ToolRecord, downscope_wire, load_tools
+from agent.mason.workspace import workspace_client, workspace_headers
 from agent.mcps import build_mcp_servers
 
 logger = logging.getLogger(__name__)
 
 
 def _server_from_tool(tool: ToolRecord) -> DatabricksMCPServer | None:
-    workspace_client = WorkspaceClient()
-    host = workspace_client.config.host.rstrip("/")
+    client = workspace_client()
+    host = client.config.host.rstrip("/")
     if tool.kind in {"sandbox", "mcp"}:
         return DatabricksMCPServer(
             name=tool.id,
             url=f"{host}/ai-gateway/mcp-services/{tool.service}",
-            workspace_client=workspace_client,
+            headers=workspace_headers() or None,
+            workspace_client=client,
             timeout=120.0,
         )
     if tool.kind == "uc_function":
@@ -32,7 +33,8 @@ def _server_from_tool(tool: ToolRecord) -> DatabricksMCPServer | None:
             schema=schema,
             function_name=function_name,
             name=tool.id,
-            workspace_client=workspace_client,
+            headers=workspace_headers() or None,
+            workspace_client=client,
             timeout=120.0,
         )
     return None

--- a/integrations/mason/templates/agent-langgraph/agent/mason/memory.py
+++ b/integrations/mason/templates/agent-langgraph/agent/mason/memory.py
@@ -15,8 +15,9 @@ long-term memory; change ``_actor_id`` to scope per user (e.g. from request cont
 
 import os
 
-from databricks.sdk import WorkspaceClient
 from langchain_core.tools import BaseTool, tool
+
+from agent.mason.workspace import workspace_client
 
 _AGENTS_V1 = "/api/agents/v1"
 
@@ -31,7 +32,7 @@ def _store_path() -> str:
 
 def _api():
     # Build the client lazily (needs workspace auth) so importing this module stays cheap.
-    return WorkspaceClient().api_client
+    return workspace_client().api_client
 
 
 @tool

--- a/integrations/mason/templates/agent-langgraph/agent/mason/session_store_client.py
+++ b/integrations/mason/templates/agent-langgraph/agent/mason/session_store_client.py
@@ -17,6 +17,8 @@ from typing import Any, Iterator, Optional, Sequence
 
 from databricks.sdk import WorkspaceClient
 
+from agent.mason.workspace import workspace_client as default_workspace_client
+
 _API_ROOT = "/api/agents/v1"
 
 
@@ -42,7 +44,7 @@ class SessionStoreClient:
     """Thin REST client over the managed Session Store API."""
 
     def __init__(self, workspace_client: Optional[WorkspaceClient] = None) -> None:
-        self._api = (workspace_client or WorkspaceClient()).api_client
+        self._api = (workspace_client or default_workspace_client()).api_client
         self._store_name: Optional[str] = None
 
     def set_session_store(self, session_store_name: str) -> "SessionStoreClient":

--- a/integrations/mason/templates/agent-langgraph/agent/mason/workspace.py
+++ b/integrations/mason/templates/agent-langgraph/agent/mason/workspace.py
@@ -1,0 +1,27 @@
+"""Construct Databricks SDK clients with workspace routing when required."""
+
+from __future__ import annotations
+
+import os
+
+from databricks.sdk import WorkspaceClient
+
+
+def workspace_headers() -> dict[str, str]:
+    """Return headers required to route an account-host request to its workspace."""
+    workspace_id = os.getenv("DATABRICKS_WORKSPACE_ID", "").strip()
+    return {"X-Databricks-Org-Id": workspace_id} if workspace_id else {}
+
+
+def workspace_client() -> WorkspaceClient:
+    """Return the environment-authenticated client for the active workspace.
+
+    ``databricks apps run-local`` can authenticate through an account-level vanity host while
+    exposing the target workspace through ``DATABRICKS_WORKSPACE_ID``. The SDK needs the same
+    routing header as the Databricks CLI for those profiles. Ordinary workspace hosts and deployed
+    Apps continue to use the SDK's default authentication chain.
+    """
+    headers = workspace_headers()
+    if not headers:
+        return WorkspaceClient()
+    return WorkspaceClient(custom_headers=headers)

--- a/integrations/mason/templates/agent-langgraph/runtime/runtime.py
+++ b/integrations/mason/templates/agent-langgraph/runtime/runtime.py
@@ -15,9 +15,10 @@ documented router cookie for sticky routing.
 
 Endpoints: ``POST /invocations`` (``stream: true`` → SSE ending with ``data: [DONE]``;
 ``background: true`` → an ``invocation_id`` to poll), ``GET /invocations/{invocation_id}`` to poll a
-background run, and ``GET /health``. Each route also has an ``/api`` alias because Databricks Apps
-accepts programmatic Bearer-token authentication only on paths under ``/api/``. Each request is
-wrapped in an MLflow span for tracing.
+background run, ``POST /api/session/new`` to rotate the routing session, and ``GET /health``. The
+invocation and health routes also have ``/api`` aliases because Databricks Apps accepts programmatic
+Bearer-token authentication only on paths under ``/api/``. Each request is wrapped in an MLflow span
+for tracing.
 """
 
 import asyncio
@@ -26,7 +27,7 @@ from collections.abc import AsyncGenerator, Awaitable, Callable
 
 import mlflow
 from agent.mason.background import BackgroundRuns
-from fastapi import FastAPI, Request
+from fastapi import FastAPI, Request, Response
 from fastapi.responses import JSONResponse, StreamingResponse
 from uuid_utils import uuid7
 
@@ -53,6 +54,27 @@ def _sse(data: dict | str) -> str:
 def _set_trace_name(name: str) -> None:
     if mlflow.get_current_active_span() is not None:
         mlflow.update_current_trace(tags={_TRACE_NAME_TAG: name})
+
+
+def rotate_session_cookie(request: Request, response: Response, session_id: str) -> None:
+    if request.cookies.get(_ROUTING_COOKIE):
+        response.set_cookie(
+            _ROUTING_COOKIE,
+            session_id,
+            secure=True,
+            httponly=True,
+            samesite="lax",
+            path="/",
+        )
+        response.delete_cookie(_LOCAL_SESSION_COOKIE, path="/")
+    elif request.cookies.get(_LOCAL_SESSION_COOKIE):
+        response.set_cookie(
+            _LOCAL_SESSION_COOKIE,
+            session_id,
+            httponly=True,
+            samesite="lax",
+            path="/",
+        )
 
 
 def build_app(invoke_handler: InvokeHandler, stream_handler: StreamHandler) -> FastAPI:
@@ -135,5 +157,19 @@ def build_app(invoke_handler: InvokeHandler, stream_handler: StreamHandler) -> F
     @app.get("/health")
     async def health() -> dict[str, str]:
         return {"status": "ok"}
+
+    @app.post("/api/session/new")
+    async def new_session(request: Request) -> JSONResponse:
+        previous_session_id = request.state.session_id
+        session_id = str(uuid7())
+        request.state.session_id = session_id
+        response = JSONResponse(
+            {
+                "session_id": session_id,
+                "previous_session_id": previous_session_id,
+            }
+        )
+        rotate_session_cookie(request, response, session_id)
+        return response
 
     return app

--- a/integrations/mason/templates/agent-langgraph/tests/test_agent.py
+++ b/integrations/mason/templates/agent-langgraph/tests/test_agent.py
@@ -61,6 +61,17 @@ def test_configure_raises_clear_error_without_auth(monkeypatch):
         configure()
 
 
+def test_chat_model_forwards_account_routing_header(monkeypatch):
+    from agent.agent import _RoutedChatDatabricks
+
+    monkeypatch.setenv("DATABRICKS_WORKSPACE_ID", "123456")
+    model = _RoutedChatDatabricks(endpoint="test-endpoint")
+
+    assert model._get_client_kwargs()["default_headers"] == {
+        "X-Databricks-Org-Id": "123456"
+    }
+
+
 def test_thread_config_from_session_id():
     # actor_id rides alongside thread_id — the durable saver maps it onto the Session's actor.
     assert thread_config("abc-123") == {

--- a/integrations/mason/templates/agent-langgraph/tests/test_agent.py
+++ b/integrations/mason/templates/agent-langgraph/tests/test_agent.py
@@ -6,6 +6,7 @@ model; it is skipped unless a workspace profile is configured.
 """
 
 import os
+from uuid import UUID
 
 import pytest
 from agent.agent import _serialize_events, _session_id
@@ -62,12 +63,16 @@ def test_configure_raises_clear_error_without_auth(monkeypatch):
 
 def test_thread_config_from_session_id():
     # actor_id rides alongside thread_id — the durable saver maps it onto the Session's actor.
-    assert thread_config("abc-123") == {"configurable": {"thread_id": "abc-123", "actor_id": "abc-123"}}
+    assert thread_config("abc-123") == {
+        "configurable": {"thread_id": "abc-123", "actor_id": "abc-123"}
+    }
 
 
 def test_thread_config_uses_configured_actor(monkeypatch):
     monkeypatch.setenv("AGENT_SESSION_ACTOR_ID", "alice")
-    assert thread_config("abc-123") == {"configurable": {"thread_id": "abc-123", "actor_id": "alice"}}
+    assert thread_config("abc-123") == {
+        "configurable": {"thread_id": "abc-123", "actor_id": "alice"}
+    }
 
 
 def test_checkpointer_is_shared(monkeypatch):
@@ -148,6 +153,63 @@ def test_runtime_sets_local_session_cookie_when_apps_router_is_absent():
     assert first.status_code == 200
     assert first.cookies.get("mason-local-session") == first.json()["session_id"]
     assert second.json()["session_id"] == first.json()["session_id"]
+
+
+def test_runtime_rotates_local_session_cookie():
+    async def invoke_handler(request):
+        return {"output": [], "session_id": request["session_id"], "status": "completed"}
+
+    async def stream_handler(request):
+        if False:
+            yield request
+
+    client = TestClient(build_app(invoke_handler, stream_handler))
+    current = client.post("/invocations", json={"input": []}).json()["session_id"]
+    created = client.post("/api/session/new")
+
+    assert created.status_code == 200
+    assert created.json()["previous_session_id"] == current
+    assert created.json()["session_id"] != current
+    UUID(created.json()["session_id"])
+    assert created.cookies.get("mason-local-session") == created.json()["session_id"]
+    assert (
+        client.post("/invocations", json={"input": []}).json()["session_id"]
+        == created.json()["session_id"]
+    )
+
+
+def test_runtime_rotates_apps_routing_cookie_and_clears_local_fallback():
+    async def invoke_handler(request):
+        return {"output": [], "session_id": request["session_id"], "status": "completed"}
+
+    async def stream_handler(request):
+        if False:
+            yield request
+
+    client = TestClient(build_app(invoke_handler, stream_handler), base_url="https://testserver")
+    created = client.post(
+        "/api/session/new",
+        headers={"cookie": "__Host-databricks-app-router=old-session; mason-local-session=stale"},
+    )
+
+    assert created.status_code == 200
+    assert created.json()["previous_session_id"] == "old-session"
+    session_id = created.json()["session_id"]
+    set_cookie_headers = created.headers.get_list("set-cookie")
+    routing_cookie = next(
+        header
+        for header in set_cookie_headers
+        if header.startswith("__Host-databricks-app-router=")
+    ).lower()
+    assert "httponly" in routing_cookie
+    assert "path=/" in routing_cookie
+    assert "samesite=lax" in routing_cookie
+    assert "secure" in routing_cookie
+    assert any(
+        header.startswith('mason-local-session=""') and "Max-Age=0" in header
+        for header in set_cookie_headers
+    )
+    assert client.post("/invocations", json={"input": []}).json()["session_id"] == session_id
 
 
 def _has_workspace_auth() -> bool:

--- a/integrations/mason/templates/agent-langgraph/tests/test_workspace.py
+++ b/integrations/mason/templates/agent-langgraph/tests/test_workspace.py
@@ -1,0 +1,28 @@
+from agent.mason import workspace
+
+
+class _FakeWorkspaceClient:
+    def __init__(self, **kwargs):
+        self.kwargs = kwargs
+
+
+def test_workspace_client_adds_account_routing_header(monkeypatch):
+    monkeypatch.setenv("DATABRICKS_WORKSPACE_ID", " 123456 ")
+    monkeypatch.setattr(workspace, "WorkspaceClient", _FakeWorkspaceClient)
+
+    client = workspace.workspace_client()
+
+    assert client.kwargs == {
+        "custom_headers": {"X-Databricks-Org-Id": "123456"},
+    }
+    assert workspace.workspace_headers() == {"X-Databricks-Org-Id": "123456"}
+
+
+def test_workspace_client_uses_default_sdk_resolution_without_workspace_id(monkeypatch):
+    monkeypatch.delenv("DATABRICKS_WORKSPACE_ID", raising=False)
+    monkeypatch.setattr(workspace, "WorkspaceClient", _FakeWorkspaceClient)
+
+    client = workspace.workspace_client()
+
+    assert client.kwargs == {}
+    assert workspace.workspace_headers() == {}

--- a/integrations/mason/templates/ui/agent-langgraph/CHAT_APP.md
+++ b/integrations/mason/templates/ui/agent-langgraph/CHAT_APP.md
@@ -29,6 +29,14 @@ the application session id; request bodies do not carry `session_id`. Local deve
 runtime's `mason-local-session` fallback cookie. TODO: switch to `X-Routing-Key` when Apps supports
 it.
 
+The Sessions card calls `POST /api/session/new` to replace that routing cookie with a fresh UUID and
+start an empty conversation. With a managed Session Store, `GET /api/demo/sessions` lists the most
+recent sessions for the configured actor and each Open action calls
+`POST /api/demo/sessions/{session_id}/open`. Opening a listed session verifies that it belongs to the
+same actor, replaces the routing cookie, and reloads its transcript and pending LangGraph state. In
+local in-memory mode only the current browser session can be listed because there is no shared
+session index.
+
 The recovery flow is intentionally a demo, not a production lease implementation: ownership is
 last-writer-wins, the worker persists heartbeats, the browser detects a stale owner, and work resumes
 at the first node whose output was not checkpointed.

--- a/integrations/mason/templates/ui/agent-langgraph/CHAT_APP.md
+++ b/integrations/mason/templates/ui/agent-langgraph/CHAT_APP.md
@@ -37,6 +37,10 @@ same actor, replaces the routing cookie, and reloads its transcript and pending 
 local in-memory mode only the current browser session can be listed because there is no shared
 session index.
 
+The session list excludes internal `mason-demo-durability` execution sessions. Transcript responses
+also include only user, assistant, tool, system, and human-decision message items; checkpoint
+fragments and durability events remain in Session Store but are never returned to the chat UI.
+
 The recovery flow is intentionally a demo, not a production lease implementation: ownership is
 last-writer-wins, the worker persists heartbeats, the browser detects a stale owner, and work resumes
 at the first node whose output was not checkpointed.

--- a/integrations/mason/templates/ui/agent-langgraph/runtime/ui.py
+++ b/integrations/mason/templates/ui/agent-langgraph/runtime/ui.py
@@ -10,7 +10,7 @@ from pathlib import Path
 from typing import Any
 
 from agent.mason import recovery
-from databricks.sdk import WorkspaceClient
+from agent.mason.workspace import workspace_client
 from fastapi import FastAPI, HTTPException, Query, Request
 from fastapi.responses import FileResponse, JSONResponse
 from fastapi.staticfiles import StaticFiles
@@ -79,7 +79,7 @@ def _session_actor() -> str:
 
 class _ManagedStateClient:
     def __init__(self) -> None:
-        self._workspace = WorkspaceClient()
+        self._workspace = workspace_client()
 
     def _do(
         self,

--- a/integrations/mason/templates/ui/agent-langgraph/runtime/ui.py
+++ b/integrations/mason/templates/ui/agent-langgraph/runtime/ui.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import json
 import os
 from functools import lru_cache
 from pathlib import Path
@@ -11,9 +12,10 @@ from typing import Any
 from agent.mason import recovery
 from databricks.sdk import WorkspaceClient
 from fastapi import FastAPI, HTTPException, Query, Request
-from fastapi.responses import FileResponse
+from fastapi.responses import FileResponse, JSONResponse
 from fastapi.staticfiles import StaticFiles
 from pydantic import BaseModel, Field
+from runtime.runtime import rotate_session_cookie
 
 _UI_ROOT = Path(__file__).resolve().parent.parent / "ui"
 _INSTANCE_ID = recovery.process_id()
@@ -44,9 +46,7 @@ def _execution_identity() -> str:
         return "Databricks App service principal"
     profile = os.getenv("DATABRICKS_CONFIG_PROFILE")
     return (
-        f"Local Databricks profile: {profile}"
-        if profile
-        else "Databricks default authentication"
+        f"Local Databricks profile: {profile}" if profile else "Databricks default authentication"
     )
 
 
@@ -94,9 +94,7 @@ class _ManagedStateClient:
         }
         if request.description:
             body["description"] = request.description
-        return self._do(
-            "POST", f"{_AGENTS_API}/memory-stores/{_memory_store()}/entries", body=body
-        )
+        return self._do("POST", f"{_AGENTS_API}/memory-stores/{_memory_store()}/entries", body=body)
 
     def list_memory_entries(self, path_prefix: str | None = None) -> dict:
         query = {"actor_id": _memory_actor(), "page_size": 100}
@@ -144,9 +142,18 @@ class _ManagedStateClient:
             f"{_AGENTS_API}/session-stores/{_session_store()}/sessions/{session_id}",
         )
 
-    def append_session_items(
-        self, session_id: str, items: list[dict[str, Any]]
-    ) -> dict:
+    def list_sessions(self) -> dict:
+        return self._do(
+            "GET",
+            f"{_AGENTS_API}/session-stores/{_session_store()}/sessions",
+            query={
+                "filter": f"actor_id = {json.dumps(_session_actor())}",
+                "order_by": "last_activity_time desc",
+                "page_size": 50,
+            },
+        )
+
+    def append_session_items(self, session_id: str, items: list[dict[str, Any]]) -> dict:
         return self._do(
             "POST",
             f"{_AGENTS_API}/session-stores/{_session_store()}/sessions/{session_id}/items:append",
@@ -230,9 +237,7 @@ async def _checkpoint_history(session_id: str) -> dict[str, Any]:
 
 def install_ui(app: FastAPI) -> None:
     """Mount the Mason demo UI and its runtime control endpoints."""
-    app.mount(
-        "/ui-assets", StaticFiles(directory=_UI_ROOT), name="mason-demo-ui-assets"
-    )
+    app.mount("/ui-assets", StaticFiles(directory=_UI_ROOT), name="mason-demo-ui-assets")
 
     @app.get("/", include_in_schema=False)
     async def index() -> FileResponse:
@@ -259,9 +264,7 @@ def install_ui(app: FastAPI) -> None:
                 "durable": bool(session_store),
                 "managed": bool(session_store),
                 "history": True,
-                "mode": "Managed Session Store"
-                if session_store
-                else "In-process checkpointer",
+                "mode": "Managed Session Store" if session_store else "In-process checkpointer",
                 "store": session_store or None,
                 "actor": _session_actor(),
             },
@@ -298,9 +301,7 @@ def install_ui(app: FastAPI) -> None:
         }
 
     @app.post("/api/demo/memory/entries", include_in_schema=False)
-    async def create_memory_entry(
-        request: Request, payload: MemoryEntryRequest
-    ) -> dict:
+    async def create_memory_entry(request: Request, payload: MemoryEntryRequest) -> dict:
         _require_memory()
         return await _managed_call(
             _state_client().create_memory_entry, payload, request.state.session_id
@@ -321,21 +322,55 @@ def install_ui(app: FastAPI) -> None:
     @app.post("/api/demo/sessions", include_in_schema=False)
     async def ensure_session(request: Request) -> dict:
         _require_session()
-        return await _managed_call(
-            _state_client().ensure_session, request.state.session_id
+        return await _managed_call(_state_client().ensure_session, request.state.session_id)
+
+    @app.get("/api/demo/sessions", include_in_schema=False)
+    async def list_sessions(request: Request) -> dict:
+        session_id = request.state.session_id
+        if not _session_store():
+            return {
+                "sessions": [
+                    {
+                        "session_id": session_id,
+                        "actor_id": _session_actor(),
+                        "metadata": {"client": "mason-demo-ui-local"},
+                    }
+                ],
+                "current_session_id": session_id,
+                "managed": False,
+            }
+        result = await _managed_call(_state_client().list_sessions)
+        return {
+            **result,
+            "current_session_id": session_id,
+            "managed": True,
+        }
+
+    @app.post("/api/demo/sessions/{session_id}/open", include_in_schema=False)
+    async def open_session(request: Request, session_id: str) -> JSONResponse:
+        _require_session()
+        session = await _managed_call(_state_client().get_session, session_id)
+        if session.get("actor_id") != _session_actor():
+            raise HTTPException(status_code=403, detail="Session belongs to another actor.")
+        previous_session_id = request.state.session_id
+        request.state.session_id = session_id
+        response = JSONResponse(
+            {
+                "session_id": session_id,
+                "previous_session_id": previous_session_id,
+                "managed": True,
+            }
         )
+        rotate_session_cookie(request, response, session_id)
+        return response
 
     @app.get("/api/demo/session", include_in_schema=False)
     async def get_session(request: Request) -> dict:
         _require_session()
-        return await _managed_call(
-            _state_client().get_session, request.state.session_id
-        )
+        return await _managed_call(_state_client().get_session, request.state.session_id)
 
     @app.post("/api/demo/session/items", include_in_schema=False)
-    async def append_session_items(
-        request: Request, payload: SessionItemsRequest
-    ) -> dict:
+    async def append_session_items(request: Request, payload: SessionItemsRequest) -> dict:
         _require_session()
         return await _managed_call(
             _state_client().append_session_items,

--- a/integrations/mason/templates/ui/agent-langgraph/runtime/ui.py
+++ b/integrations/mason/templates/ui/agent-langgraph/runtime/ui.py
@@ -24,6 +24,17 @@ _MEMORY_ACTOR_ENV = "AGENT_MEMORY_ACTOR_ID"
 _SESSION_STORE_ENV = "AGENT_SESSION_STORE"
 _SESSION_ACTOR_ENV = "AGENT_SESSION_ACTOR_ID"
 _AGENTS_API = "/api/agents/v1"
+_MESSAGE_ROLES = {
+    "ai",
+    "assistant",
+    "developer",
+    "function",
+    "human",
+    "human_decision",
+    "system",
+    "tool",
+    "user",
+}
 
 
 class MemoryEntryRequest(BaseModel):
@@ -235,6 +246,33 @@ async def _checkpoint_history(session_id: str) -> dict[str, Any]:
     return {"session_id": session_id, "session_items": items, "interrupts": interrupts}
 
 
+def _chat_sessions(result: dict[str, Any]) -> list[dict[str, Any]]:
+    sessions = []
+    for session in result.get("sessions", []):
+        if not isinstance(session, dict):
+            continue
+        metadata = session.get("metadata")
+        metadata = metadata if isinstance(metadata, dict) else {}
+        if metadata.get("client") == "mason-demo-durability" or metadata.get("public_session_id"):
+            continue
+        sessions.append(session)
+    return sessions
+
+
+def _chat_session_items(result: dict[str, Any]) -> dict[str, Any]:
+    items = []
+    for item in result.get("session_items", []):
+        if not isinstance(item, dict):
+            continue
+        data = item.get("data")
+        if not isinstance(data, dict) or data.get("event_type") or "content" not in data:
+            continue
+        role = str(data.get("role") or data.get("type") or "").lower()
+        if role in _MESSAGE_ROLES:
+            items.append(item)
+    return {**result, "session_items": items}
+
+
 def install_ui(app: FastAPI) -> None:
     """Mount the Mason demo UI and its runtime control endpoints."""
     app.mount("/ui-assets", StaticFiles(directory=_UI_ROOT), name="mason-demo-ui-assets")
@@ -342,6 +380,7 @@ def install_ui(app: FastAPI) -> None:
         result = await _managed_call(_state_client().list_sessions)
         return {
             **result,
+            "sessions": _chat_sessions(result),
             "current_session_id": session_id,
             "managed": True,
         }
@@ -382,7 +421,8 @@ def install_ui(app: FastAPI) -> None:
     async def list_session_items(request: Request) -> dict:
         session_id = request.state.session_id
         if _session_store():
-            return await _managed_call(_state_client().list_session_items, session_id)
+            result = await _managed_call(_state_client().list_session_items, session_id)
+            return _chat_session_items(result)
         return await _checkpoint_history(session_id)
 
     @app.get("/api/demo/recovery", include_in_schema=False)

--- a/integrations/mason/templates/ui/agent-langgraph/tests/test_demo_ui.py
+++ b/integrations/mason/templates/ui/agent-langgraph/tests/test_demo_ui.py
@@ -16,11 +16,7 @@ class _FakeStateClient:
         return {"managed_memory_entries": [{"path": f"{path_prefix or ''}/profile.md"}]}
 
     def search_memory_entries(self, request):
-        return {
-            "managed_memory_entries": [
-                {"path": "/profile.md", "content": request.query}
-            ]
-        }
+        return {"managed_memory_entries": [{"path": "/profile.md", "content": request.query}]}
 
     def ensure_session(self, session_id):
         return {"session_id": session_id, "actor_id": "alice"}
@@ -28,14 +24,28 @@ class _FakeStateClient:
     def get_session(self, session_id):
         return {"session_id": session_id, "actor_id": "alice"}
 
+    def list_sessions(self):
+        return {
+            "sessions": [
+                {
+                    "session_id": "s1",
+                    "actor_id": "alice",
+                    "last_activity_time": "2026-08-28T12:00:00Z",
+                },
+                {
+                    "session_id": "s2",
+                    "actor_id": "alice",
+                    "last_activity_time": "2026-08-27T12:00:00Z",
+                },
+            ]
+        }
+
     def append_session_items(self, session_id, items):
         return {"session_items": [{"item_id": "1", "data": item} for item in items]}
 
     def list_session_items(self, session_id):
         return {
-            "session_items": [
-                {"item_id": "1", "data": {"role": "user", "content": session_id}}
-            ]
+            "session_items": [{"item_id": "1", "data": {"role": "user", "content": session_id}}]
         }
 
 
@@ -100,9 +110,7 @@ async def _recovery_resume(session_id):
     return await _recovery_start(session_id)
 
 
-def _client(
-    monkeypatch, *, configured=False, history=False, session_id="routing-session"
-):
+def _client(monkeypatch, *, configured=False, history=False, session_id="routing-session"):
     monkeypatch.delenv("MASON_DEMO_TOOL_STEP_SECONDS", raising=False)
     if configured:
         monkeypatch.setenv("AGENT_MEMORY_STORE", "store")
@@ -128,7 +136,7 @@ def _client(
 
     app = build_app(invoke_handler, stream_handler)
     ui.install_ui(app)
-    client = TestClient(app)
+    client = TestClient(app, base_url="https://testserver")
     client.cookies.set("__Host-databricks-app-router", session_id)
     return client
 
@@ -136,10 +144,15 @@ def _client(
 def test_demo_ui_routes(monkeypatch):
     client = _client(monkeypatch)
 
-    assert client.get("/").status_code == 200
+    index = client.get("/")
+    assert index.status_code == 200
+    assert 'id="new-session"' in index.text
+    assert 'id="session-list"' in index.text
     app_script = client.get("/ui-assets/app.js")
     assert app_script.status_code == 200
-    assert "refreshSession({ hydrateChat: true })" in app_script.text
+    assert "refreshSessionView({ hydrateChat: true })" in app_script.text
+    assert 'fetch("/api/session/new"' in app_script.text
+    assert "/api/demo/sessions/${encodeURIComponent(sessionId)}/open" in app_script.text
     assert "session_id: ensureSessionId()" not in app_script.text
 
     config = client.get("/api/demo/config").json()
@@ -154,14 +167,21 @@ def test_demo_ui_routes(monkeypatch):
     assert config["heartbeat"]["enabled"] is False
     assert config["recovery"]["enabled"] is False
 
-    assert (
-        client.post("/api/demo/memory/search", json={"query": "profile"}).status_code
-        == 503
-    )
-    assert (
-        client.post("/api/demo/sessions", json={"session_id": "ignored"}).status_code
-        == 503
-    )
+    sessions = client.get("/api/demo/sessions").json()
+    assert sessions == {
+        "sessions": [
+            {
+                "session_id": "routing-session",
+                "actor_id": "agent",
+                "metadata": {"client": "mason-demo-ui-local"},
+            }
+        ],
+        "current_session_id": "routing-session",
+        "managed": False,
+    }
+
+    assert client.post("/api/demo/memory/search", json={"query": "profile"}).status_code == 503
+    assert client.post("/api/demo/sessions", json={"session_id": "ignored"}).status_code == 503
 
 
 def test_unmanaged_checkpoint_history_route(monkeypatch):
@@ -176,6 +196,31 @@ def test_unmanaged_checkpoint_history_route(monkeypatch):
     assert [item["data"]["content"] for item in result.json()["session_items"]] == [
         "local-session",
         "checkpoint reply",
+    ]
+
+
+def test_managed_session_list_is_actor_scoped(monkeypatch):
+    monkeypatch.setenv("AGENT_SESSION_STORE", "sessions")
+    monkeypatch.setenv("AGENT_SESSION_ACTOR_ID", 'alice "demo"')
+    state_client = object.__new__(ui._ManagedStateClient)
+    calls = []
+    state_client._do = lambda method, path, **kwargs: calls.append((method, path, kwargs)) or {
+        "sessions": []
+    }
+
+    assert state_client.list_sessions() == {"sessions": []}
+    assert calls == [
+        (
+            "GET",
+            "/api/agents/v1/session-stores/sessions/sessions",
+            {
+                "query": {
+                    "filter": 'actor_id = "alice \\"demo\\""',
+                    "order_by": "last_activity_time desc",
+                    "page_size": 50,
+                }
+            },
+        )
     ]
 
 
@@ -266,19 +311,18 @@ def test_managed_memory_and_session_routes(monkeypatch):
     assert created.status_code == 200
     assert created.json()["path"] == "/profile.md"
     assert created.json()["session_id"] == "s1"
-    assert (
-        client.get("/api/demo/memory/entries", params={"path_prefix": "/"}).status_code
-        == 200
-    )
+    assert client.get("/api/demo/memory/entries", params={"path_prefix": "/"}).status_code == 200
     search = client.post("/api/demo/memory/search", json={"query": "Databricks"})
     assert search.json()["managed_memory_entries"][0]["content"] == "Databricks"
 
     assert (
-        client.post("/api/demo/sessions", json={"session_id": "ignored"}).json()[
-            "session_id"
-        ]
+        client.post("/api/demo/sessions", json={"session_id": "ignored"}).json()["session_id"]
         == "s1"
     )
+    listed = client.get("/api/demo/sessions").json()
+    assert [session["session_id"] for session in listed["sessions"]] == ["s1", "s2"]
+    assert listed["current_session_id"] == "s1"
+    assert listed["managed"] is True
     assert client.get("/api/demo/session").json()["session_id"] == "s1"
     appended = client.post(
         "/api/demo/session/items",
@@ -286,13 +330,35 @@ def test_managed_memory_and_session_routes(monkeypatch):
     )
     assert appended.json()["session_items"][0]["data"]["content"] == "hello"
     assert (
-        client.get("/api/demo/session/items").json()["session_items"][0]["data"][
-            "content"
-        ]
-        == "s1"
+        client.get("/api/demo/session/items").json()["session_items"][0]["data"]["content"] == "s1"
+    )
+
+    opened = client.post("/api/demo/sessions/s2/open")
+    assert opened.json() == {
+        "session_id": "s2",
+        "previous_session_id": "s1",
+        "managed": True,
+    }
+    assert client.get("/api/demo/config").json()["session_id"] == "s2"
+    assert (
+        client.get("/api/demo/session/items").json()["session_items"][0]["data"]["content"] == "s2"
     )
 
     assert client.get("/api/demo/recovery").json()["needs_resume"] is True
     assert client.post("/api/demo/recovery/start").json()["worker_active"] is True
     assert client.post("/api/demo/app/start").json()["worker_active"] is True
     assert client.post("/api/demo/recovery/resume").json()["worker_active"] is True
+
+
+def test_open_session_rejects_another_actor(monkeypatch):
+    client = _client(monkeypatch, configured=True, session_id="s1")
+
+    class _ForeignActorClient(_FakeStateClient):
+        def get_session(self, session_id):
+            return {"session_id": session_id, "actor_id": "bob"}
+
+    monkeypatch.setattr(ui, "_state_client", lambda: _ForeignActorClient())
+
+    response = client.post("/api/demo/sessions/s2/open")
+    assert response.status_code == 403
+    assert response.json()["detail"] == "Session belongs to another actor."

--- a/integrations/mason/templates/ui/agent-langgraph/tests/test_demo_ui.py
+++ b/integrations/mason/templates/ui/agent-langgraph/tests/test_demo_ui.py
@@ -37,6 +37,15 @@ class _FakeStateClient:
                     "actor_id": "alice",
                     "last_activity_time": "2026-08-27T12:00:00Z",
                 },
+                {
+                    "session_id": "durability-s1",
+                    "actor_id": "alice",
+                    "metadata": {
+                        "client": "mason-demo-durability",
+                        "public_session_id": "s1",
+                    },
+                    "last_activity_time": "2026-08-28T12:01:00Z",
+                },
             ]
         }
 
@@ -45,7 +54,24 @@ class _FakeStateClient:
 
     def list_session_items(self, session_id):
         return {
-            "session_items": [{"item_id": "1", "data": {"role": "user", "content": session_id}}]
+            "session_items": [
+                {"item_id": "1", "data": {"role": "user", "content": session_id}},
+                {
+                    "item_id": "2",
+                    "data": {"type": "assistant", "content": "saved reply"},
+                },
+                {
+                    "item_id": "3",
+                    "data": {"event_type": "checkpoint", "checkpoint_id": "checkpoint-1"},
+                },
+                {
+                    "item_id": "4",
+                    "data": {
+                        "event_type": "mason_demo_durability",
+                        "event": "heartbeat",
+                    },
+                },
+            ]
         }
 
 
@@ -154,6 +180,9 @@ def test_demo_ui_routes(monkeypatch):
     assert 'fetch("/api/session/new"' in app_script.text
     assert "/api/demo/sessions/${encodeURIComponent(sessionId)}/open" in app_script.text
     assert "session_id: ensureSessionId()" not in app_script.text
+    styles = client.get("/ui-assets/styles.css").text
+    assert "@media (min-width: 1181px)" in styles
+    assert "scrollbar-gutter: stable" in styles
 
     config = client.get("/api/demo/config").json()
     assert config["session_id"] == "routing-session"
@@ -222,6 +251,32 @@ def test_managed_session_list_is_actor_scoped(monkeypatch):
             },
         )
     ]
+
+
+def test_chat_session_items_exclude_checkpoints_and_durability_events():
+    result = ui._chat_session_items(
+        {
+            "session_items": [
+                {"item_id": "1", "data": {"role": "user", "content": "hello"}},
+                {"item_id": "2", "data": {"type": "ai", "content": "hi"}},
+                {"item_id": "3", "data": {"event_type": "checkpoint"}},
+                {
+                    "item_id": "4",
+                    "data": {"event_type": "mason_demo_durability", "event": "heartbeat"},
+                },
+                {"item_id": "5", "data": {"content": "missing role"}},
+            ],
+            "next_page_token": "next",
+        }
+    )
+
+    assert result == {
+        "session_items": [
+            {"item_id": "1", "data": {"role": "user", "content": "hello"}},
+            {"item_id": "2", "data": {"type": "ai", "content": "hi"}},
+        ],
+        "next_page_token": "next",
+    }
 
 
 @pytest.mark.asyncio
@@ -332,6 +387,10 @@ def test_managed_memory_and_session_routes(monkeypatch):
     assert (
         client.get("/api/demo/session/items").json()["session_items"][0]["data"]["content"] == "s1"
     )
+    assert [
+        item["data"]["content"]
+        for item in client.get("/api/demo/session/items").json()["session_items"]
+    ] == ["s1", "saved reply"]
 
     opened = client.post("/api/demo/sessions/s2/open")
     assert opened.json() == {

--- a/integrations/mason/templates/ui/agent-langgraph/ui/app.js
+++ b/integrations/mason/templates/ui/agent-langgraph/ui/app.js
@@ -29,6 +29,7 @@ const elements = {
   memoryQuery: document.querySelector("#memory-query"),
   memoryResults: document.querySelector("#memory-results"),
   memoryStatus: document.querySelector("#memory-status"),
+  newSession: document.querySelector("#new-session"),
   promptInput: document.querySelector("#prompt-input"),
   askMemory: document.querySelector("#ask-memory"),
   searchMemory: document.querySelector("#search-memory"),
@@ -44,6 +45,7 @@ const elements = {
   sendButton: document.querySelector("#send-button"),
   sessionId: document.querySelector("#session-id"),
   sessionItems: document.querySelector("#session-items"),
+  sessionList: document.querySelector("#session-list"),
   sessionMode: document.querySelector("#session-mode-value"),
   sessionStatus: document.querySelector("#session-status"),
   sessionStoreLabel: document.querySelector("#session-store-label"),
@@ -108,9 +110,13 @@ function setBusy(busy, label = "Working") {
   elements.rememberButton.disabled = busy || !state.config?.memory.enabled;
   elements.searchMemory.disabled = busy || !state.config?.memory.enabled;
   elements.askMemory.disabled = busy || !state.config?.memory.enabled;
+  elements.newSession.disabled = busy;
   elements.refreshSession.disabled = busy || !state.config?.session.history;
   elements.resumeSession.disabled = busy || !state.config?.session.durable;
   elements.rejectSession.disabled = busy || !state.config?.session.durable;
+  document.querySelectorAll(".session-open-button").forEach((button) => {
+    button.disabled = busy;
+  });
   updateRecoveryControls();
   if (busy) setStatus(label, "busy");
   else if (!elements.runStatus.classList.contains("error")) setStatus("Ready");
@@ -369,6 +375,10 @@ function sessionItems(payload) {
   return payload?.session_items || [];
 }
 
+function sessions(payload) {
+  return payload?.sessions || [];
+}
+
 function renderMemoryEntries(entries, emptyMessage = "No matching memory entries.") {
   renderStateItems(elements.memoryResults, entries, emptyMessage, (entry) => ({
     title: entry.path || entry.name || "Memory entry",
@@ -386,6 +396,43 @@ function renderSessionItems(items) {
       meta: [item.item_id, item.create_time, data.transport].filter(Boolean).join(" · "),
     };
   });
+}
+
+function renderSessions(items) {
+  elements.sessionList.replaceChildren();
+  if (!items.length) {
+    stateMessage(elements.sessionList, "No sessions yet.");
+    return;
+  }
+  for (const session of items) {
+    const current = session.session_id === state.sessionId;
+    const item = document.createElement("article");
+    item.className = `state-item session-item${current ? " current" : ""}`;
+    const heading = document.createElement("div");
+    heading.className = "session-item-heading";
+    const title = document.createElement("strong");
+    title.textContent = current ? "Current session" : "Session";
+    heading.append(title);
+    if (!current && state.config?.session.managed) {
+      const open = document.createElement("button");
+      open.className = "text-button session-open-button";
+      open.type = "button";
+      open.textContent = "Open";
+      open.disabled = state.busy;
+      open.addEventListener("click", () => openSession(session.session_id));
+      heading.append(open);
+    }
+    const content = document.createElement("p");
+    content.textContent = session.session_id || "Unknown session";
+    const meta = document.createElement("small");
+    meta.textContent = [
+      session.actor_id,
+      session.last_activity_time || session.create_time,
+      current ? "active routing cookie" : "",
+    ].filter(Boolean).join(" · ");
+    item.append(heading, content, meta);
+    elements.sessionList.append(item);
+  }
 }
 
 function renderSessionTranscript(items) {
@@ -452,6 +499,24 @@ async function refreshSession({ hydrateChat = false } = {}) {
   }
 }
 
+async function refreshSessions() {
+  stateMessage(elements.sessionList, "Loading sessions…", "loading");
+  try {
+    const response = await fetch("/api/demo/sessions", { cache: "no-store" });
+    const result = await jsonResponse(response);
+    renderSessions(sessions(result));
+    addEvent("sessions.list", result);
+  } catch (error) {
+    stateMessage(elements.sessionList, error instanceof Error ? error.message : String(error), "error");
+    addEvent("session.error", { message: String(error) });
+  }
+}
+
+async function refreshSessionView({ hydrateChat = false } = {}) {
+  await refreshSession({ hydrateChat });
+  await refreshSessions();
+}
+
 async function recordSessionItems(items) {
   if (!state.config?.session.managed || !items.length) return;
   try {
@@ -463,7 +528,7 @@ async function recordSessionItems(items) {
     });
     const result = await jsonResponse(response);
     addEvent("session.items.append", result);
-    await refreshSession();
+    await refreshSessionView();
   } catch (error) {
     stateMessage(elements.sessionItems, error instanceof Error ? error.message : String(error), "error");
     addEvent("session.error", { message: String(error) });
@@ -688,15 +753,88 @@ async function resume(decision) {
   }
 }
 
-function clearChat() {
+function clearChat({ recordEvent = true } = {}) {
   state.pendingInterrupt = null;
   state.draft = null;
   state.draftText = "";
+  state.lastAssistantText = "";
   elements.approvalPanel.hidden = true;
   elements.chatLog.replaceChildren(elements.emptyState);
   elements.emptyState.hidden = false;
   elements.promptInput.focus();
-  addEvent("chat.cleared", { session_id: state.sessionId });
+  if (recordEvent) addEvent("chat.cleared", { session_id: state.sessionId });
+}
+
+function resetSessionState() {
+  if (state.recoveryPollTimer) clearTimeout(state.recoveryPollTimer);
+  state.lastDurabilityAttempt = 0;
+  state.lastDurabilityHeartbeat = "";
+  state.lastRecoveryStatus = "";
+  state.recovery = null;
+  state.recoveryPollTimer = null;
+  state.recoverySessionId = "";
+  state.recoverySignature = "";
+  clearChat({ recordEvent: false });
+  stateMessage(elements.sessionList, "Loading sessions…", "loading");
+  stateMessage(elements.sessionItems, "Loading transcript…", "loading");
+  stateMessage(elements.recoverySteps, "No recovery sequence started for this session.");
+  elements.durabilityExecution.textContent = "Not started";
+  elements.durabilityAttempt.textContent = "—";
+  elements.durabilityOwner.textContent = "—";
+  elements.durabilityHeartbeat.textContent = "Not started";
+  elements.recoveryStatus.textContent = state.config?.recovery.enabled
+    ? "Start App to run the durable tool sequence for this session."
+    : "Stop is included, but durability needs a managed Session Store.";
+  updateRecoveryControls();
+}
+
+async function createNewSession() {
+  if (state.busy) return;
+  setBusy(true, "Creating session");
+  try {
+    const response = await fetch("/api/session/new", {
+      method: "POST",
+      credentials: "same-origin",
+    });
+    const result = await jsonResponse(response);
+    setSessionId(result.session_id);
+    resetSessionState();
+    addEvent("session.new", result);
+    if (state.config?.session.managed) await ensureManagedSession();
+    await refreshSessionView({ hydrateChat: true });
+    if (state.config?.recovery.enabled) {
+      await monitorRecovery(state.sessionId, { autoResume: false });
+    }
+    setConnection("online", "Connected");
+  } catch (error) {
+    appendError(error);
+  } finally {
+    setBusy(false);
+  }
+}
+
+async function openSession(sessionId) {
+  if (state.busy || !sessionId || sessionId === state.sessionId) return;
+  setBusy(true, "Opening session");
+  try {
+    const response = await fetch(`/api/demo/sessions/${encodeURIComponent(sessionId)}/open`, {
+      method: "POST",
+      credentials: "same-origin",
+    });
+    const result = await jsonResponse(response);
+    setSessionId(result.session_id);
+    resetSessionState();
+    addEvent("session.open", result);
+    await refreshSessionView({ hydrateChat: true });
+    if (state.config?.recovery.enabled) {
+      await monitorRecovery(state.sessionId, { autoResume: true });
+    }
+    setConnection("online", "Connected");
+  } catch (error) {
+    appendError(error);
+  } finally {
+    setBusy(false);
+  }
 }
 
 async function loadConfig() {
@@ -728,6 +866,7 @@ async function loadConfig() {
     elements.rememberButton.disabled = state.busy || !config.memory.enabled;
     elements.searchMemory.disabled = state.busy || !config.memory.enabled;
     elements.askMemory.disabled = state.busy || !config.memory.enabled;
+    elements.newSession.disabled = state.busy;
     elements.refreshSession.disabled = state.busy || !config.session.history;
     elements.resumeSession.disabled = state.busy || !config.session.durable;
     elements.rejectSession.disabled = state.busy || !config.session.durable;
@@ -745,7 +884,7 @@ async function loadConfig() {
       : `Ready: ${config.recovery.steps.length} steps, about ${config.recovery.step_seconds}s each.`;
     setConnection("online", "Connected");
     addEvent("runtime.config", config);
-    void refreshSession({ hydrateChat: true });
+    void refreshSessionView({ hydrateChat: true });
     if (config.recovery.enabled) {
       const recoverySessionId = state.recoverySessionId || state.sessionId;
       void monitorRecovery(recoverySessionId, { autoResume: true });
@@ -1064,7 +1203,8 @@ elements.copySession.addEventListener("click", async () => {
 });
 
 elements.refreshConfig.addEventListener("click", () => loadConfig().catch(appendError));
-elements.refreshSession.addEventListener("click", () => refreshSession({ hydrateChat: true }));
+elements.newSession.addEventListener("click", createNewSession);
+elements.refreshSession.addEventListener("click", () => refreshSessionView({ hydrateChat: true }));
 elements.clearEvents.addEventListener("click", () => {
   state.events = [];
   elements.eventLog.innerHTML = '<div class="event-empty">Invocation events appear here.</div>';

--- a/integrations/mason/templates/ui/agent-langgraph/ui/index.html
+++ b/integrations/mason/templates/ui/agent-langgraph/ui/index.html
@@ -80,10 +80,11 @@
           <section class="rail-section session-card">
             <div class="section-heading compact">
               <div>
-                <p class="eyebrow">Managed transcript</p>
-                <h2>Session Store</h2>
+                <p class="eyebrow">Conversation history</p>
+                <h2>Sessions</h2>
               </div>
               <div class="button-row compact-actions">
+                <button id="new-session" class="text-button" type="button">New session</button>
                 <button id="refresh-session" class="text-button" type="button">Refresh</button>
               </div>
             </div>
@@ -96,6 +97,11 @@
               <button id="reject-session" class="button button-secondary" type="button">Reject paused HITL</button>
             </div>
             <p id="session-store-label" class="supporting-text">The Databricks Apps routing cookie is also the application session ID.</p>
+            <label>Recent sessions</label>
+            <div id="session-list" class="state-list compact-list" aria-live="polite">
+              <div class="state-empty">Loading sessions…</div>
+            </div>
+            <label>Current transcript</label>
             <div id="session-items" class="state-list compact-list" aria-live="polite">
               <div class="state-empty">Connect a Session Store to mirror transcript items.</div>
             </div>

--- a/integrations/mason/templates/ui/agent-langgraph/ui/styles.css
+++ b/integrations/mason/templates/ui/agent-langgraph/ui/styles.css
@@ -284,6 +284,7 @@ h2 {
   color: var(--accent-deep);
   font-size: 0.75rem;
   font-weight: 750;
+  white-space: nowrap;
 }
 
 .capability-list {
@@ -1084,6 +1085,33 @@ h2 {
 @keyframes blink {
   0%, 45% { opacity: 1; }
   46%, 100% { opacity: 0; }
+}
+
+@media (min-width: 1181px) {
+  html,
+  body,
+  .app-shell {
+    height: 100%;
+    overflow: hidden;
+  }
+
+  .workspace {
+    height: calc(100vh - 110px);
+    min-height: 0;
+  }
+
+  .left-rail,
+  .right-rail {
+    min-height: 0;
+    overflow-y: auto;
+    overscroll-behavior: contain;
+    scrollbar-gutter: stable;
+  }
+
+  .chat-panel {
+    height: 100%;
+    min-height: 0;
+  }
 }
 
 @media (max-width: 1180px) {

--- a/integrations/mason/templates/ui/agent-langgraph/ui/styles.css
+++ b/integrations/mason/templates/ui/agent-langgraph/ui/styles.css
@@ -981,6 +981,22 @@ h2 {
   font-size: 0.7rem;
 }
 
+.session-item.current {
+  background: var(--success-soft);
+}
+
+.session-item-heading {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.session-item-heading .text-button {
+  flex: 0 0 auto;
+  padding: 2px 6px;
+}
+
 .state-item p {
   margin: 5px 0;
   color: var(--ink-soft);

--- a/integrations/mason/tests/unit_tests/tool_runtime_test.py
+++ b/integrations/mason/tests/unit_tests/tool_runtime_test.py
@@ -52,6 +52,7 @@ def _project(tmp_path: pathlib.Path) -> pathlib.Path:
     )
     shutil.copyfile(template_mason / "tool_manifest.py", mason / "tool_manifest.py")
     shutil.copyfile(template_mason / "mcp_runtime.py", mason / "mcp_runtime.py")
+    shutil.copyfile(template_mason / "workspace.py", mason / "workspace.py")
     return project
 
 


### PR DESCRIPTION
## Summary

- add `POST /api/session/new` to create a fresh UUID session and rotate the existing routing cookie
- list recent actor-scoped managed sessions in the LangGraph chat UI, with the current local session as the in-memory fallback
- allow opening a listed managed session after verifying actor ownership, then reload its transcript, pending HITL state, and recovery state
- exclude internal durability sessions, checkpoints, heartbeats, and other runtime records from the session list and chat transcript responses
- keep the desktop chat, session rail, and demo controls independently scrollable while preserving normal page scrolling on smaller screens
- document the session APIs and add coverage for local and Databricks Apps cookie rotation

## Routing behavior

The client still does not send `session_id` in invocation request bodies. The session id is the routing key:

- deployed Apps use `__Host-databricks-app-router`
- local development uses `mason-local-session`
- the existing TODO to move API clients to `X-Routing-Key` remains

Creating or opening a session replaces the routing cookie, so sticky routing and the LangGraph thread/session id stay identical.

## Session Store filtering

The Session Store continues to retain LangGraph checkpoints and durability events. The browser-facing session APIs only return message-shaped items with supported chat roles, and the session picker excludes internal `mason-demo-durability` execution sessions.

## Validation

- `uv run pytest tests/unit_tests -q` — 146 passed
- generated `mason init --framework langgraph --enable-chat-app` project tests — 27 passed, 1 skipped
- `uv run ruff check src tests templates/agent-langgraph templates/ui/agent-langgraph`
- `uv run ruff format --check src tests templates/agent-langgraph templates/ui/agent-langgraph`
- `uv run ty check`
- `node --check ui/app.js`
- headless Chrome verification at 1440×900 with a 30-message transcript



## Account-routed workspace support

- generated SDK clients forward `DATABRICKS_WORKSPACE_ID` as `X-Databricks-Org-Id` for account/vanity-host profiles
- the generated LangGraph model adapter also forwards that routing header to the underlying sync and async OpenAI clients
- MCP transports receive the same routing header without changing `integrations/openai`

## Demo app

- https://mason-pr487-185019-6051921418418893.staging.aws.databricksapps.com

## Additional E2E validation · August 28, 2026

- clean editable Mason install and fresh `mason init --framework langgraph --enable-chat-app` scaffold
- generated project: `30 passed, 1 skipped`
- local Apps proxy: session create/list/open, message-only transcript hydration, sync, streaming, background, memory create/list/search, and HITL resume
- stop/start recovery retained `tool_step_1` and `tool_step_2`, then resumed only `tool_step_3` and `tool_step_4` on a new process
- deployed `mason-pr487-185019`: deployment `SUCCEEDED`, app `RUNNING`, compute `ACTIVE`
