### PR TITLE
Add proprietary NOTICE for databricks-mason

### DIFF
--- a/integrations/mason/NOTICE
+++ b/integrations/mason/NOTICE
@@ -14,6 +14,14 @@ Package: rich
 Project URL: https://github.com/Textualize/rich
 Copyright: 2020 Will McGugan
 
+Package: tomli
+Project URL: https://github.com/hukkin/tomli
+Copyright: 2021 Taneli Hukkinen
+
+Package: tomlkit
+Project URL: https://github.com/python-poetry/tomlkit
+Copyright: 2018 Sébastien Eustace
+
 # Apache License 2.0
 
 This Software contains code from the following open source projects, licensed under the Apache License 2.0 license (https://www.apache.org/licenses/LICENSE-2.0).
@@ -24,7 +32,7 @@ Copyright: 2023 Databricks, Inc.
 
 # BSD 3-Clause License
 
-This Software contains code from the following open source projects, licensed under the BSD 3-Clause License license (https://opensource.org/license/bsd-3-clause).
+This Software contains code from the following open source projects, licensed under the BSD 3-Clause License (https://opensource.org/license/bsd-3-clause).
 
 Package: click
 Project URL: https://github.com/pallets/click

--- a/integrations/mason/NOTICE
+++ b/integrations/mason/NOTICE
@@ -1,0 +1,31 @@
+Copyright (c) 2026 Databricks, Inc. All rights reserved.
+
+This Software is the property of Databricks, Inc. ("Databricks") and no license, right, or authorization to install, use, copy, modify, or distribute this Software is granted except pursuant to Databricks' prior written authorization. Any use of this Software without such written authorization from Databricks is strictly prohibited.
+
+# MIT License
+
+This Software contains code from the following open source projects, licensed under the MIT license (https://opensource.org/licenses/MIT).
+
+Package: PyYAML
+Project URL: https://github.com/yaml/pyyaml
+Copyright: 2017-2021 Ingy döt Net, 2006-2016 Kirill Simonov
+
+Package: rich
+Project URL: https://github.com/Textualize/rich
+Copyright: 2020 Will McGugan
+
+# Apache License 2.0
+
+This Software contains code from the following open source projects, licensed under the Apache License 2.0 license (https://www.apache.org/licenses/LICENSE-2.0).
+
+Package: databricks-sdk
+Project URL: https://github.com/databricks/databricks-sdk-py
+Copyright: 2023 Databricks, Inc.
+
+# BSD 3-Clause License
+
+This Software contains code from the following open source projects, licensed under the BSD 3-Clause License license (https://opensource.org/license/bsd-3-clause).
+
+Package: click
+Project URL: https://github.com/pallets/click
+Copyright: 2014 Pallets

--- a/integrations/mason/pyproject.toml
+++ b/integrations/mason/pyproject.toml
@@ -6,7 +6,6 @@ authors = [
     { name="Databricks", email="agent-feedback@databricks.com" },
 ]
 readme = "README.md"
-license = { text="Apache-2.0" }
 requires-python = ">=3.10"
 dependencies = [
     "click>=8.1",
@@ -41,6 +40,7 @@ build-backend = "hatchling.build"
 
 [tool.hatch.build]
 include = [
+    "NOTICE",
     "src/databricks_mason/*",
     "src/databricks_mason/py.typed",
     "src/databricks_mason/templates/**",


### PR DESCRIPTION
## Changes

- add the approved proprietary NOTICE and third-party attributions for `databricks-mason`
- remove the conflicting Apache-2.0 package metadata
- include the NOTICE in wheel and source distributions

## Validation

- `uv build --offline`
- verified the wheel contains `dist-info/licenses/NOTICE`
- verified the source distribution contains `NOTICE`
- verified the wheel no longer declares Apache-2.0 license metadata