### PR TITLE
feat(mason): support Unity Catalog agent skills

### DIFF
--- a/integrations/mason/README.md
+++ b/integrations/mason/README.md
@@ -189,7 +189,8 @@ both fetch from UC on demand. Mason does not copy skill bundles into the project
 
 This release supports UC sources on LangGraph only. Local, custom, and path-based skills,
 automatic discovery, versions, and script materialization are not supported. A deployed App's
-service principal needs `USE_CATALOG`, `USE_SCHEMA`, and `READ_SKILL` on the bound resources.
+service principal needs `USE_CATALOG`, `USE_SCHEMA`, and `READ_VOLUME` on the bound resources.
+The legacy `READ_SKILL` privilege does not authorize skill metadata or bundle reads.
 
 ## Initialize the chat app demo
 

--- a/integrations/mason/README.md
+++ b/integrations/mason/README.md
@@ -1,7 +1,7 @@
 # `databricks-mason`
 
 Mason is an experimental CLI for Databricks custom agent preview APIs and
-deployments. It manages memory, sessions, tracing, and deployments from one
+deployments. It manages skills, memory, sessions, tracing, and deployments from one
 authenticated command.
 
 > The underlying APIs are in preview and may need workspace enablement.
@@ -91,6 +91,9 @@ mason [-p <profile>] [-o text|json]
     list | get | instrument
   mcp
     list             [--schema CATALOG.SCHEMA]
+  skills
+    list             --schema CATALOG.SCHEMA
+    add uc           CATALOG.SCHEMA.SKILL [--name NAME] [--source PATH]
   tools
     add sandbox      --scope SCOPE [--scope SCOPE ...] [--source PATH]
     add mcp          SERVICE [--name NAME] [--source PATH]
@@ -161,6 +164,32 @@ Sandbox scopes default to read-only access. Repeat `--scope` to allow more than 
 `volume:` or `workspace:` for those resource types, and use `--permission read_write` only when the
 agent needs writes. Every sandbox call carries this fixed downscope in MCP `_meta`, outside the tool
 arguments controlled by the model.
+
+## Unity Catalog skills
+
+Mason's LangGraph template supports exact Unity Catalog skill bindings. Discover visible skills in
+a schema, then attach one to the current agent project:
+
+```sh
+mason skills list --schema catalog.schema
+mason skills add uc catalog.schema.skill --source .
+```
+
+The add command writes the same declarative contract you can author directly:
+
+```toml
+[[skills]]
+id = "skill"
+source = { kind = "uc", name = "catalog.schema.skill" }
+```
+
+At graph construction, Mason injects only each declared skill's ID, FQN, and description. The
+model calls `load_skill` when the task matches and `read_skill_file` for a referenced relative file;
+both fetch from UC on demand. Mason does not copy skill bundles into the project or deployment.
+
+This release supports UC sources on LangGraph only. Local, custom, and path-based skills,
+automatic discovery, versions, and script materialization are not supported. A deployed App's
+service principal needs `USE_CATALOG`, `USE_SCHEMA`, and `READ_SKILL` on the bound resources.
 
 ## Initialize the chat app demo
 

--- a/integrations/mason/src/databricks_mason/agent_project.py
+++ b/integrations/mason/src/databricks_mason/agent_project.py
@@ -21,6 +21,7 @@ _SUPPORTED_FRAMEWORKS = {"langgraph", "openai"}
 _SUPPORTED_SCOPE_KINDS = {"table", "volume", "workspace"}
 _SUPPORTED_PERMISSIONS = {"read_only", "read_write"}
 _TOOL_ID = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.-]*$")
+_LANGGRAPH_SKILLS_ONLY = "Agent skills are LangGraph-only in this release."
 
 
 def _three_part_name(value: str, description: str) -> str:
@@ -185,6 +186,35 @@ class ToolSpec:
         )
 
 
+@dataclass(frozen=True)
+class SkillSource:
+    """Unity Catalog source for one skill binding."""
+
+    kind: str
+    name: str | None = None
+
+
+@dataclass(frozen=True)
+class SkillSpec:
+    """One Unity Catalog skill binding from ``agent.toml``."""
+
+    id: str
+    source: SkillSource
+
+    def __post_init__(self) -> None:
+        if not _TOOL_ID.fullmatch(self.id):
+            raise AgentCliError(f"Invalid skill id {self.id!r}.")
+        if self.source.kind != "uc":
+            raise AgentCliError(f"Unsupported skill source kind {self.source.kind!r}.")
+        if self.source.name is None:
+            raise AgentCliError("UC skills require a name.")
+        _three_part_name(self.source.name, "UC skill")
+
+    @classmethod
+    def uc(cls, skill_id: str, *, name: str) -> "SkillSpec":
+        return cls(skill_id, SkillSource(kind="uc", name=_three_part_name(name, "UC skill")))
+
+
 def _required_string(value: object, description: str) -> str:
     if not isinstance(value, str) or not value:
         raise AgentCliError(f"Tool manifest must declare {description}.")
@@ -238,6 +268,31 @@ def _tool_from_manifest(value: object) -> ToolSpec:
     )
 
 
+def _skill_from_manifest(value: object) -> SkillSpec:
+    if not isinstance(value, Mapping):
+        raise AgentCliError("Each agent.toml skill must be a TOML table.")
+    value = cast(Mapping[str, Any], value)
+    skill_id = value.get("id")
+    if not isinstance(skill_id, str) or not skill_id:
+        raise AgentCliError("Skill manifest must declare an id.")
+    source = value.get("source")
+    if not isinstance(source, Mapping):
+        raise AgentCliError("Each agent.toml skill must declare a source table.")
+    source = cast(Mapping[str, Any], source)
+    unsupported_fields = set(source) - {"kind", "name"}
+    if unsupported_fields:
+        raise AgentCliError(
+            f"Unsupported skill source fields: {', '.join(sorted(unsupported_fields))}."
+        )
+    kind = source.get("kind")
+    if not isinstance(kind, str) or not kind:
+        raise AgentCliError("Skill source must declare a kind.")
+    name = source.get("name")
+    if name is not None and not isinstance(name, str):
+        raise AgentCliError("Skill source name must be a string.")
+    return SkillSpec(id=skill_id, source=SkillSource(kind=kind, name=name))
+
+
 def _inline_table(values: Mapping[str, str]) -> Any:
     table = tomlkit.inline_table()
     for key, value in values.items():
@@ -266,6 +321,14 @@ def _tool_table(spec: ToolSpec) -> Any:
     return table
 
 
+def _skill_table(spec: SkillSpec) -> Any:
+    assert spec.source.name is not None
+    table = tomlkit.table()
+    table.add("id", spec.id)
+    table.add("source", _inline_table({"kind": spec.source.kind, "name": spec.source.name}))
+    return table
+
+
 class AgentProject:
     """Loaded mutable view of a project's canonical tool manifest."""
 
@@ -275,12 +338,14 @@ class AgentProject:
         document: TOMLDocument,
         framework: str,
         tools: list[ToolSpec],
+        skills: list[SkillSpec],
     ) -> None:
         self.root = root
         self.path = root / "agent.toml"
         self._document = document
         self.framework = framework
         self.tools = tools
+        self.skills = skills
 
     @classmethod
     def load(cls, root: pathlib.Path | str) -> "AgentProject":
@@ -314,7 +379,16 @@ class AgentProject:
         ids = [tool.id for tool in tools]
         if len(ids) != len(set(ids)):
             raise AgentCliError("agent.toml tool ids must be unique.")
-        return cls(project_root, document, framework, tools)
+        raw_skills = document.get("skills", [])
+        if not isinstance(raw_skills, list):
+            raise AgentCliError("agent.toml skills must be an array of tables.")
+        if raw_skills and framework != "langgraph":
+            raise AgentCliError(_LANGGRAPH_SKILLS_ONLY)
+        skills = [_skill_from_manifest(item) for item in raw_skills]
+        skill_ids = [skill.id for skill in skills]
+        if len(skill_ids) != len(set(skill_ids)):
+            raise AgentCliError("agent.toml skill ids must be unique.")
+        return cls(project_root, document, framework, tools, skills)
 
     @classmethod
     def create(cls, root: pathlib.Path | str, *, framework: str) -> "AgentProject":
@@ -327,7 +401,7 @@ class AgentProject:
         agent = tomlkit.table()
         agent.add("framework", framework)
         document.add("agent", agent)
-        return cls(project_root, document, framework, [])
+        return cls(project_root, document, framework, [], [])
 
     def add_tool(self, spec: ToolSpec) -> bool:
         for existing in self.tools:
@@ -365,6 +439,27 @@ class AgentProject:
             raise AgentCliError("agent.toml tools must be an array of tables.")
         del raw_tools[index]
         del self.tools[index]
+        return True
+
+    def add_skill(self, spec: SkillSpec) -> bool:
+        if self.framework != "langgraph":
+            raise AgentCliError(_LANGGRAPH_SKILLS_ONLY)
+        for existing in self.skills:
+            if existing.id != spec.id:
+                continue
+            if existing == spec:
+                return False
+            raise AgentCliError(
+                f"Skill id {spec.id!r} already exists with different configuration."
+            )
+        raw_skills = self._document.get("skills")
+        if raw_skills is None:
+            raw_skills = tomlkit.aot()
+            self._document.append("skills", raw_skills)
+        elif not hasattr(raw_skills, "append"):
+            raise AgentCliError("agent.toml skills must be an array of tables.")
+        raw_skills.append(_skill_table(spec))
+        self.skills.append(spec)
         return True
 
     def write(self) -> pathlib.Path:

--- a/integrations/mason/src/databricks_mason/agent_project.py
+++ b/integrations/mason/src/databricks_mason/agent_project.py
@@ -272,6 +272,9 @@ def _skill_from_manifest(value: object) -> SkillSpec:
     if not isinstance(value, Mapping):
         raise AgentCliError("Each agent.toml skill must be a TOML table.")
     value = cast(Mapping[str, Any], value)
+    unsupported_fields = set(value) - {"id", "source"}
+    if unsupported_fields:
+        raise AgentCliError(f"Unsupported skill fields: {', '.join(sorted(unsupported_fields))}.")
     skill_id = value.get("id")
     if not isinstance(skill_id, str) or not skill_id:
         raise AgentCliError("Skill manifest must declare an id.")

--- a/integrations/mason/src/databricks_mason/cli.py
+++ b/integrations/mason/src/databricks_mason/cli.py
@@ -19,6 +19,7 @@ from databricks_mason.init import init
 from databricks_mason.mcp import mcp
 from databricks_mason.memory import memory
 from databricks_mason.sessions import sessions
