### PR TITLE
fix(openai): pin HTTPX-compatible SDK versions

### DIFF
--- a/integrations/openai/pyproject.toml
+++ b/integrations/openai/pyproject.toml
@@ -11,12 +11,13 @@ requires-python = ">=3.10"
 dependencies = [
     "databricks-ai-search>=0.73",
     "databricks-ai-bridge>=0.21.0",
-    "openai>=1.99.9",
+    # OpenAI 3 and openai-agents 0.21 use httpx2; this integration provides httpx clients.
+    "openai>=1.99.9,<3",
     "pydantic>2.10.0",
     "mlflow>=3.10.1",
     "unitycatalog-openai[databricks]>=0.2.0",
     "databricks-mcp>=0.4.0",
-    "openai-agents>=0.5.0",
+    "openai-agents>=0.5.0,<0.21",
     # direct import in databricks_openai.agents.mcp_server; mcp 2.0.0 removed
     # GetSessionIdCallback / rewrote the streamable-http transport
     "mcp>=1.19,<2"


### PR DESCRIPTION
## Summary

- constrain `openai` to the HTTPX-based 2.x release line
- constrain `openai-agents` to the matching pre-0.21 release line
- document why the bounds must move together

## Why

OpenAI 3 migrated its transport types from `httpx` to `httpx2`. `databricks-openai` supplies custom `httpx` clients, so unconstrained dependency resolution caused `ty` to report incompatible client, request, and response types.

## Testing

Using the Databricks PyPI proxy (`https://pypi-proxy.cloud.databricks.com/simple/`), the environment resolved `openai==2.54.0`, `openai-agents==0.20.0`, and `httpx==0.28.1`.

- `ty check --output-format github`
- `ruff check --output-format github`
- `ruff format --check --diff`
- `python -m pytest tests/unit_tests/ -q` — 213 passed