+from databricks_mason.skills import skills
 from databricks_mason.tools import tools
 from databricks_mason.tracing import tracing
 
@@ -70,6 +71,7 @@ mason.add_command(sessions)
 mason.add_command(tracing)
 mason.add_command(deploy)
 mason.add_command(deployments)
+mason.add_command(skills)
 mason.add_command(tools)
 configure_help(mason)
 

--- a/integrations/mason/src/databricks_mason/client.py
+++ b/integrations/mason/src/databricks_mason/client.py
@@ -23,6 +23,7 @@ from databricks_mason.errors import AgentCliError, wrap_api_error
 
 _BASE = "/api/agents/v1"
 _MCP_SERVICES_PATH = "/api/2.1/unity-catalog/mcp-services"
+_SKILLS_PATH = "/api/2.1/unity-catalog/skills"
 
 
 def _query(**kwargs: Any) -> dict[str, Any]:
@@ -133,6 +134,25 @@ class MasonClient:
             "GET",
             _MCP_SERVICES_PATH,
             query=_query(parent=f"schemas/{schema}", page_token=page_token),
+        )
+
+    # --- Unity Catalog Skills -----------------------------------------------
+
+    def list_uc_skills(
+        self,
+        schema: str,
+        page_size: Optional[int] = None,
+        page_token: Optional[str] = None,
+    ) -> dict:
+        """List skills visible to the user in a Unity Catalog schema."""
+        return self._do(
+            "GET",
+            _SKILLS_PATH,
+            query=_query(
+                parent=f"schemas/{schema}",
+                page_size=page_size,
+                page_token=page_token,
+            ),
         )
 
     # --- memory stores -------------------------------------------------------

--- a/integrations/mason/src/databricks_mason/help.py
+++ b/integrations/mason/src/databricks_mason/help.py
@@ -45,6 +45,13 @@ _EXAMPLES: dict[CommandPath, tuple[str, ...]] = {
     ("memory", "entries", "delete"): ("mason memory entries delete --store <store> <entry>",),
     ("mcp",): ("mason mcp list", "mason mcp list --schema main.tools"),
     ("mcp", "list"): ("mason mcp list", "mason mcp list --schema main.tools"),
+    ("skills",): (
+        "mason skills list --schema catalog.schema",
+        "mason skills add uc catalog.schema.skill --source .",
+    ),
+    ("skills", "list"): ("mason skills list --schema catalog.schema",),
+    ("skills", "add"): ("mason skills add uc catalog.schema.skill --source .",),
+    ("skills", "add", "uc"): ("mason skills add uc catalog.schema.skill --source .",),
     ("sessions",): ("mason sessions stores list", "mason sessions list --help"),
     ("sessions", "stores"): ("mason sessions stores list",),
     ("sessions", "stores", "create"): ("mason sessions stores create --name agent-sessions",),

--- a/integrations/mason/src/databricks_mason/langgraph/__init__.py
+++ b/integrations/mason/src/databricks_mason/langgraph/__init__.py
@@ -36,6 +36,7 @@ if TYPE_CHECKING:
     from databricks_mason.langgraph.mcp import mcp_tools
     from databricks_mason.langgraph.memory import memory_tools, recall, remember
     from databricks_mason.langgraph.session_store import checkpointer, thread_config
+    from databricks_mason.langgraph.skills import build_skill_context
     from databricks_mason.runtime import tag_session, workspace_client, workspace_headers
 
 
@@ -55,6 +56,8 @@ def configure_tracing() -> None:
 __all__ = [
     # MCP tools from agent.toml (plus any servers you pass) — add them to your agent's tool list.
     "mcp_tools",
+    # UC Skills declared in agent.toml — add returned tools and prompt context to the agent.
+    "build_skill_context",
     # Long-term memory tools (opt-in via AGENT_MEMORY_STORE) — add to your tool list.
     "memory_tools",
     "remember",
@@ -75,6 +78,7 @@ __all__ = [
 # pull in the others' dependencies. ``configure_tracing`` is defined above (binds LangChain autolog).
 _MODULE_BY_NAME = {
     "mcp_tools": "databricks_mason.langgraph.mcp",
+    "build_skill_context": "databricks_mason.langgraph.skills",
     "memory_tools": "databricks_mason.langgraph.memory",
     "remember": "databricks_mason.langgraph.memory",
     "recall": "databricks_mason.langgraph.memory",

--- a/integrations/mason/src/databricks_mason/langgraph/skills.py
+++ b/integrations/mason/src/databricks_mason/langgraph/skills.py
@@ -1,0 +1,212 @@
+"""Inject declared UC Skills as metadata context and two lazy LangGraph tools."""
+
+from __future__ import annotations
+
+import pathlib
+import re
+from dataclasses import dataclass
+from typing import Any
+
+from databricks_langchain import DatabricksMCPServer
+from langchain_core.tools import BaseTool, StructuredTool
+from langchain_mcp_adapters.sessions import create_session
+
+from databricks_mason.runtime.skill_manifest import SkillRecord, load_skills
+from databricks_mason.runtime.workspace import workspace_client, workspace_headers
+
+
+@dataclass(frozen=True)
+class SkillDescriptor:
+    """Prompt-safe metadata for one declared UC skill."""
+
+    id: str
+    source: str
+    name: str
+    description: str
+
+
+def _relative_path(value: str) -> str:
+    windows = pathlib.PureWindowsPath(value)
+    parts = re.split(r"[/\\]", value)
+    if (
+        not value
+        or pathlib.PurePosixPath(value).is_absolute()
+        or windows.is_absolute()
+        or bool(windows.drive)
+        or any(part in {"", ".", ".."} for part in parts)
+    ):
+        raise RuntimeError(f"Skill file path {value!r} must be a contained relative path.")
+    return pathlib.PurePosixPath(*parts).as_posix()
+
+
+def _uc_failure(skill_id: str, operation: str, exc: Exception) -> RuntimeError:
+    return RuntimeError(
+        f"Declared skill {skill_id!r} failed at the UC Skills endpoint during {operation}: {exc}."
+    )
+
+
+def _result_text(result: Any, skill_id: str) -> str:
+    if getattr(result, "isError", False):
+        raise RuntimeError(f"UC Skills endpoint returned an error for declared skill {skill_id!r}.")
+    blocks = getattr(result, "content", None)
+    texts = (
+        [
+            item.text
+            for item in blocks
+            if getattr(item, "type", None) == "text"
+            and isinstance(getattr(item, "text", None), str)
+        ]
+        if isinstance(blocks, (list, tuple))
+        else []
+    )
+    if not texts:
+        raise RuntimeError(
+            f"Declared skill {skill_id!r} did not return a valid MCP result with a text block "
+            "from the UC Skills endpoint."
+        )
+    return "\n".join(texts)
+
+
+class _UCProvider:
+    def __init__(self, record: SkillRecord, server: DatabricksMCPServer, tool: Any):
+        self.record = record
+        self.server = server
+        description = getattr(tool, "description", None)
+        if not isinstance(description, str) or not description.strip():
+            raise RuntimeError(
+                f"Declared skill {record.id!r} has no description at the UC Skills endpoint."
+            )
+        description = description.strip()
+        provenance_prefix = f"[{record.name}] "
+        if description.startswith(provenance_prefix):
+            description = description[len(provenance_prefix) :].strip()
+        if not description:
+            raise RuntimeError(
+                f"Declared skill {record.id!r} has no description at the UC Skills endpoint."
+            )
+        self.tool_name = str(tool.name)
+        self.descriptor = SkillDescriptor(
+            id=record.id,
+            source=record.name,
+            name=record.name.rsplit(".", 1)[-1],
+            description=description,
+        )
+
+    async def _call(self, name: str, arguments: dict[str, Any]) -> str:
+        try:
+            async with create_session(self.server.to_connection_dict()) as session:
+                await session.initialize()
+                result = await session.call_tool(name, arguments)
+        except Exception as exc:
+            raise _uc_failure(self.record.id, "content loading", exc) from exc
+        return _result_text(result, self.record.id)
+
+    async def load(self) -> str:
+        return await self._call(self.tool_name, {})
+
+    async def read_file(self, path: str) -> str:
+        relative = _relative_path(path)
+        return await self._call(
+            "get_skill_files",
+            {"full_name": self.record.name, "paths": [relative]},
+        )
+
+
+def _uc_server(catalog: str, schema: str) -> DatabricksMCPServer:
+    client = workspace_client()
+    host = client.config.host.rstrip("/")
+    return DatabricksMCPServer(
+        name=f"uc-skills-{catalog}-{schema}",
+        url=f"{host}/api/2.0/ai-gateway/skills/?schema={catalog}.{schema}",
+        headers=workspace_headers() or None,
+        workspace_client=client,
+        timeout=120.0,
+    )
+
+
+async def _uc_providers(records: tuple[SkillRecord, ...]) -> list[_UCProvider]:
+    groups: dict[tuple[str, str], list[SkillRecord]] = {}
+    for record in records:
+        catalog, schema, _ = record.name.split(".")
+        groups.setdefault((catalog, schema), []).append(record)
+
+    providers: list[_UCProvider] = []
+    for (catalog, schema), declarations in groups.items():
+        server = _uc_server(catalog, schema)
+        try:
+            async with create_session(server.to_connection_dict()) as session:
+                await session.initialize()
+                response = await session.list_tools()
+        except Exception as exc:
+            raise _uc_failure(declarations[0].id, "metadata discovery", exc) from exc
+        tools: dict[str, list[Any]] = {}
+        for tool in getattr(response, "tools", ()):
+            name = getattr(tool, "name", None)
+            if isinstance(name, str):
+                tools.setdefault(name, []).append(tool)
+        for record in declarations:
+            matches = tools.get(f"skill_{record.name}", [])
+            if not matches:
+                raise RuntimeError(
+                    f"Declared skill {record.id!r} was not found at the UC Skills endpoint "
+                    f"for {catalog}.{schema}."
+                )
+            if len(matches) > 1:
+                raise RuntimeError(
+                    f"Declared skill {record.id!r} is ambiguous because duplicate dynamic tools "
+                    f"were returned by the UC Skills endpoint for {catalog}.{schema}."
+                )
+            providers.append(_UCProvider(record, server, matches[0]))
+    return providers
+
+
+def _tools(providers: tuple[_UCProvider, ...]) -> list[BaseTool]:
+    registry = {provider.descriptor.id: provider for provider in providers}
+
+    def provider_for(skill_id: str) -> _UCProvider:
+        provider = registry.get(skill_id)
+        if provider is None:
+            raise RuntimeError(f"Unknown or undeclared skill ID {skill_id!r}.")
+        return provider
+
+    async def load_skill(skill_id: str) -> str:
+        """Load the instructions for one declared skill by its ID."""
+        return await provider_for(skill_id).load()
+
+    async def read_skill_file(skill_id: str, path: str) -> str:
+        """Read a relative file referenced by one declared skill."""
+        return await provider_for(skill_id).read_file(path)
+
+    return [
+        StructuredTool.from_function(
+            coroutine=load_skill,
+            name="load_skill",
+            description="Load instructions for a declared skill by its ID.",
+        ),
+        StructuredTool.from_function(
+            coroutine=read_skill_file,
+            name="read_skill_file",
+            description="Read a relative file referenced by a declared skill.",
+        ),
+    ]
+
+
+async def build_skill_context() -> tuple[str, list[BaseTool]]:
+    """Return metadata-only prompt context plus lazy tools for exact UC skill bindings."""
+    records = load_skills(expected_framework="langgraph")
+    if not records:
+        return "", []
+    providers = tuple(await _uc_providers(records))
+    lines = [
+        f"- [{descriptor.id}] (uc:{descriptor.source}) {descriptor.description}"
+        for descriptor in sorted(
+            (provider.descriptor for provider in providers), key=lambda item: item.id
+        )
+    ]
+    context = (
+        "Available skills:\n"
+        + "\n".join(lines)
+        + "\n\nCall load_skill with an ID when a task matches. "
+        "Read referenced files only with read_skill_file."
+    )
+    return context, _tools(providers)

--- a/integrations/mason/src/databricks_mason/langgraph/skills.py
+++ b/integrations/mason/src/databricks_mason/langgraph/skills.py
@@ -126,7 +126,7 @@ def _uc_server(catalog: str, schema: str) -> DatabricksMCPServer:
     host = client.config.host.rstrip("/")
     return DatabricksMCPServer(
         name=f"uc-skills-{catalog}-{schema}",
-        url=f"{host}/api/2.0/ai-gateway/skills/?schema={catalog}.{schema}",
+        url=f"{host}/ai-gateway/skills/?schema={catalog}.{schema}",
         headers=workspace_headers() or None,
         workspace_client=client,
         timeout=120.0,

--- a/integrations/mason/src/databricks_mason/langgraph/skills.py
+++ b/integrations/mason/src/databricks_mason/langgraph/skills.py
@@ -14,6 +14,8 @@ from langchain_mcp_adapters.sessions import create_session
 from databricks_mason.runtime.skill_manifest import SkillRecord, load_skills
 from databricks_mason.runtime.workspace import workspace_client, workspace_headers
 
+_MAX_CONTENT_BYTES = 1024 * 1024
+
 
 @dataclass(frozen=True)
 class SkillDescriptor:
@@ -64,7 +66,14 @@ def _result_text(result: Any, skill_id: str) -> str:
             f"Declared skill {skill_id!r} did not return a valid MCP result with a text block "
             "from the UC Skills endpoint."
         )
-    return "\n".join(texts)
+    content = "\n".join(texts)
+    try:
+        size = len(content.encode("utf-8"))
+    except UnicodeEncodeError as exc:
+        raise RuntimeError(f"UC skill content for {skill_id!r} must be UTF-8.") from exc
+    if size > _MAX_CONTENT_BYTES:
+        raise RuntimeError(f"UC skill content for {skill_id!r} exceeds the 1 MiB limit.")
+    return content
 
 
 class _UCProvider:

--- a/integrations/mason/src/databricks_mason/runtime/skill_manifest.py
+++ b/integrations/mason/src/databricks_mason/runtime/skill_manifest.py
@@ -1,0 +1,85 @@
+"""Read the UC skill bindings in the project's ``agent.toml``."""
+
+from __future__ import annotations
+
+import pathlib
+import re
+from dataclasses import dataclass
+from typing import Any, cast
+
+try:
+    import tomllib  # ty: ignore[unresolved-import]
+except ModuleNotFoundError:
+    import tomli as tomllib
+
+from databricks_mason.runtime.tool_manifest import project_root
+
+_SKILL_ID = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.-]*$")
+
+
+@dataclass(frozen=True)
+class SkillRecord:
+    """One exact Unity Catalog skill binding."""
+
+    id: str
+    kind: str
+    name: str
+
+
+def _required_string(value: object, description: str) -> str:
+    if not isinstance(value, str) or not value:
+        raise RuntimeError(f"agent.toml must declare {description}.")
+    return value
+
+
+def _three_part_name(value: str) -> str:
+    parts = value.split(".")
+    if len(parts) != 3 or any(not part for part in parts) or any(char.isspace() for char in value):
+        raise RuntimeError(f"Invalid UC skill name {value!r}.")
+    return value
+
+
+def _skill(value: object) -> SkillRecord:
+    if not isinstance(value, dict):
+        raise RuntimeError("agent.toml skills must be tables.")
+    value = cast(dict[str, Any], value)
+    skill_id = _required_string(value.get("id"), "a skill id")
+    if not _SKILL_ID.fullmatch(skill_id):
+        raise RuntimeError(f"Invalid skill id {skill_id!r}.")
+    source = value.get("source")
+    if not isinstance(source, dict):
+        raise RuntimeError("Each agent.toml skill must declare a source table.")
+    source = cast(dict[str, Any], source)
+    kind = _required_string(source.get("kind"), "a skill source kind")
+    if kind != "uc":
+        raise RuntimeError(f"Unsupported agent.toml skill kind: {kind!r}; only 'uc' is supported.")
+    if source.get("path") is not None:
+        raise RuntimeError("UC skill bindings do not accept source.path.")
+    name = _three_part_name(_required_string(source.get("name"), "a UC skill source.name"))
+    return SkillRecord(id=skill_id, kind=kind, name=name)
+
+
+def load_skills(*, expected_framework: str) -> tuple[SkillRecord, ...]:
+    """Load a fresh immutable view so direct manifest edits apply on the next request."""
+    path: pathlib.Path = project_root() / "agent.toml"
+    try:
+        with path.open("rb") as input_file:
+            document: dict[str, Any] = tomllib.load(input_file)
+    except (OSError, tomllib.TOMLDecodeError) as exc:
+        raise RuntimeError(f"Could not read {path}: {exc}") from exc
+    if document.get("schema_version") != 1:
+        raise RuntimeError(f"Unsupported agent.toml schema in {path}; expected schema_version = 1.")
+    agent = document.get("agent")
+    if not isinstance(agent, dict) or agent.get("framework") != expected_framework:
+        actual = agent.get("framework") if isinstance(agent, dict) else None
+        raise RuntimeError(
+            f"agent.toml framework {actual!r} does not match runtime {expected_framework!r}."
+        )
+    raw_skills = document.get("skills", [])
+    if not isinstance(raw_skills, list):
+        raise RuntimeError("agent.toml skills must be an array of tables.")
+    skills = tuple(_skill(item) for item in raw_skills)
+    ids = [skill.id for skill in skills]
+    if len(ids) != len(set(ids)):
+        raise RuntimeError("agent.toml skill ids must be unique.")
+    return skills

--- a/integrations/mason/src/databricks_mason/runtime/skill_manifest.py
+++ b/integrations/mason/src/databricks_mason/runtime/skill_manifest.py
@@ -43,6 +43,9 @@ def _skill(value: object) -> SkillRecord:
     if not isinstance(value, dict):
         raise RuntimeError("agent.toml skills must be tables.")
     value = cast(dict[str, Any], value)
+    unsupported_fields = set(value) - {"id", "source"}
+    if unsupported_fields:
+        raise RuntimeError(f"Unsupported skill fields: {', '.join(sorted(unsupported_fields))}.")
     skill_id = _required_string(value.get("id"), "a skill id")
     if not _SKILL_ID.fullmatch(skill_id):
         raise RuntimeError(f"Invalid skill id {skill_id!r}.")
@@ -50,11 +53,14 @@ def _skill(value: object) -> SkillRecord:
     if not isinstance(source, dict):
         raise RuntimeError("Each agent.toml skill must declare a source table.")
     source = cast(dict[str, Any], source)
+    unsupported_fields = set(source) - {"kind", "name"}
+    if unsupported_fields:
+        raise RuntimeError(
+            f"Unsupported skill source fields: {', '.join(sorted(unsupported_fields))}."
+        )
     kind = _required_string(source.get("kind"), "a skill source kind")
     if kind != "uc":
         raise RuntimeError(f"Unsupported agent.toml skill kind: {kind!r}; only 'uc' is supported.")
-    if source.get("path") is not None:
-        raise RuntimeError("UC skill bindings do not accept source.path.")
     name = _three_part_name(_required_string(source.get("name"), "a UC skill source.name"))
     return SkillRecord(id=skill_id, kind=kind, name=name)
 

--- a/integrations/mason/src/databricks_mason/skills.py
+++ b/integrations/mason/src/databricks_mason/skills.py
@@ -1,0 +1,200 @@
+"""Discover and attach exact Unity Catalog agent skills."""
+
+from __future__ import annotations
+
+import pathlib
+from typing import Any
+
+import click
+
+from databricks_mason import render
+from databricks_mason.agent_project import AgentProject, SkillSpec
+from databricks_mason.errors import AgentCliError
+
+_RESOURCE_PREFIX = "skills/"
+_METADATA_FIELDS = ("bundle_name", "description", "etag", "comment", "effective_owner")
+
+
+def _validate_schema(schema: str) -> str:
+    normalized = schema.strip()
+    parts = normalized.split(".")
+    if (
+        len(parts) != 2
+        or any(not part for part in parts)
+        or any(character.isspace() for character in normalized)
+    ):
+        raise AgentCliError(
+            f"Invalid schema {schema!r}.",
+            hint="Use a two-part Unity Catalog schema name: catalog.schema.",
+        )
+    return normalized
+
+
+def _skill_record(skill: Any) -> tuple[dict[str, str] | None, str | None]:
+    if not isinstance(skill, dict):
+        return None, "entry is not an object"
+    raw_name = skill.get("name")
+    if not isinstance(raw_name, str) or not raw_name:
+        return None, "name is missing or is not a string"
+    if not raw_name.startswith(_RESOURCE_PREFIX):
+        return None, "name must use skills/catalog.schema.skill"
+    name = raw_name.removeprefix(_RESOURCE_PREFIX)
+    parts = name.split(".")
+    if (
+        len(parts) != 3
+        or any(not part for part in parts)
+        or any(character.isspace() for character in name)
+    ):
+        return None, "name must use skills/catalog.schema.skill"
+    record = {"name": name}
+    for field in _METADATA_FIELDS:
+        value = skill.get(field)
+        if isinstance(value, str) and value:
+            record[field] = value
+    return record, None
+
+
+def _warn_malformed_skill(page: int, index: int, reason: str) -> None:
+    click.echo(
+        f"Warning: skipped malformed UC skill entry at page {page}, index {index}: {reason}.",
+        err=True,
+    )
+
+
+def _list_uc_skills(client: Any, schema: str) -> list[dict[str, str]]:
+    by_name: dict[str, dict[str, str]] = {}
+    page_token = None
+    seen_tokens: set[str] = set()
+    page_number = 0
+    while True:
+        page_number += 1
+        response = client.list_uc_skills(schema, page_token=page_token)
+        if not isinstance(response, dict):
+            raise AgentCliError("The Skills API returned an invalid response.")
+        page = response.get("skills", [])
+        if not isinstance(page, list):
+            raise AgentCliError("The Skills API returned an invalid response.")
+        for index, skill in enumerate(page, 1):
+            record, reason = _skill_record(skill)
+            if reason is not None:
+                _warn_malformed_skill(page_number, index, reason)
+            if record is not None and record["name"] not in by_name:
+                by_name[record["name"]] = record
+        if "next_page_token" not in response:
+            break
+        page_token = response["next_page_token"]
+        if not isinstance(page_token, str):
+            raise AgentCliError(
+                "The Skills API returned an invalid response: pagination token must be a string."
+            )
+        if not page_token:
+            break
+        if page_token in seen_tokens:
+            raise AgentCliError("The Skills API returned a repeated pagination token.")
+        seen_tokens.add(page_token)
+    return [by_name[name] for name in sorted(by_name)]
+
+
+def _manifest_record(spec: SkillSpec) -> dict[str, str]:
+    assert spec.source.name is not None
+    return {
+        "id": spec.id,
+        "kind": spec.source.kind,
+        "source": spec.source.name,
+    }
+
+
+def _emit_change(
+    obj: Any,
+    project: AgentProject,
+    spec: SkillSpec,
+    changed_files: list[pathlib.Path],
+) -> None:
+    payload = {
+        "schema_version": 1,
+        "changed": bool(changed_files),
+        "changed_files": [str(path) for path in changed_files],
+        "skill": _manifest_record(spec),
+    }
+    if getattr(obj, "output", "text") == "json":
+        render.emit_json(payload)
+        return
+    if changed_files:
+        render.success(
+            f"Added {spec.id}",
+            fields={"Kind": spec.source.kind, "Manifest": str(project.path)},
+        )
+    else:
+        click.echo(f"Skill {spec.id!r} is already configured in {project.path}")
+
+
+def _add_spec(obj: Any, source: pathlib.Path, spec: SkillSpec) -> None:
+    project = AgentProject.load(source)
+    changed = project.add_skill(spec)
+    changed_files = [project.write()] if changed else []
+    _emit_change(obj, project, spec, changed_files)
+
+
+def _source_option(function):
+    return click.option(
+        "--source",
+        type=click.Path(exists=True, file_okay=False, path_type=pathlib.Path),
+        default=pathlib.Path("."),
+        show_default=True,
+        help="Mason agent project containing agent.toml.",
+    )(function)
+
+
+@click.group()
+def skills() -> None:
+    """Discover and attach Unity Catalog agent skills."""
+
+
+@skills.command("list")
+@click.option(
+    "--schema",
+    required=True,
+    help="Two-part Unity Catalog schema containing skills.",
+)
+@click.pass_obj
+def list_skills(obj: Any, schema: str) -> None:
+    """List Unity Catalog skills that can be attached to an agent."""
+    schema = _validate_schema(schema)
+    records = _list_uc_skills(obj.client(), schema)
+    if getattr(obj, "output", "text") == "json":
+        render.emit_json({"schema_version": 1, "skills": records})
+        return
+    render.resource_table(
+        "Unity Catalog skills",
+        [("Skill", "left"), ("Description", "left")],
+        [(record["name"], record.get("description")) for record in records],
+        subtitle=f"Available in {schema}",
+    )
+    if records:
+        click.echo("\nAdd a skill:")
+        for record in records:
+            click.echo(f"mason skills add uc {record['name']}")
+
+
+@skills.group("add")
+def add() -> None:
+    """Attach an exact skill binding to agent.toml."""
+
+
+@add.command("uc")
+@click.argument("name")
+@click.option("--name", "skill_id", default=None)
+@_source_option
+@click.pass_obj
+def add_uc(
+    obj: Any,
+    name: str,
+    skill_id: str | None,
+    source: pathlib.Path,
+) -> None:
+    """Attach an exact three-part Unity Catalog skill."""
+    _add_spec(
+        obj,
+        source,
+        SkillSpec.uc(skill_id or name.rsplit(".", 1)[-1], name=name),
+    )

--- a/integrations/mason/templates/agent-langgraph/AGENTS.md
+++ b/integrations/mason/templates/agent-langgraph/AGENTS.md
@@ -117,7 +117,8 @@ reads referenced files with `read_skill_file`, which fetches them remotely from 
 
 Local, custom, and path-based skills, automatic discovery, and versions are not supported. A
 deployed App's service principal needs `USE_CATALOG` on the catalog, `USE_SCHEMA` on the schema,
-and `READ_SKILL` on the bound skill.
+and `READ_VOLUME` on the bound skill. The legacy `READ_SKILL` privilege does not authorize skill
+metadata or bundle reads.
 
 ## Sessions & durability
 

--- a/integrations/mason/templates/agent-langgraph/AGENTS.md
+++ b/integrations/mason/templates/agent-langgraph/AGENTS.md
@@ -77,6 +77,7 @@ curl -sb "$COOKIE_JAR" -X POST http://localhost:8000/invocations \
 | Add a function tool | new `*.py` in `agent/tools/` with a `@tool` function (auto-collected) |
 | Require human approval for a tool | add its name to `REQUIRE_APPROVAL` in `agent/agent.py` |
 | Add an MCP server | append a `DatabricksMCPServer` to `build_mcp_servers()` in `agent/mcps.py` |
+| Attach a Unity Catalog skill | `mason skills add uc catalog.schema.skill --source .` (`agent.toml`) |
 | Change how a request maps to a run | `agent/agent.py` (`invoke_handler` / `stream_handler`) |
 | Change the session checkpointer | `databricks_mason/langgraph/session_store.py` |
 | Change the HTTP surface (routes, SSE, background wiring) | `runtime/runtime.py` |
@@ -97,6 +98,26 @@ so the template ships only your agent code.
 `@tool`-decorated `BaseTool` it finds. So a tool registers just by existing in a file there —
 `create_agent_graph()` calls `all_tools()`. **Do not** edit `agent/agent.py` to add a tool — just add
 a file to `agent/tools/`.
+
+## Unity Catalog skills
+
+This LangGraph template supports exact Unity Catalog skill bindings only:
+
+```toml
+[[skills]]
+id = "review"
+source = { kind = "uc", name = "catalog.schema.skill" }
+```
+
+Use `mason skills list --schema catalog.schema` to discover skills and
+`mason skills add uc catalog.schema.skill --source .` to add one. The model initially receives only
+the declared skills' names and descriptions. It loads instructions lazily with `load_skill` and
+reads referenced files with `read_skill_file`, which fetches them remotely from UC through
+`get_skill_files`; those files are never copied into the project or deployment.
+
+Local, custom, and path-based skills, automatic discovery, and versions are not supported. A
+deployed App's service principal needs `USE_CATALOG` on the catalog, `USE_SCHEMA` on the schema,
+and `READ_SKILL` on the bound skill.
 
 ## Sessions & durability
 

--- a/integrations/mason/templates/agent-langgraph/README.md
+++ b/integrations/mason/templates/agent-langgraph/README.md
@@ -264,7 +264,8 @@ are never copied into the project or deployment.
 
 Only exact UC bindings are supported. There are no local, custom, or path-based sources, automatic
 discovery, or versions. The deployed Databricks App's service principal needs `USE_CATALOG` on the
-catalog, `USE_SCHEMA` on the schema, and `READ_SKILL` on the bound skill.
+catalog, `USE_SCHEMA` on the schema, and `READ_VOLUME` on the bound skill. The legacy `READ_SKILL`
+privilege does not authorize skill metadata or bundle reads.
 
 ## Test
 

--- a/integrations/mason/templates/agent-langgraph/README.md
+++ b/integrations/mason/templates/agent-langgraph/README.md
@@ -240,6 +240,32 @@ and durable event replay.
 - **Change the HTTP surface:** `runtime/runtime.py` — routes, SSE framing, background wiring (the run
   store itself is `databricks_mason/runtime/background.py`).
 
+### Use Unity Catalog skills (LangGraph only)
+
+Discover the skills in a Unity Catalog schema, then attach an exact skill binding to this project:
+
+```bash
+mason skills list --schema catalog.schema
+mason skills add uc catalog.schema.skill --source .
+```
+
+Bindings live in `agent.toml`:
+
+```toml
+[[skills]]
+id = "review"
+source = { kind = "uc", name = "catalog.schema.skill" }
+```
+
+The agent receives each declared skill's name and description as metadata. Instructions are fetched
+only when it calls `load_skill` with the binding ID; referenced files are fetched remotely from UC
+through `read_skill_file` and the `get_skill_files` endpoint. Skill instructions and reference files
+are never copied into the project or deployment.
+
+Only exact UC bindings are supported. There are no local, custom, or path-based sources, automatic
+discovery, or versions. The deployed Databricks App's service principal needs `USE_CATALOG` on the
+catalog, `USE_SCHEMA` on the schema, and `READ_SKILL` on the bound skill.
+
 ## Test
 
 ```bash

--- a/integrations/mason/templates/agent-langgraph/agent/agent.py
+++ b/integrations/mason/templates/agent-langgraph/agent/agent.py
@@ -9,18 +9,23 @@ from langchain.agents.middleware import HumanInTheLoopMiddleware
 from langchain.messages import AIMessageChunk
 from langgraph.types import Command
 
+from agent.mcps import build_mcp_servers
+
+# Importing the tools package auto-registers every tool module.
+from agent.tools import all_tools
 from databricks_mason import (
     configure_tracing,
     tag_session,
     workspace_client,
     workspace_headers,
 )
-from databricks_mason.langgraph import checkpointer, mcp_tools, memory_tools, thread_config
-
-from agent.mcps import build_mcp_servers
-
-# Importing the tools package auto-registers every tool module.
-from agent.tools import all_tools
+from databricks_mason.langgraph import (
+    build_skill_context,
+    checkpointer,
+    mcp_tools,
+    memory_tools,
+    thread_config,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -74,17 +79,19 @@ def _check_databricks_auth() -> None:
 
 
 async def create_agent_graph():
-    """Build the LangGraph agent: local tools + long-term-memory tools + any MCP tools."""
+    """Build the agent with local, memory, MCP, and lazily loaded UC skill tools."""
     # Join the manifest's MCP servers (from agent.toml) with your own hand-declared ones (mcps.py),
     # then fetch their tools. Edit build_mcp_servers in agent/mcps.py to add servers.
     mcp = await mcp_tools(build_mcp_servers())
-    tools = [*all_tools(), *memory_tools(), *mcp]
+    skill_prompt, skill_tools = await build_skill_context()
+    tools = [*all_tools(), *memory_tools(), *mcp, *skill_tools]
     middleware = (
         [HumanInTheLoopMiddleware(interrupt_on=REQUIRE_APPROVAL)] if REQUIRE_APPROVAL else []
     )
     return create_agent(
         model=_RoutedChatDatabricks(endpoint=MODEL, workspace_client=workspace_client()),
         tools=tools,
+        system_prompt=skill_prompt or None,
         middleware=middleware,
         checkpointer=checkpointer(),
     )

--- a/integrations/mason/templates/agent-langgraph/tests/test_agent.py
+++ b/integrations/mason/templates/agent-langgraph/tests/test_agent.py
@@ -5,16 +5,18 @@ Databricks auth needed, so they run anywhere. The live test builds the full agen
 model; it is skipped unless a workspace profile is configured.
 """
 
+import asyncio
 import os
 from uuid import UUID
 
 import pytest
 from agent.agent import _serialize_events, _session_id
-from databricks_mason.langgraph.session_store import checkpointer, thread_config
 from agent.tools import all_tools
 from fastapi.testclient import TestClient
 from langchain_core.tools import BaseTool
 from runtime.runtime import build_app
+
+from databricks_mason.langgraph.session_store import checkpointer, thread_config
 
 
 def test_tools_autoregister():
@@ -30,6 +32,74 @@ def test_gated_tool_is_in_require_approval():
 
     assert REQUIRE_APPROVAL.get("send_message")
     assert "send_message" in {t.name for t in all_tools()}
+
+
+def test_create_agent_graph_appends_skill_tools_and_metadata_prompt(monkeypatch):
+    import agent.agent as agent_module
+
+    captured = {}
+    local_tools = [object()]
+    memory = [object()]
+    mcp = [object()]
+    skill_tools = [object(), object()]
+
+    async def mcp_tools(extra_servers):
+        assert extra_servers == ["custom-server"]
+        return mcp
+
+    async def build_skill_context():
+        return "Available skills:\n- [review] (uc:main.ai.review) Review safely.", skill_tools
+
+    monkeypatch.setattr(agent_module, "REQUIRE_APPROVAL", {})
+    monkeypatch.setattr(agent_module, "all_tools", lambda: local_tools)
+    monkeypatch.setattr(agent_module, "memory_tools", lambda: memory)
+    monkeypatch.setattr(agent_module, "mcp_tools", mcp_tools)
+    monkeypatch.setattr(agent_module, "build_mcp_servers", lambda: ["custom-server"])
+    monkeypatch.setattr(agent_module, "build_skill_context", build_skill_context, raising=False)
+    monkeypatch.setattr(agent_module, "_RoutedChatDatabricks", lambda **kwargs: "model")
+    monkeypatch.setattr(agent_module, "workspace_client", lambda: "workspace")
+    monkeypatch.setattr(agent_module, "checkpointer", lambda: "checkpointer")
+    monkeypatch.setattr(
+        agent_module,
+        "create_agent",
+        lambda **kwargs: captured.update(kwargs) or "graph",
+    )
+
+    assert asyncio.run(agent_module.create_agent_graph()) == "graph"
+    assert captured["tools"] == [*local_tools, *memory, *mcp, *skill_tools]
+    assert captured["system_prompt"] == (
+        "Available skills:\n- [review] (uc:main.ai.review) Review safely."
+    )
+
+
+def test_create_agent_graph_omits_empty_skill_prompt(monkeypatch):
+    import agent.agent as agent_module
+
+    captured = {}
+
+    async def empty_tools(*args):
+        return []
+
+    async def empty_skill_context():
+        return "", []
+
+    monkeypatch.setattr(agent_module, "REQUIRE_APPROVAL", {})
+    monkeypatch.setattr(agent_module, "all_tools", lambda: [])
+    monkeypatch.setattr(agent_module, "memory_tools", lambda: [])
+    monkeypatch.setattr(agent_module, "mcp_tools", empty_tools)
+    monkeypatch.setattr(agent_module, "build_mcp_servers", lambda: [])
+    monkeypatch.setattr(agent_module, "build_skill_context", empty_skill_context, raising=False)
+    monkeypatch.setattr(agent_module, "_RoutedChatDatabricks", lambda **kwargs: "model")
+    monkeypatch.setattr(agent_module, "workspace_client", lambda: "workspace")
+    monkeypatch.setattr(agent_module, "checkpointer", lambda: "checkpointer")
+    monkeypatch.setattr(
+        agent_module,
+        "create_agent",
+        lambda **kwargs: captured.update(kwargs) or "graph",
+    )
+
+    assert asyncio.run(agent_module.create_agent_graph()) == "graph"
+    assert captured["system_prompt"] is None
 
 
 class _FakeInterrupt:
@@ -67,9 +137,7 @@ def test_chat_model_forwards_account_routing_header(monkeypatch):
     monkeypatch.setenv("DATABRICKS_WORKSPACE_ID", "123456")
     model = _RoutedChatDatabricks(endpoint="test-endpoint")
 
-    assert model._get_client_kwargs()["default_headers"] == {
-        "X-Databricks-Org-Id": "123456"
-    }
+    assert model._get_client_kwargs()["default_headers"] == {"X-Databricks-Org-Id": "123456"}
 
 
 def test_thread_config_from_session_id():

--- a/integrations/mason/tests/unit_tests/agent_project_test.py
+++ b/integrations/mason/tests/unit_tests/agent_project_test.py
@@ -6,6 +6,7 @@ import pathlib
 
 import pytest
 
+from databricks_mason import agent_project as project_model
 from databricks_mason.agent_project import AgentProject, Scope, ToolSpec
 from databricks_mason.errors import AgentCliError
 
@@ -99,5 +100,123 @@ def test_write_is_atomic_when_replace_fails(tmp_path: pathlib.Path, monkeypatch)
     monkeypatch.setattr("databricks_mason.agent_project.os.replace", fail_replace)
     with pytest.raises(AgentCliError, match="replace failed"):
         project.write()
+
+    assert path.read_text(encoding="utf-8") == before
+
+
+def test_uc_skill_round_trips_and_add_is_idempotent(tmp_path: pathlib.Path):
+    project = AgentProject.create(tmp_path, framework="langgraph")
+    spec = project_model.SkillSpec.uc("review", name="catalog.schema.skill")
+
+    assert project.add_skill(spec) is True
+    assert project.add_skill(spec) is False
+    project.write()
+
+    assert "[[skills]]" in (tmp_path / "agent.toml").read_text(encoding="utf-8")
+    assert AgentProject.load(tmp_path).skills == [spec]
+
+
+def test_uc_skill_rejects_conflicting_id(tmp_path: pathlib.Path):
+    project = AgentProject.create(tmp_path, framework="langgraph")
+    project.add_skill(project_model.SkillSpec.uc("review", name="main.ai.review"))
+
+    with pytest.raises(AgentCliError, match="Skill id 'review' already exists"):
+        project.add_skill(project_model.SkillSpec.uc("review", name="main.ai.other-review"))
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        "catalog.schema",
+        "catalog..review",
+        "catalog.schema.review.extra",
+        "catalog.schema.project review",
+    ],
+)
+def test_uc_skill_rejects_invalid_three_part_name(name: str):
+    with pytest.raises(AgentCliError, match="UC skill"):
+        project_model.SkillSpec.uc("review", name=name)
+
+
+def test_load_rejects_duplicate_skill_ids(tmp_path: pathlib.Path):
+    _write_manifest(
+        tmp_path,
+        """schema_version = 1
+
+[agent]
+framework = "langgraph"
+
+[[skills]]
+id = "review"
+source = { kind = "uc", name = "main.ai.review" }
+
+[[skills]]
+id = "review"
+source = { kind = "uc", name = "main.ai.other-review" }
+""",
+    )
+
+    with pytest.raises(AgentCliError, match="skill ids must be unique"):
+        AgentProject.load(tmp_path)
+
+
+@pytest.mark.parametrize(
+    "skill_entry",
+    [
+        'id = "review"',
+        'id = "review"\nsource = "uc"',
+        'id = "review"\nsource = { kind = "unknown" }',
+        'id = "review"\nsource = { kind = "local", path = "skills/review" }',
+        'id = "review"\nsource = { kind = "uc" }',
+        'id = "review"\nsource = { kind = "uc", name = 42 }',
+        (
+            'id = "review"\n'
+            'source = { kind = "uc", name = "main.ai.review", path = "skills/review" }'
+        ),
+    ],
+)
+def test_load_rejects_malformed_or_non_uc_skill_sources(tmp_path: pathlib.Path, skill_entry: str):
+    _write_manifest(
+        tmp_path,
+        f"""schema_version = 1
+
+[agent]
+framework = "langgraph"
+
+[[skills]]
+{skill_entry}
+""",
+    )
+
+    with pytest.raises(AgentCliError, match="[Ss]kill|source"):
+        AgentProject.load(tmp_path)
+
+
+def test_openai_project_rejects_skill_addition(tmp_path: pathlib.Path):
+    project = AgentProject.create(tmp_path, framework="openai")
+
+    with pytest.raises(AgentCliError, match="Agent skills are LangGraph-only"):
+        project.add_skill(project_model.SkillSpec.uc("review", name="main.ai.review"))
+
+    assert project.skills == []
+
+
+def test_load_rejects_openai_manifest_with_skills(tmp_path: pathlib.Path):
+    path = _write_manifest(
+        tmp_path,
+        """schema_version = 1
+
+[agent]
+framework = "openai"
+
+[[skills]]
+id = "review"
+source = { kind = "uc", name = "main.ai.review" }
+""",
+    )
+    before = path.read_text(encoding="utf-8")
+
+    with pytest.raises(AgentCliError, match="Agent skills are LangGraph-only"):
+        AgentProject.load(tmp_path)
 
     assert path.read_text(encoding="utf-8") == before

--- a/integrations/mason/tests/unit_tests/agent_project_test.py
+++ b/integrations/mason/tests/unit_tests/agent_project_test.py
@@ -173,6 +173,7 @@ source = { kind = "uc", name = "main.ai.other-review" }
             'id = "review"\n'
             'source = { kind = "uc", name = "main.ai.review", path = "skills/review" }'
         ),
+        'id = "review"\nsource = { kind = "uc", name = "main.ai.review" }\nversion = "v1"',
     ],
 )
 def test_load_rejects_malformed_or_non_uc_skill_sources(tmp_path: pathlib.Path, skill_entry: str):

--- a/integrations/mason/tests/unit_tests/cli_test.py
+++ b/integrations/mason/tests/unit_tests/cli_test.py
@@ -36,6 +36,7 @@ def test_root_registers_supported_commands():
         "deploy",
         "deployments",
         "mcp",
+        "skills",
         "tools",
     } <= names
     assert "help" not in names
@@ -76,6 +77,26 @@ def test_tools_add_help_explains_types_and_project_targeting():
         "mason tools add python lookup-ticket",
     ):
         assert example in result.output
+
+
+def test_skills_help_explains_uc_workflow():
+    result = CliRunner().invoke(cli.mason, ["skills", "--help"])
+
+    assert result.exit_code == 0, result.output
+    assert "Discover and attach Unity Catalog agent skills." in result.output
+    assert "List Unity Catalog skills that can be attached to an agent." in result.output
+    assert "Attach an exact skill binding to agent.toml." in result.output
+    assert "mason skills list --schema catalog.schema" in result.output
+    assert "mason skills add uc catalog.schema.skill" in result.output
+
+
+def test_skills_add_uc_help_shows_project_targeting_and_example():
+    result = CliRunner().invoke(cli.mason, ["skills", "add", "uc", "--help"])
+
+    assert result.exit_code == 0, result.output
+    assert "Usage: mason skills add uc [OPTIONS] NAME" in result.output
+    assert "--source DIRECTORY" in result.output
+    assert "mason skills add uc catalog.schema.skill --source ." in result.output
 
 
 def test_help_examples_recommend_the_default_happy_path():

--- a/integrations/mason/tests/unit_tests/client_test.py
+++ b/integrations/mason/tests/unit_tests/client_test.py
@@ -56,6 +56,24 @@ def test_list_mcp_services_query(workspace_client):
 
 
 @mock.patch("databricks_mason.client.WorkspaceClient")
+def test_list_uc_skills_query(workspace_client):
+    c, do = _client(workspace_client)
+
+    c.list_uc_skills("catalog.schema", page_size=25, page_token="next")
+
+    do.assert_called_once_with(
+        "GET",
+        "/api/2.1/unity-catalog/skills",
+        query={
+            "parent": "schemas/catalog.schema",
+            "page_size": 25,
+            "page_token": "next",
+        },
+        body=None,
+    )
+
+
+@mock.patch("databricks_mason.client.WorkspaceClient")
 def test_get_memory_store_normalizes_id(workspace_client):
     c, do = _client(workspace_client)
     c.get_memory_store("abc123")

--- a/integrations/mason/tests/unit_tests/skill_runtime_test.py
+++ b/integrations/mason/tests/unit_tests/skill_runtime_test.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import asyncio
 import importlib
 import pathlib
+import sys
+import types
 from types import SimpleNamespace
 
 import pytest
@@ -101,6 +103,32 @@ class _FakeStructuredTool:
         return await self.coroutine(**arguments)
 
 
+def _import_runtime(monkeypatch):
+    """Import the runtime adapter with only its optional dependencies faked."""
+    databricks_langchain = types.ModuleType("databricks_langchain")
+    databricks_langchain.__dict__["DatabricksMCPServer"] = object
+    langchain_core = types.ModuleType("langchain_core")
+    langchain_tools = types.ModuleType("langchain_core.tools")
+    langchain_tools.__dict__["BaseTool"] = object
+    langchain_tools.__dict__["StructuredTool"] = _FakeStructuredTool
+    adapters = types.ModuleType("langchain_mcp_adapters")
+    sessions = types.ModuleType("langchain_mcp_adapters.sessions")
+    sessions.__dict__["create_session"] = lambda connection: None
+    monkeypatch.setitem(sys.modules, "databricks_langchain", databricks_langchain)
+    monkeypatch.setitem(sys.modules, "langchain_core", langchain_core)
+    monkeypatch.setitem(sys.modules, "langchain_core.tools", langchain_tools)
+    monkeypatch.setitem(sys.modules, "langchain_mcp_adapters", adapters)
+    monkeypatch.setitem(sys.modules, "langchain_mcp_adapters.sessions", sessions)
+    sys.modules.pop("databricks_mason.langgraph.skills", None)
+    return importlib.import_module("databricks_mason.langgraph.skills")
+
+
+@pytest.fixture(autouse=True)
+def _unload_skill_runtime_after_test():
+    yield
+    sys.modules.pop("databricks_mason.langgraph.skills", None)
+
+
 class _FakeSessions:
     def __init__(self, tools):
         self.tools = tools
@@ -150,7 +178,7 @@ def _uc_tool(
 def _load_runtime(monkeypatch, tmp_path: pathlib.Path, tools):
     _write_manifest(tmp_path, UC_SKILL)
     monkeypatch.setenv("MASON_PROJECT_ROOT", str(tmp_path))
-    runtime = importlib.import_module("databricks_mason.langgraph.skills")
+    runtime = _import_runtime(monkeypatch)
     sessions = _FakeSessions(tools)
 
     class FakeDatabricksMCPServer:
@@ -232,8 +260,8 @@ def test_uc_skill_rejects_missing_dynamic_tool(monkeypatch, tmp_path: pathlib.Pa
         asyncio.run(runtime.build_skill_context())
 
 
-def test_uc_skill_rejects_content_over_one_mibibyte():
-    runtime = importlib.import_module("databricks_mason.langgraph.skills")
+def test_uc_skill_rejects_content_over_one_mibibyte(monkeypatch):
+    runtime = _import_runtime(monkeypatch)
     content = "é" * (1024 * 1024 // 2) + "a"
     result = SimpleNamespace(
         isError=False,
@@ -256,8 +284,8 @@ def test_uc_reference_reader_requires_relative_contained_path(
     assert sessions.calls == []
 
 
-def test_langgraph_package_exports_skill_context_builder():
+def test_langgraph_package_exports_skill_context_builder(monkeypatch):
     langgraph = importlib.import_module("databricks_mason.langgraph")
-    runtime = importlib.import_module("databricks_mason.langgraph.skills")
+    runtime = _import_runtime(monkeypatch)
 
     assert langgraph.build_skill_context is runtime.build_skill_context

--- a/integrations/mason/tests/unit_tests/skill_runtime_test.py
+++ b/integrations/mason/tests/unit_tests/skill_runtime_test.py
@@ -200,7 +200,7 @@ def test_uc_skill_injects_metadata_and_loads_body_and_reference_lazily(
     assert "REFERENCE_MARKER" not in context
     assert [tool.name for tool in tools] == ["load_skill", "read_skill_file"]
     assert [server.url for server in server_type.created] == [
-        "https://df1.example.com/api/2.0/ai-gateway/skills/?schema=main.finance"
+        "https://df1.example.com/ai-gateway/skills/?schema=main.finance"
     ]
     assert server_type.created[0].kwargs["workspace_client"] is client
     assert server_type.created[0].kwargs["headers"] == {"X-Databricks-Org-Id": "123"}

--- a/integrations/mason/tests/unit_tests/skill_runtime_test.py
+++ b/integrations/mason/tests/unit_tests/skill_runtime_test.py
@@ -1,0 +1,237 @@
+"""Behavior tests for UC Skills manifest loading and LangGraph injection."""
+
+from __future__ import annotations
+
+import asyncio
+import importlib
+import pathlib
+from types import SimpleNamespace
+
+import pytest
+
+UC_SKILL = """[[skills]]
+id = "quarter-close"
+source = { kind = "uc", name = "main.finance.quarter-close" }
+"""
+
+
+def _write_manifest(root: pathlib.Path, *skills: str, framework: str = "langgraph") -> None:
+    (root / "agent.toml").write_text(
+        f'''schema_version = 1
+
+[agent]
+framework = "{framework}"
+
+{"".join(skills)}''',
+        encoding="utf-8",
+    )
+
+
+def test_load_skills_preserves_exact_uc_binding(monkeypatch, tmp_path: pathlib.Path):
+    _write_manifest(tmp_path, UC_SKILL)
+    monkeypatch.setenv("MASON_PROJECT_ROOT", str(tmp_path))
+
+    manifest = importlib.import_module("databricks_mason.runtime.skill_manifest")
+
+    assert manifest.load_skills(expected_framework="langgraph") == (
+        manifest.SkillRecord(
+            id="quarter-close",
+            kind="uc",
+            name="main.finance.quarter-close",
+        ),
+    )
+
+
+@pytest.mark.parametrize(
+    "source",
+    [
+        '{ kind = "local", path = "skills/review" }',
+        '{ kind = "uc", name = "main.finance" }',
+        '{ kind = "uc", name = "main.finance.review", path = "skills/review" }',
+    ],
+)
+def test_load_skills_rejects_non_uc_or_malformed_sources(
+    monkeypatch, tmp_path: pathlib.Path, source: str
+):
+    _write_manifest(
+        tmp_path,
+        f'[[skills]]\nid = "review"\nsource = {source}\n',
+    )
+    monkeypatch.setenv("MASON_PROJECT_ROOT", str(tmp_path))
+    manifest = importlib.import_module("databricks_mason.runtime.skill_manifest")
+
+    with pytest.raises(RuntimeError, match="[Ss]kill|UC"):
+        manifest.load_skills(expected_framework="langgraph")
+
+
+def test_load_skills_rejects_duplicate_ids(monkeypatch, tmp_path: pathlib.Path):
+    _write_manifest(tmp_path, UC_SKILL, UC_SKILL)
+    monkeypatch.setenv("MASON_PROJECT_ROOT", str(tmp_path))
+    manifest = importlib.import_module("databricks_mason.runtime.skill_manifest")
+
+    with pytest.raises(RuntimeError, match="skill ids must be unique"):
+        manifest.load_skills(expected_framework="langgraph")
+
+
+class _FakeStructuredTool:
+    def __init__(self, *, name, description, coroutine):
+        self.name = name
+        self.description = description
+        self.coroutine = coroutine
+
+    @classmethod
+    def from_function(cls, *, coroutine, name, description):
+        return cls(name=name, description=description, coroutine=coroutine)
+
+    async def ainvoke(self, arguments):
+        return await self.coroutine(**arguments)
+
+
+class _FakeSessions:
+    def __init__(self, tools):
+        self.tools = tools
+        self.connections = []
+        self.calls = []
+
+    def create(self, connection):
+        self.connections.append(connection)
+        parent = self
+
+        class Context:
+            async def __aenter__(self):
+                return Session()
+
+            async def __aexit__(self, *args):
+                return False
+
+        class Session:
+            async def initialize(self):
+                return None
+
+            async def list_tools(self):
+                return SimpleNamespace(tools=parent.tools)
+
+            async def call_tool(self, name, arguments):
+                parent.calls.append((name, arguments))
+                text = (
+                    "=== references/close.md ===\nREFERENCE_MARKER"
+                    if name == "get_skill_files"
+                    else "BODY_MARKER"
+                )
+                return SimpleNamespace(
+                    isError=False,
+                    content=[SimpleNamespace(type="text", text=text)],
+                )
+
+        return Context()
+
+
+def _uc_tool(
+    name: str = "skill_main.finance.quarter-close",
+    description: str = "[main.finance.quarter-close] Close the quarter consistently.",
+):
+    return SimpleNamespace(name=name, description=description, inputSchema={})
+
+
+def _load_runtime(monkeypatch, tmp_path: pathlib.Path, tools):
+    _write_manifest(tmp_path, UC_SKILL)
+    monkeypatch.setenv("MASON_PROJECT_ROOT", str(tmp_path))
+    runtime = importlib.import_module("databricks_mason.langgraph.skills")
+    sessions = _FakeSessions(tools)
+
+    class FakeDatabricksMCPServer:
+        created = []
+
+        def __init__(self, name, url, **kwargs):
+            self.name = name
+            self.url = url
+            self.kwargs = kwargs
+            self.created.append(self)
+
+        def to_connection_dict(self):
+            return {
+                "transport": "streamable_http",
+                "url": self.url,
+                "headers": self.kwargs.get("headers"),
+            }
+
+    client = SimpleNamespace(config=SimpleNamespace(host="https://df1.example.com/"))
+    monkeypatch.setattr(runtime, "DatabricksMCPServer", FakeDatabricksMCPServer)
+    monkeypatch.setattr(runtime, "StructuredTool", _FakeStructuredTool)
+    monkeypatch.setattr(runtime, "create_session", sessions.create)
+    monkeypatch.setattr(runtime, "workspace_client", lambda: client)
+    monkeypatch.setattr(runtime, "workspace_headers", lambda: {"X-Databricks-Org-Id": "123"})
+    return runtime, sessions, FakeDatabricksMCPServer, client
+
+
+def test_uc_skill_injects_metadata_and_loads_body_and_reference_lazily(
+    monkeypatch, tmp_path: pathlib.Path
+):
+    runtime, sessions, server_type, client = _load_runtime(
+        monkeypatch,
+        tmp_path,
+        [_uc_tool(), _uc_tool("get_skill_files", "Read referenced files.")],
+    )
+
+    context, tools = asyncio.run(runtime.build_skill_context())
+
+    assert context == (
+        "Available skills:\n"
+        "- [quarter-close] (uc:main.finance.quarter-close) "
+        "Close the quarter consistently.\n\n"
+        "Call load_skill with an ID when a task matches. "
+        "Read referenced files only with read_skill_file."
+    )
+    assert "BODY_MARKER" not in context
+    assert "REFERENCE_MARKER" not in context
+    assert [tool.name for tool in tools] == ["load_skill", "read_skill_file"]
+    assert [server.url for server in server_type.created] == [
+        "https://df1.example.com/api/2.0/ai-gateway/skills/?schema=main.finance"
+    ]
+    assert server_type.created[0].kwargs["workspace_client"] is client
+    assert server_type.created[0].kwargs["headers"] == {"X-Databricks-Org-Id": "123"}
+    assert sessions.calls == []
+
+    load, read = tools
+    assert asyncio.run(load.ainvoke({"skill_id": "quarter-close"})) == "BODY_MARKER"
+    assert (
+        asyncio.run(read.ainvoke({"skill_id": "quarter-close", "path": "references/close.md"}))
+        == "=== references/close.md ===\nREFERENCE_MARKER"
+    )
+    assert sessions.calls == [
+        ("skill_main.finance.quarter-close", {}),
+        (
+            "get_skill_files",
+            {"full_name": "main.finance.quarter-close", "paths": ["references/close.md"]},
+        ),
+    ]
+
+
+def test_uc_skill_rejects_missing_dynamic_tool(monkeypatch, tmp_path: pathlib.Path):
+    runtime, _, _, _ = _load_runtime(
+        monkeypatch,
+        tmp_path,
+        [_uc_tool("skill_main.finance.other", "Another skill.")],
+    )
+
+    with pytest.raises(RuntimeError, match="quarter-close.*not found.*UC Skills endpoint"):
+        asyncio.run(runtime.build_skill_context())
+
+
+@pytest.mark.parametrize("path", ["../secret.md", "/tmp/secret.md", r"C:\\secret.md"])
+def test_uc_reference_reader_requires_relative_contained_path(
+    monkeypatch, tmp_path: pathlib.Path, path: str
+):
+    runtime, sessions, _, _ = _load_runtime(monkeypatch, tmp_path, [_uc_tool()])
+    _, tools = asyncio.run(runtime.build_skill_context())
+
+    with pytest.raises(RuntimeError, match="relative path"):
+        asyncio.run(tools[1].ainvoke({"skill_id": "quarter-close", "path": path}))
+    assert sessions.calls == []
+
+
+def test_langgraph_package_exports_skill_context_builder():
+    langgraph = importlib.import_module("databricks_mason.langgraph")
+    runtime = importlib.import_module("databricks_mason.langgraph.skills")
+
+    assert langgraph.build_skill_context is runtime.build_skill_context

--- a/integrations/mason/tests/unit_tests/skill_runtime_test.py
+++ b/integrations/mason/tests/unit_tests/skill_runtime_test.py
@@ -48,6 +48,7 @@ def test_load_skills_preserves_exact_uc_binding(monkeypatch, tmp_path: pathlib.P
         '{ kind = "local", path = "skills/review" }',
         '{ kind = "uc", name = "main.finance" }',
         '{ kind = "uc", name = "main.finance.review", path = "skills/review" }',
+        '{ kind = "uc", name = "main.finance.review", version = "v1" }',
     ],
 )
 def test_load_skills_rejects_non_uc_or_malformed_sources(
@@ -70,6 +71,19 @@ def test_load_skills_rejects_duplicate_ids(monkeypatch, tmp_path: pathlib.Path):
     manifest = importlib.import_module("databricks_mason.runtime.skill_manifest")
 
     with pytest.raises(RuntimeError, match="skill ids must be unique"):
+        manifest.load_skills(expected_framework="langgraph")
+
+
+def test_load_skills_rejects_unsupported_version_field(monkeypatch, tmp_path: pathlib.Path):
+    _write_manifest(
+        tmp_path,
+        '[[skills]]\nid = "review"\n'
+        'source = { kind = "uc", name = "main.finance.review" }\nversion = "v1"\n',
+    )
+    monkeypatch.setenv("MASON_PROJECT_ROOT", str(tmp_path))
+    manifest = importlib.import_module("databricks_mason.runtime.skill_manifest")
+
+    with pytest.raises(RuntimeError, match="Unsupported skill fields.*version"):
         manifest.load_skills(expected_framework="langgraph")
 
 
@@ -216,6 +230,18 @@ def test_uc_skill_rejects_missing_dynamic_tool(monkeypatch, tmp_path: pathlib.Pa
 
     with pytest.raises(RuntimeError, match="quarter-close.*not found.*UC Skills endpoint"):
         asyncio.run(runtime.build_skill_context())
+
+
+def test_uc_skill_rejects_content_over_one_mibibyte():
+    runtime = importlib.import_module("databricks_mason.langgraph.skills")
+    content = "é" * (1024 * 1024 // 2) + "a"
+    result = SimpleNamespace(
+        isError=False,
+        content=[SimpleNamespace(type="text", text=content)],
+    )
+
+    with pytest.raises(RuntimeError, match="quarter-close.*1 MiB"):
+        runtime._result_text(result, "quarter-close")
 
 
 @pytest.mark.parametrize("path", ["../secret.md", "/tmp/secret.md", r"C:\\secret.md"])

--- a/integrations/mason/tests/unit_tests/skills_test.py
+++ b/integrations/mason/tests/unit_tests/skills_test.py
@@ -1,0 +1,297 @@
+"""Unit tests for Unity Catalog skill discovery and exact bindings."""
+
+from __future__ import annotations
+
+import importlib
+import json
+import pathlib
+from typing import Any, cast
+
+import pytest
+from click.testing import CliRunner
+
+from databricks_mason.agent_project import AgentProject
+
+
+class _Client:
+    def __init__(self, pages):
+        self.pages = iter(pages)
+        self.calls = []
+
+    def list_uc_skills(self, schema, page_size=None, page_token=None):
+        self.calls.append((schema, page_size, page_token))
+        return next(self.pages)
+
+
+class _Context:
+    def __init__(self, client=None, output="text"):
+        self._client = client
+        self.output = output
+
+    def client(self):
+        return self._client
+
+
+class _RepeatingTokenClient:
+    def __init__(self):
+        self.calls = []
+
+    def list_uc_skills(self, schema, page_size=None, page_token=None):
+        self.calls.append((schema, page_size, page_token))
+        if len(self.calls) > 2:
+            raise AssertionError("list followed a repeated pagination token")
+        return {"skills": [], "next_page_token": "loop"}
+
+
+def _skills_command():
+    return importlib.import_module("databricks_mason.skills").skills
+
+
+def _project(tmp_path: pathlib.Path, *, framework: str = "langgraph") -> pathlib.Path:
+    project = tmp_path / "agent"
+    AgentProject.create(project, framework=framework).write()
+    return project
+
+
+def _runner_with_separate_stderr() -> CliRunner:
+    runner_type = cast(Any, CliRunner)
+    try:
+        return runner_type(mix_stderr=False)
+    except TypeError:
+        return CliRunner()
+
+
+def test_list_json_normalizes_sorts_deduplicates_and_paginates():
+    client = _Client(
+        [
+            {
+                "skills": [
+                    {
+                        "name": "skills/catalog.schema.zeta",
+                        "bundle_name": "zeta-bundle",
+                        "description": "Close the quarter.",
+                        "etag": "zeta-etag",
+                        "comment": "Finance owned",
+                        "effective_owner": "finance@example.com",
+                        "id": "not-part-of-the-cli-contract",
+                    },
+                    {
+                        "name": "skills/catalog.schema.alpha",
+                        "description": "First skill",
+                    },
+                    {"description": "missing name"},
+                ],
+                "next_page_token": "page-2",
+            },
+            {
+                "skills": [
+                    {
+                        "name": "skills/catalog.schema.alpha",
+                        "description": "duplicate must not replace first",
+                    },
+                    {"name": "skills/catalog.schema.beta"},
+                ]
+            },
+        ]
+    )
+
+    result = _runner_with_separate_stderr().invoke(
+        _skills_command(),
+        ["list", "--schema", "catalog.schema"],
+        obj=_Context(client, "json"),
+    )
+
+    assert result.exit_code == 0, result.output
+    assert client.calls == [
+        ("catalog.schema", None, None),
+        ("catalog.schema", None, "page-2"),
+    ]
+    assert json.loads(result.stdout) == {
+        "schema_version": 1,
+        "skills": [
+            {"name": "catalog.schema.alpha", "description": "First skill"},
+            {"name": "catalog.schema.beta"},
+            {
+                "name": "catalog.schema.zeta",
+                "bundle_name": "zeta-bundle",
+                "description": "Close the quarter.",
+                "etag": "zeta-etag",
+                "comment": "Finance owned",
+                "effective_owner": "finance@example.com",
+            },
+        ],
+    }
+
+
+@pytest.mark.parametrize("response", [None, {"skills": {"name": "not-a-list"}}])
+def test_list_rejects_malformed_api_response(response):
+    result = CliRunner().invoke(
+        _skills_command(),
+        ["list", "--schema", "catalog.schema"],
+        obj=_Context(_Client([response])),
+    )
+
+    assert result.exit_code != 0
+    assert "Skills API returned an invalid response" in result.output
+
+
+def test_list_rejects_wrong_typed_pagination_token():
+    result = _runner_with_separate_stderr().invoke(
+        _skills_command(),
+        ["list", "--schema", "catalog.schema"],
+        obj=_Context(_Client([{"skills": [], "next_page_token": 42}]), "json"),
+    )
+
+    assert result.exit_code != 0
+    assert "pagination token" in result.stderr.lower()
+    assert "invalid response" in result.stderr.lower()
+
+
+def test_list_rejects_repeated_pagination_token_without_requesting_it_again():
+    client = _RepeatingTokenClient()
+
+    result = _runner_with_separate_stderr().invoke(
+        _skills_command(),
+        ["list", "--schema", "catalog.schema"],
+        obj=_Context(client, "json"),
+    )
+
+    assert result.exit_code != 0
+    assert "repeated pagination token" in result.stderr.lower()
+    assert client.calls == [
+        ("catalog.schema", None, None),
+        ("catalog.schema", None, "loop"),
+    ]
+
+
+def test_list_skips_malformed_entries_with_stderr_diagnostics_and_valid_json():
+    client = _Client(
+        [
+            {
+                "skills": [
+                    {"name": "skills/catalog.schema.valid-skill", "description": "Valid."},
+                    {"name": "garbage"},
+                    {"name": "skills/not.three-part"},
+                    {},
+                    {"name": 42},
+                    "not-an-object",
+                ]
+            }
+        ]
+    )
+
+    result = _runner_with_separate_stderr().invoke(
+        _skills_command(),
+        ["list", "--schema", "catalog.schema"],
+        obj=_Context(client, "json"),
+    )
+
+    assert result.exit_code == 0, result.stderr
+    assert json.loads(result.stdout) == {
+        "schema_version": 1,
+        "skills": [{"name": "catalog.schema.valid-skill", "description": "Valid."}],
+    }
+    assert result.stderr.count("Warning: skipped malformed UC skill entry") == 5
+
+
+def test_list_rejects_invalid_schema_before_api_call():
+    client = _Client([])
+
+    result = CliRunner().invoke(
+        _skills_command(),
+        ["list", "--schema", "catalog"],
+        obj=_Context(client),
+    )
+
+    assert result.exit_code != 0
+    assert "catalog.schema" in result.output
+    assert client.calls == []
+
+
+def test_list_text_shows_copyable_add_commands():
+    client = _Client(
+        [
+            {
+                "skills": [
+                    {"name": "skills/catalog.schema.close-quarter"},
+                    {"name": "skills/catalog.schema.audit-ledger"},
+                ]
+            }
+        ]
+    )
+
+    result = CliRunner().invoke(
+        _skills_command(),
+        ["list", "--schema", "catalog.schema"],
+        obj=_Context(client),
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "mason skills add uc catalog.schema.audit-ledger" in result.output
+    assert "mason skills add uc catalog.schema.close-quarter" in result.output
+
+
+def test_add_uc_is_exact_and_idempotent(tmp_path: pathlib.Path):
+    project = _project(tmp_path)
+    args = [
+        "add",
+        "uc",
+        "catalog.schema.skill",
+        "--name",
+        "review",
+        "--source",
+        str(project),
+    ]
+    runner = CliRunner()
+
+    first = runner.invoke(_skills_command(), args, obj=_Context(output="json"))
+    second = runner.invoke(_skills_command(), args, obj=_Context(output="json"))
+
+    assert first.exit_code == 0, first.output
+    assert second.exit_code == 0, second.output
+    assert json.loads(first.output) == {
+        "schema_version": 1,
+        "changed": True,
+        "changed_files": [str(project / "agent.toml")],
+        "skill": {
+            "id": "review",
+            "kind": "uc",
+            "source": "catalog.schema.skill",
+        },
+    }
+    assert json.loads(second.output)["changed"] is False
+    assert json.loads(second.output)["changed_files"] == []
+    assert len(AgentProject.load(project).skills) == 1
+
+
+def test_add_uc_defaults_id_to_fqn_leaf(tmp_path: pathlib.Path):
+    project = _project(tmp_path)
+
+    result = CliRunner().invoke(
+        _skills_command(),
+        ["add", "uc", "catalog.schema.skill", "--source", str(project)],
+        obj=_Context(),
+    )
+
+    assert result.exit_code == 0, result.output
+    assert AgentProject.load(project).skills[0].id == "skill"
+
+
+def test_add_exposes_only_uc_sources():
+    add = _skills_command().commands["add"]
+
+    assert set(add.commands) == {"uc"}
+
+
+def test_add_uc_rejects_openai_project(tmp_path: pathlib.Path):
+    project = _project(tmp_path, framework="openai")
+
+    result = CliRunner().invoke(
+        _skills_command(),
+        ["add", "uc", "catalog.schema.skill", "--source", str(project)],
+        obj=_Context(),
+    )
+
+    assert result.exit_code != 0
+    assert "Agent skills are LangGraph-only" in result.output
+    assert AgentProject.load(project).skills == []

--- a/integrations/mason/tests/unit_tests/tool_runtime_test.py
+++ b/integrations/mason/tests/unit_tests/tool_runtime_test.py
@@ -50,7 +50,11 @@ class _FakeWorkspaceClient:
 
 def _reload_mcp():
     # The runtime modules read env at call time, but re-import so patched sys.modules take effect.
-    for name in ("databricks_mason.langgraph.mcp", "databricks_mason.runtime.tool_manifest"):
+    for name in (
+        "databricks_mason.langgraph.mcp",
+        "databricks_mason.runtime.tool_manifest",
+        "databricks_mason.runtime.workspace",
+    ):
         sys.modules.pop(name, None)
     return importlib.import_module("databricks_mason.langgraph.mcp")
 


### PR DESCRIPTION
## What

Adds declarative Unity Catalog Skills support to Mason's LangGraph template:

- `mason skills list --schema catalog.schema` discovers UC skills through the workspace Skills endpoint.
- `mason skills add uc catalog.schema.skill --source .` writes an exact, idempotent `[[skills]]` binding to `agent.toml`.
- Graph construction injects skill name/description metadata only. `load_skill` fetches instructions lazily, and `read_skill_file` fetches referenced files lazily through `get_skill_files`.
- The same binding is used in local development and Databricks Apps; skill bodies and references are never copied into the project or deployment.

```toml
[[skills]]
id = "review"
source = { kind = "uc", name = "catalog.schema.skill" }
```

## Why

Custom agents need a declarative skill contract with progressive disclosure while keeping skill content governed in Unity Catalog and fresh at invocation time.

## Scope and limits

- Unity Catalog skills only. Local, custom, and path-based skill sources are rejected.
- LangGraph template only; nonempty OpenAI skill declarations fail before dev/deploy side effects.
- Exact three-part UC names only; versions, automatic discovery, and local file copying are not supported.
- Prompt injection is metadata-only. Instruction and reference payloads are fetched remotely and bounded to 1 MiB of UTF-8 text.
- A deployed App principal needs `USE_CATALOG`, `USE_SCHEMA`, and `READ_VOLUME` on each bound
  skill. The legacy `READ_SKILL` privilege does not authorize metadata or bundle reads.

## CLI customer journey

```bash
MASON=/path/to/databricks-ai-bridge/integrations/mason/.venv/bin/mason
PROJECT=/tmp/mason-uc-skill-cuj

"$MASON" --profile <workspace-profile> init --framework langgraph \
  --profile <workspace-profile> --repo /path/to/databricks-ai-bridge \
  --ref feat/mason-agent-skills "$PROJECT"

"$MASON" --profile <workspace-profile> skills list \
  --schema catalog.schema
"$MASON" --profile <workspace-profile> skills add uc \
  catalog.schema.skill --source "$PROJECT"

"$MASON" --profile <workspace-profile> dev --source "$PROJECT"
"$MASON" --profile <workspace-profile> deploy <unique-app-name> \
  --source "$PROJECT"
```

## Verification

- Isolated Mason base-install suite: 223 passed on the rebased head.
- Ruff lint/format and `ty check`: passed.
- Live CLI/local-agent CUJ on product SHA `d821203`: list, idempotent add, exact manifest binding,
  no local file copy, lazy body loading, and lazy referenced-file loading passed. After the final
  conflict-free rebase, `git range-diff` maps that product patch identically to `9163537`.
- Clean deployed-App CUJ: body prompt called `load_skill({"skill_id":"uc-cuj"})`; reference prompt
  called `load_skill` then
  `read_skill_file({"skill_id":"uc-cuj","path":"references/proof.txt"})`. Both completed with
  HTTP 200 and exact proof markers after granting the App principal `READ_VOLUME`.
- The generated `agent/agent.py` was byte-identical to the template before the final deployment;
  the deployment source contained no copied skill body or reference file.
- Temporary App, workspace deployment source, and UC skill were deleted and verified absent.
- Internal CLI/CUJ HTML report SHA-256:
  `b944c5b7c340e6964d95d799185a9786fcf6c89165d1843ea1bedf68f2dba891` (byte-identical publish
  round trip). The reproducible commands and decisive proof are included above without exposing
  private workspace/report URLs in this public PR.

## Design reference

- [Anthropic managed-agent skills](https://platform.claude.com/docs/en/managed-agents/skills)

This pull request and its description were written by Isaac.
