### PR TITLE
De-vendor mason runtime

### DIFF
--- a/integrations/mason/pyproject.toml
+++ b/integrations/mason/pyproject.toml
@@ -21,6 +21,20 @@ dependencies = [
 tracing = [
     "mlflow[databricks]>=3.9.0",
 ]
+# The agent-side runtime helpers (databricks_mason.runtime) that a deployed agent imports. Kept as
+# an extra so a plain `pip install databricks-mason` (the CLI) stays light; the template depends on
+# `databricks-mason[runtime]`.
+runtime = [
+    "databricks-langchain>=0.17.0",
+    "langgraph>=1.1.0",
+    "langchain>=1.0.0",
+    "langchain-mcp-adapters>=0.2.1",
+    "fastapi>=0.129.0",
+    "mlflow>=3.10.1",
+    "uuid-utils>=0.10.0",
+    "opentelemetry-exporter-otlp-proto-grpc>=1.25.0",
+    "databricks-agents>=1.9.3",
+]
 
 [project.scripts]
 mason = "databricks_mason.cli:main"

--- a/integrations/mason/pyproject.toml
+++ b/integrations/mason/pyproject.toml
@@ -75,3 +75,7 @@ root = ["./src", "./tests"]
 
 [tool.ty.src]
 include = ["./src", "./tests"]
+# The files under templates/ are code-as-data — scaffolding snippets written into a generated agent
+# project, not importable package modules. They import scaffold-relative paths (agent.mason.*,
+# agent.mcps) that never resolve in the package, so type-checking them here is meaningless.
+exclude = ["./src/databricks_mason/templates"]

--- a/integrations/mason/src/databricks_mason/init.py
+++ b/integrations/mason/src/databricks_mason/init.py
@@ -16,6 +16,8 @@ import shutil
 import subprocess
 import tempfile
 from importlib import resources
+from importlib.metadata import PackageNotFoundError
+from importlib.metadata import version as _installed_version
 from typing import Optional
 
 import click
@@ -28,7 +30,7 @@ from databricks_mason.project_config import write_project_metadata
 # Each framework's template has its own home: the git repo, ref, and path-within-repo to fetch.
 # (The two basic templates currently live in different repos; this keeps each pointed at its own.)
 # `--repo` / `--ref` override the repo/ref here, e.g. to pull from a fork or branch before merge.
-_TEMPLATES = {
+_TEMPLATES: dict[str, dict[str, str]] = {
     "openai": {
         "repo": "https://github.com/databricks/app-templates.git",
         "ref": "main",
@@ -41,9 +43,38 @@ _TEMPLATES = {
     },
 }
 
+# Frameworks whose template lives in this repo and is released in lockstep with the CLI: a scaffold
+# they produce pins `databricks-mason[runtime]` at this package's version, so init fetches the
+# template tagged for the installed CLI (see `_template_ref`) rather than `main`. That keeps a
+# user's scaffold from outrunning the `databricks-mason` they have installed.
+_VERSIONED_TEMPLATES = frozenset({"langgraph"})
+
+# The release workflow tags each published version `databricks-mason-v<version>`.
+_RELEASE_TAG_PREFIX = "databricks-mason-v"
+
 _CHAT_APP_TEMPLATES = {
     "langgraph": "integrations/mason/templates/ui/agent-langgraph",
 }
+
+
+def _template_ref(framework: str) -> str:
+    """The git ref to fetch a framework's template from, absent a `--ref` override.
+
+    For a versioned framework, fetch the tag matching the installed CLI so the scaffold's pinned
+    `databricks-mason` matches what the user has. Fall back to the default ref when the version
+    isn't a published release — an editable/dev build (e.g. `0.1.0.dev0`, or a local `+`
+    local-version install) has no corresponding tag, so those keep fetching `main`.
+    """
+    default_ref = _TEMPLATES[framework]["ref"]
+    if framework not in _VERSIONED_TEMPLATES:
+        return default_ref
+    try:
+        installed = _installed_version("databricks-mason")
+    except PackageNotFoundError:
+        return default_ref
+    if "dev" in installed or "+" in installed:
+        return default_ref
+    return f"{_RELEASE_TAG_PREFIX}{installed}"
 
 
 def _runtime_template(name: str) -> str:
@@ -206,7 +237,7 @@ def init(
     overlay_dirs = (_CHAT_APP_TEMPLATES[framework],) if enable_chat_app else ()
     _fetch_template(
         repo or spec["repo"],
-        ref or spec["ref"],
+        ref or _template_ref(framework),
         template_path,
         dest,
         overlay_dirs,

--- a/integrations/mason/src/databricks_mason/runtime/__init__.py
+++ b/integrations/mason/src/databricks_mason/runtime/__init__.py
@@ -1,0 +1,8 @@
+"""Agent-side runtime helpers a deployed Mason agent imports (installed via ``databricks-mason[runtime]``).
+
+The session-store checkpointer, MLflow tracing setup, MCP tool loading, background-run store,
+durability log, and recovery workflow. These need the agent stack (databricks-langchain, langgraph,
+langchain, fastapi, mlflow), so they live behind the ``[runtime]`` optional extra to keep the CLI
+install light. Agents import from here rather than vendoring copies; the CLI itself does not import
+this subpackage.
+"""

--- a/integrations/mason/src/databricks_mason/runtime/background.py
+++ b/integrations/mason/src/databricks_mason/runtime/background.py
@@ -1,0 +1,37 @@
+"""Background-run store — plumbing, slated to move into a Databricks SDK / durable backend.
+
+``BackgroundRuns`` tracks in-flight ``background: true`` requests by invocation id so ``GET
+/invocations/{id}`` can poll them. This default is **in-memory and single-process**: runs live in a
+dict in this process, so they do NOT survive a restart and are NOT shared across replicas.
+
+TODO: the SDK contract for managing background-run lifecycle isn't finalized. When it lands, replace
+this with a shared durable store (crash recovery, cross-pod resume, surviving the ~120s Apps proxy
+timeout) with the same interface — ``runtime/runtime.py`` only depends on
+``start``/``complete``/``fail``/``get``.
+"""
+
+import uuid
+from typing import Any
+
+
+class BackgroundRuns:
+    """In-memory store of background runs, keyed by invocation id. Single-process, non-durable."""
+
+    def __init__(self) -> None:
+        self._runs: dict[str, dict[str, Any]] = {}
+
+    def start(self) -> str:
+        invocation_id = f"inv_{uuid.uuid4().hex[:24]}"
+        self._runs[invocation_id] = {"status": "in_progress", "output": None, "error": None}
+        return invocation_id
+
+    def complete(self, invocation_id: str, output: dict) -> None:
+        self._runs[invocation_id] = {"status": "completed", "output": output, "error": None}
+
+    def fail(self, invocation_id: str, error: str) -> None:
+        self._runs[invocation_id] = {"status": "failed", "output": None, "error": error}
+
+    def get(self, invocation_id: str) -> dict | None:
+        """The run's record — ``status`` plus ``output`` (when completed) or ``error`` (when failed);
+        ``None`` if the id is unknown. Not just the final result: it's the whole tracked state."""
+        return self._runs.get(invocation_id)

--- a/integrations/mason/src/databricks_mason/runtime/durability.py
+++ b/integrations/mason/src/databricks_mason/runtime/durability.py
@@ -1,0 +1,377 @@
+"""Session Store-backed durability metadata for the Mason stop/start demo."""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import os
+import uuid
+from collections.abc import Callable
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any, cast
+
+from databricks.sdk import WorkspaceClient
+
+from databricks_mason.runtime.workspace import workspace_client as default_workspace_client
+
+_EVENT_TYPE = "mason_demo_durability"
+_SESSION_STORE_ENV = "AGENT_SESSION_STORE"
+_SESSION_ACTOR_ENV = "AGENT_SESSION_ACTOR_ID"
+_HEARTBEAT_SECONDS_ENV = "MASON_DEMO_HEARTBEAT_SECONDS"
+_STALE_SECONDS_ENV = "MASON_DEMO_STALE_SECONDS"
+_AGENTS_API = "/api/agents/v1"
+
+
+@dataclass(frozen=True)
+class _Session:
+    session_id: str
+
+
+@dataclass(frozen=True)
+class _SessionItem:
+    data: Any
+
+
+class _SessionStoreClient:
+    """Minimal Session Store client kept local to the generated durability demo."""
+
+    def __init__(self, workspace_client: WorkspaceClient | None = None) -> None:
+        self._workspace = workspace_client or default_workspace_client()
+        self._store_name = ""
+
+    def set_session_store(self, session_store_name: str) -> "_SessionStoreClient":
+        self._store_name = session_store_name
+        return self
+
+    def get_session(self, *, session_id: str) -> _Session:
+        self._workspace.api_client.do("GET", f"{self._sessions_path()}/{session_id}")
+        return _Session(session_id)
+
+    def create_session(
+        self,
+        *,
+        actor_id: str,
+        session_id: str,
+        metadata: dict[str, str],
+    ) -> _Session:
+        self._workspace.api_client.do(
+            "POST",
+            self._sessions_path(),
+            query={"session_id": session_id},
+            body={"actor_id": actor_id, "metadata": metadata},
+        )
+        return _Session(session_id)
+
+    def append_items(self, session: _Session, *, items: list[dict[str, Any]]) -> None:
+        self._workspace.api_client.do(
+            "POST",
+            f"{self._sessions_path()}/{session.session_id}/items:append",
+            body={"items": [{"data": item} for item in items]},
+        )
+
+    def list_items(self, session: _Session, *, order_by: str) -> list[_SessionItem]:
+        page_token = None
+        items = []
+        while True:
+            query = {"order_by": order_by, "page_size": 100}
+            if page_token:
+                query["page_token"] = page_token
+            response = self._workspace.api_client.do(
+                "GET",
+                f"{self._sessions_path()}/{session.session_id}/items",
+                query=query,
+            )
+            if not isinstance(response, dict):
+                raise RuntimeError("Expected an object response while listing durability events.")
+            response_object = cast(dict[str, Any], response)
+            items.extend(
+                _SessionItem(item["data"])
+                for item in response_object.get("session_items", [])
+                if "data" in item
+            )
+            page_token = response_object.get("next_page_token")
+            if not page_token:
+                return items
+
+    def _sessions_path(self) -> str:
+        return f"{_AGENTS_API}/session-stores/{self._store_name}/sessions"
+
+
+def execution_id(session_id: str) -> str:
+    """Return the durable execution id associated with a public chat session."""
+    return hashlib.sha256(f"mason-demo-recovery\x1f{session_id}".encode()).hexdigest()
+
+
+def heartbeat_seconds() -> float:
+    """How often an active process persists an ownership heartbeat."""
+    return max(0.1, float(os.getenv(_HEARTBEAT_SECONDS_ENV, "3")))
+
+
+def stale_seconds() -> float:
+    """How old a heartbeat must be before another process may resume the run."""
+    configured = max(0.2, float(os.getenv(_STALE_SECONDS_ENV, "10")))
+    return max(configured, heartbeat_seconds() * 2)
+
+
+@dataclass(frozen=True)
+class DurabilityLease:
+    session_id: str
+    execution_id: str
+    attempt: int
+    lease_id: str
+    owner_id: str
+
+
+@dataclass(frozen=True)
+class DurabilityState:
+    session_id: str
+    execution_id: str
+    status: str
+    attempt: int
+    lease_id: str | None
+    owner_id: str | None
+    heartbeat_at: str | None
+    heartbeat_age_seconds: float | None
+    heartbeat_fresh: bool
+    event_count: int
+    recent_events: list[dict[str, Any]]
+
+
+class SessionStoreDurabilityLog:
+    """Append-only attempt and heartbeat log stored beside LangGraph checkpoints.
+
+    Session Store does not expose an atomic compare-and-swap claim. This helper is
+    intentionally a demo-grade, last-writer-wins lease. A process verifies ownership
+    before each heartbeat, and the Databricks Apps affinity cookie keeps one browser
+    routed to one replica, but a production runtime still needs a transactional claim.
+    """
+
+    def __init__(
+        self,
+        session_store_name: str | None = None,
+        *,
+        client: Any | None = None,
+        clock: Callable[[], datetime] | None = None,
+    ) -> None:
+        self._store_name = session_store_name or os.getenv(_SESSION_STORE_ENV, "").strip()
+        self._client = None
+        if self._store_name:
+            self._client = (client or _SessionStoreClient()).set_session_store(self._store_name)
+        self._clock = clock or (lambda: datetime.now(timezone.utc))
+        self._sessions: dict[str, Any] = {}
+        self._locks: dict[str, asyncio.Lock] = {}
+
+    @property
+    def configured(self) -> bool:
+        return self._client is not None
+
+    async def state(self, session_id: str) -> DurabilityState:
+        events = await asyncio.to_thread(self._read_events, session_id)
+        return self._state_from_events(session_id, events)
+
+    async def claim(self, session_id: str, owner_id: str) -> DurabilityLease:
+        async with self._lock(session_id):
+            current = await self.state(session_id)
+            if current.status == "running":
+                raise ValueError(
+                    f"Execution {current.execution_id} still has a fresh heartbeat from "
+                    f"process {current.owner_id}."
+                )
+            lease = DurabilityLease(
+                session_id=session_id,
+                execution_id=execution_id(session_id),
+                attempt=current.attempt + 1,
+                lease_id=uuid.uuid4().hex,
+                owner_id=owner_id,
+            )
+            await self._append(
+                lease,
+                "attempt_started",
+                {
+                    "claim_mode": "session_store_last_writer_wins",
+                    "atomic_claim": False,
+                },
+            )
+            verified = await self.state(session_id)
+            if verified.lease_id != lease.lease_id:
+                raise ValueError(
+                    f"Another process acquired execution {lease.execution_id} before this "
+                    "attempt started."
+                )
+            return lease
+
+    async def heartbeat(self, lease: DurabilityLease) -> bool:
+        async with self._lock(lease.session_id):
+            current = await self.state(lease.session_id)
+            if current.status != "running" or current.lease_id != lease.lease_id:
+                return False
+            await self._append(lease, "heartbeat")
+            return True
+
+    async def complete(self, lease: DurabilityLease) -> bool:
+        return await self._finish(lease, "completed")
+
+    async def fail(self, lease: DurabilityLease, error: str) -> bool:
+        return await self._finish(lease, "failed", {"error": error})
+
+    async def _finish(
+        self,
+        lease: DurabilityLease,
+        event: str,
+        details: dict[str, Any] | None = None,
+    ) -> bool:
+        async with self._lock(lease.session_id):
+            current = await self.state(lease.session_id)
+            if current.lease_id != lease.lease_id:
+                return False
+            await self._append(lease, event, details)
+            return True
+
+    async def _append(
+        self,
+        lease: DurabilityLease,
+        event: str,
+        details: dict[str, Any] | None = None,
+    ) -> None:
+        payload = {
+            "event_type": _EVENT_TYPE,
+            "event": event,
+            "session_id": lease.session_id,
+            "execution_id": lease.execution_id,
+            "attempt": lease.attempt,
+            "lease_id": lease.lease_id,
+            "owner_id": lease.owner_id,
+            "timestamp": self._now().isoformat(),
+            **(details or {}),
+        }
+        await asyncio.to_thread(self._append_event, lease.session_id, payload)
+
+    def _append_event(self, session_id: str, payload: dict[str, Any]) -> None:
+        client = self._required_client()
+        client.append_items(self._session(session_id), items=[payload])
+
+    def _read_events(self, session_id: str) -> list[dict[str, Any]]:
+        client = self._required_client()
+        return [
+            item.data
+            for item in client.list_items(self._session(session_id), order_by="create_time asc")
+            if isinstance(item.data, dict) and item.data.get("event_type") == _EVENT_TYPE
+        ]
+
+    def _session(self, session_id: str) -> Any:
+        durable_id = execution_id(session_id)
+        if cached := self._sessions.get(durable_id):
+            return cached
+        client = self._required_client()
+        try:
+            session = client.get_session(session_id=durable_id)
+        except Exception as error:
+            if not _is_not_found(error):
+                raise
+            try:
+                session = client.create_session(
+                    actor_id=os.getenv(_SESSION_ACTOR_ENV) or session_id,
+                    session_id=durable_id,
+                    metadata={
+                        "client": "mason-demo-durability",
+                        "public_session_id": session_id,
+                    },
+                )
+            except Exception as create_error:
+                if not _is_already_exists(create_error):
+                    raise
+                session = client.get_session(session_id=durable_id)
+        self._sessions[durable_id] = session
+        return session
+
+    def _state_from_events(self, session_id: str, events: list[dict[str, Any]]) -> DurabilityState:
+        durable_id = execution_id(session_id)
+        starts = [
+            (index, event)
+            for index, event in enumerate(events)
+            if event.get("event") == "attempt_started"
+        ]
+        if not starts:
+            return DurabilityState(
+                session_id=session_id,
+                execution_id=durable_id,
+                status="not_started",
+                attempt=0,
+                lease_id=None,
+                owner_id=None,
+                heartbeat_at=None,
+                heartbeat_age_seconds=None,
+                heartbeat_fresh=False,
+                event_count=len(events),
+                recent_events=events[-8:],
+            )
+
+        start_index, started = starts[-1]
+        lease_id = str(started["lease_id"])
+        lease_events = [
+            event for event in events[start_index:] if str(event.get("lease_id")) == lease_id
+        ]
+        terminal = next(
+            (
+                event
+                for event in reversed(lease_events)
+                if event.get("event") in {"completed", "failed"}
+            ),
+            None,
+        )
+        last_heartbeat = next(
+            (
+                event
+                for event in reversed(lease_events)
+                if event.get("event") in {"attempt_started", "heartbeat"}
+            ),
+            started,
+        )
+        heartbeat_at = str(last_heartbeat["timestamp"])
+        heartbeat_age = max(0.0, (self._now() - _parse_time(heartbeat_at)).total_seconds())
+        heartbeat_fresh = terminal is None and heartbeat_age <= stale_seconds()
+        status = str(terminal["event"]) if terminal else "running" if heartbeat_fresh else "stopped"
+        return DurabilityState(
+            session_id=session_id,
+            execution_id=durable_id,
+            status=status,
+            attempt=int(started.get("attempt", 1)),
+            lease_id=lease_id,
+            owner_id=str(started.get("owner_id") or "") or None,
+            heartbeat_at=heartbeat_at,
+            heartbeat_age_seconds=heartbeat_age,
+            heartbeat_fresh=heartbeat_fresh,
+            event_count=len(events),
+            recent_events=events[-8:],
+        )
+
+    def _required_client(self) -> Any:
+        if self._client is None:
+            raise ValueError(f"Set {_SESSION_STORE_ENV} to enable durable recovery.")
+        return self._client
+
+    def _lock(self, session_id: str) -> asyncio.Lock:
+        return self._locks.setdefault(session_id, asyncio.Lock())
+
+    def _now(self) -> datetime:
+        value = self._clock()
+        return value if value.tzinfo else value.replace(tzinfo=timezone.utc)
+
+
+def _parse_time(value: str) -> datetime:
+    parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    return parsed if parsed.tzinfo else parsed.replace(tzinfo=timezone.utc)
+
+
+def _is_not_found(error: Exception) -> bool:
+    code = str(getattr(error, "error_code", "")).upper()
+    return code in {"NOT_FOUND", "RESOURCE_DOES_NOT_EXIST"} or "not found" in str(error).lower()
+
+
+def _is_already_exists(error: Exception) -> bool:
+    code = str(getattr(error, "error_code", "")).upper()
+    return (
+        code in {"ALREADY_EXISTS", "RESOURCE_ALREADY_EXISTS"}
+        or "already exists" in str(error).lower()
+    )

--- a/integrations/mason/src/databricks_mason/runtime/long_running.py
+++ b/integrations/mason/src/databricks_mason/runtime/long_running.py
@@ -1,0 +1,59 @@
+"""Deterministic long-running tools used by the Mason stop/start demo."""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import uuid
+from datetime import datetime, timezone
+from typing import Any
+
+from langchain_core.tools import tool
+
+_PROCESS_ID = uuid.uuid4().hex[:12]
+_STEP_SECONDS_ENV = "MASON_DEMO_TOOL_STEP_SECONDS"
+
+
+def process_id() -> str:
+    """Return the identifier shared by this process's UI and tool outputs."""
+    return _PROCESS_ID
+
+
+def step_seconds() -> float:
+    """Duration of each demo step, configurable for tests and local demos."""
+    return max(0.0, float(os.getenv(_STEP_SECONDS_ENV, "6")))
+
+
+async def _run_step(step: int) -> dict[str, Any]:
+    await asyncio.sleep(step_seconds())
+    name = f"tool_step_{step}"
+    return {
+        "tool": name,
+        "output": f"{name} completed successfully",
+        "completed_at": datetime.now(timezone.utc).isoformat(),
+        "instance_id": process_id(),
+    }
+
+
+@tool
+async def tool_step_1() -> dict[str, Any]:
+    """Run the first long-running demo step."""
+    return await _run_step(1)
+
+
+@tool
+async def tool_step_2() -> dict[str, Any]:
+    """Run the second long-running demo step."""
+    return await _run_step(2)
+
+
+@tool
+async def tool_step_3() -> dict[str, Any]:
+    """Run the third long-running demo step."""
+    return await _run_step(3)
+
+
+@tool
+async def tool_step_4() -> dict[str, Any]:
+    """Run the fourth long-running demo step."""
+    return await _run_step(4)

--- a/integrations/mason/src/databricks_mason/runtime/mcp.py
+++ b/integrations/mason/src/databricks_mason/runtime/mcp.py
@@ -1,0 +1,110 @@
+"""Build MCP servers and tools from the agent's ``agent.toml`` tool manifest.
+
+Two seams the agent composes:
+  - ``manifest_servers()`` — the MCP servers declared in ``agent.toml`` (sandbox/mcp + uc_function).
+  - ``mcp_client(servers)`` — a ``DatabricksMultiServerMCPClient`` with the sandbox downscoping
+    interceptor already attached, so downscoping holds however the caller drives it.
+``mcp_tools(servers)`` is a convenience wrapper that just calls ``.get_tools()``.
+
+The agent's own hand-declared servers (its ``agent/mcps.py`` hook) are joined in by the agent, not
+here — this module never imports agent code, so it lives in the shared package. Typical agent use::
+
+    servers = manifest_servers() + build_mcp_servers()  # ours + the agent's own
+    tools = await mcp_tools(servers)
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any
+
+from databricks_langchain import DatabricksMCPServer, DatabricksMultiServerMCPClient
+from langchain_mcp_adapters.sessions import create_session
+
+if TYPE_CHECKING:
+    from databricks_langchain import MCPServer
+
+from databricks_mason.runtime.tool_manifest import ToolRecord, downscope_wire, load_tools
+from databricks_mason.runtime.workspace import workspace_client, workspace_headers
+
+logger = logging.getLogger(__name__)
+
+
+def _server_from_tool(tool: ToolRecord) -> DatabricksMCPServer | None:
+    client = workspace_client()
+    host = client.config.host.rstrip("/")
+    if tool.kind in {"sandbox", "mcp"}:
+        return DatabricksMCPServer(
+            name=tool.id,
+            url=f"{host}/ai-gateway/mcp-services/{tool.service}",
+            headers=workspace_headers() or None,
+            workspace_client=client,
+            timeout=120.0,
+        )
+    if tool.kind == "uc_function":
+        catalog, schema, function_name = (tool.function or "").split(".")
+        return DatabricksMCPServer.from_uc_function(
+            catalog=catalog,
+            schema=schema,
+            function_name=function_name,
+            name=tool.id,
+            headers=workspace_headers() or None,
+            workspace_client=client,
+            timeout=120.0,
+        )
+    return None
+
+
+def manifest_servers() -> list[DatabricksMCPServer]:
+    """The MCP servers declared in the agent's ``agent.toml`` tool manifest (may be empty)."""
+    tools = load_tools(expected_framework="langgraph")
+    return [server for tool in tools if (server := _server_from_tool(tool)) is not None]
+
+
+def _sandbox_interceptor():
+    async def interceptor(request: Any, handler: Any) -> Any:
+        tools = {tool.id: tool for tool in load_tools(expected_framework="langgraph")}
+        tool = tools.get(request.server_name)
+        if tool is None or tool.kind != "sandbox":
+            return await handler(request)
+
+        server = _server_from_tool(tool)
+        if server is None:
+            raise RuntimeError(f"Could not build sandbox MCP server {tool.id!r}.")
+        async with create_session(server.to_connection_dict()) as session:
+            await session.initialize()
+            return await session.call_tool(
+                request.name,
+                request.args,
+                meta={"downscope": downscope_wire(tool)},
+            )
+
+    return interceptor
+
+
+def _has_sandbox_tool() -> bool:
+    return any(tool.kind == "sandbox" for tool in load_tools(expected_framework="langgraph"))
+
+
+def mcp_client(servers: list[DatabricksMCPServer]) -> DatabricksMultiServerMCPClient:
+    """A multi-server MCP client over ``servers`` with the sandbox downscoping interceptor attached.
+
+    The interceptor is derived from the ``agent.toml`` manifest, so sandbox tools run downscoped
+    regardless of how the caller drives the returned client (``get_tools`` or otherwise). Callers who
+    build their own client instead take on applying downscoping themselves.
+    """
+    interceptors = [_sandbox_interceptor()] if _has_sandbox_tool() else []
+    # DatabricksMCPServer is a subclass of MCPServer, so coerce the type for the API
+    servers_as_mcp: list[MCPServer] = servers  # type: ignore[name-defined,assignment]
+    return DatabricksMultiServerMCPClient(servers_as_mcp, tool_interceptors=interceptors)
+
+
+async def mcp_tools(servers: list[DatabricksMCPServer]) -> list:
+    """Fetch LangChain MCP tools from ``servers`` (with sandbox downscoping). Fail-open to ``[]``."""
+    if not servers:
+        return []
+    try:
+        return await mcp_client(servers).get_tools()
+    except Exception:
+        logger.warning("Failed to fetch MCP tools; continuing without them.", exc_info=True)
+        return []

--- a/integrations/mason/src/databricks_mason/runtime/memory.py
+++ b/integrations/mason/src/databricks_mason/runtime/memory.py
@@ -1,0 +1,63 @@
+"""Long-term memory tools — opt-in, gated on ``AGENT_MEMORY_STORE``.
+
+Unlike the session store (short-term transcript for one conversation), long-term memory is exposed
+to the model as two tools — ``remember`` and ``recall`` — over the Databricks managed memory store's
+``agents/v1`` entries API. Facts persist across conversations.
+
+``memory_tools()`` returns the tools when ``AGENT_MEMORY_STORE`` is set, else an empty list, so the
+model never sees them when memory is unconfigured. ``create_agent_graph`` composes them into its
+tool list. This is a stand-in for a future ``databricks-langchain`` memory helper — when the SDK
+provides one, swap the import in ``agent.py`` and delete this file.
+
+Memory entries are per-actor. This uses the store name as the actor id, giving the agent one shared
+long-term memory; change ``_actor_id`` to scope per user (e.g. from request context) if needed.
+"""
+
+import os
+
+from langchain_core.tools import BaseTool, tool
+
+from databricks_mason.runtime.workspace import workspace_client
+
+_AGENTS_V1 = "/api/agents/v1"
+
+
+def _actor_id() -> str:
+    return os.getenv("AGENT_MEMORY_ACTOR_ID", "agent")
+
+
+def _store_path() -> str:
+    return f"{_AGENTS_V1}/memory-stores/{os.environ['AGENT_MEMORY_STORE']}"
+
+
+def _api():
+    # Build the client lazily (needs workspace auth) so importing this module stays cheap.
+    return workspace_client().api_client
+
+
+@tool
+def remember(fact: str, topic: str) -> str:
+    """Persist a durable fact about the user in long-term memory."""
+    _api().do(
+        "POST",
+        f"{_store_path()}/entries",
+        body={"actor_id": _actor_id(), "path": f"/{topic}/{fact[:8]}.md", "content": fact},
+    )
+    return "stored"
+
+
+@tool
+def recall(query: str) -> str:
+    """Search the user's long-term memory for facts relevant to the query."""
+    data = _api().do(
+        "POST",
+        f"{_store_path()}/entries:search",
+        body={"actor_id": _actor_id(), "query": query, "limit": 5},
+    )
+    entries = data.get("managed_memory_entries") or []
+    return "\n".join(f"- {e.get('content')}" for e in entries) or "No relevant memories."
+
+
+def memory_tools() -> list[BaseTool]:
+    """The long-term-memory tools when ``AGENT_MEMORY_STORE`` is set, else none."""
+    return [remember, recall] if os.getenv("AGENT_MEMORY_STORE") else []

--- a/integrations/mason/src/databricks_mason/runtime/recovery.py
+++ b/integrations/mason/src/databricks_mason/runtime/recovery.py
@@ -1,0 +1,247 @@
+"""Checkpointed tool sequence with manual heartbeat-based recovery."""
+
+from __future__ import annotations
+
+import asyncio
+import inspect
+import logging
+import os
+from collections.abc import Awaitable, Callable, Sequence
+from typing import Any, TypedDict
+
+from langgraph.checkpoint.base import BaseCheckpointSaver
+from langgraph.graph import END, START, StateGraph
+
+from databricks_mason.runtime.durability import (
+    DurabilityLease,
+    SessionStoreDurabilityLog,
+    execution_id,
+    heartbeat_seconds,
+    stale_seconds,
+)
+from databricks_mason.runtime.long_running import (
+    process_id,
+    step_seconds,
+    tool_step_1,
+    tool_step_2,
+    tool_step_3,
+    tool_step_4,
+)
+from databricks_mason.runtime.session_store import (
+    checkpointer,
+    thread_config,
+)
+
+StepRunner = Callable[[], Awaitable[dict[str, Any]]]
+StepDefinition = tuple[str, StepRunner]
+
+_STEP_TOOLS = (tool_step_1, tool_step_2, tool_step_3, tool_step_4)
+_active_tasks: dict[str, asyncio.Task[Any]] = {}
+_task_errors: dict[str, str] = {}
+_compiled_graph: Any | None = None
+_durability: SessionStoreDurabilityLog | None = None
+
+logger = logging.getLogger(__name__)
+
+
+class RecoveryState(TypedDict, total=False):
+    session_id: str
+    outputs: list[dict[str, Any]]
+
+
+def step_names() -> list[str]:
+    return [tool.name for tool in _STEP_TOOLS]
+
+
+def recovery_config(session_id: str) -> dict[str, Any]:
+    """Map the public session id onto a separate durable workflow thread."""
+    configurable = thread_config(session_id)["configurable"]
+    actor_id = configurable.get("actor_id") or os.getenv("AGENT_SESSION_ACTOR_ID") or session_id
+    return {"configurable": {"thread_id": execution_id(session_id), "actor_id": actor_id}}
+
+
+def _tool_runner(tool: Any) -> StepRunner:
+    async def run() -> dict[str, Any]:
+        result = await tool.ainvoke({})
+        if isinstance(result, dict):
+            return result
+        return {"tool": tool.name, "output": str(result), "instance_id": process_id()}
+
+    return run
+
+
+def _step_node(runner: StepRunner):
+    async def run(state: RecoveryState) -> RecoveryState:
+        result = await runner()
+        return {"outputs": [*state.get("outputs", []), result]}
+
+    return run
+
+
+def build_recovery_graph(
+    saver: BaseCheckpointSaver,
+    steps: Sequence[StepDefinition] | None = None,
+) -> Any:
+    """Build the sequential graph; exposed for the checkpoint-boundary recovery test."""
+    definitions = list(steps or [(tool.name, _tool_runner(tool)) for tool in _STEP_TOOLS])
+    graph: StateGraph[RecoveryState] = StateGraph(RecoveryState)  # type: ignore[assignment]
+    for name, runner in definitions:
+        graph.add_node(name, _step_node(runner))
+    graph.add_edge(START, definitions[0][0])
+    for current, following in zip(definitions, definitions[1:], strict=False):
+        graph.add_edge(current[0], following[0])
+    graph.add_edge(definitions[-1][0], END)
+    return graph.compile(checkpointer=saver)
+
+
+async def _graph():
+    global _compiled_graph
+    if _compiled_graph is None:
+        saver = checkpointer()
+        if inspect.isawaitable(saver):
+            saver = await saver
+        _compiled_graph = build_recovery_graph(saver)  # type: ignore[arg-type]
+    return _compiled_graph
+
+
+def _durability_log() -> SessionStoreDurabilityLog:
+    global _durability
+    if _durability is None:
+        _durability = SessionStoreDurabilityLog()
+    return _durability
+
+
+def _task_active(session_id: str) -> bool:
+    task = _active_tasks.get(session_id)
+    return bool(task and not task.done())
+
+
+def _record_task_result(session_id: str, task: asyncio.Task[Any]) -> None:
+    if _active_tasks.get(session_id) is task:
+        _active_tasks.pop(session_id, None)
+    if task.cancelled():
+        return
+    try:
+        task.result()
+    except Exception as error:
+        _task_errors[session_id] = str(error)
+
+
+async def _heartbeat_loop(lease: DurabilityLease) -> None:
+    while True:
+        await asyncio.sleep(heartbeat_seconds())
+        try:
+            if not await _durability_log().heartbeat(lease):
+                return
+        except Exception:
+            logger.exception("Failed to persist durability heartbeat for %s", lease.execution_id)
+
+
+async def _run_attempt(
+    session_id: str,
+    graph_input: RecoveryState | None,
+    lease: DurabilityLease,
+) -> None:
+    heartbeat = asyncio.create_task(_heartbeat_loop(lease))
+    try:
+        graph = await _graph()
+        await graph.ainvoke(graph_input, config=recovery_config(session_id))
+    except asyncio.CancelledError:
+        raise
+    except Exception as error:
+        try:
+            await _durability_log().fail(lease, str(error))
+        except Exception:
+            logger.exception("Failed to persist failed durability attempt %s", lease.execution_id)
+        raise
+    else:
+        try:
+            await _durability_log().complete(lease)
+        except Exception:
+            logger.exception(
+                "Failed to persist completed durability attempt %s", lease.execution_id
+            )
+    finally:
+        heartbeat.cancel()
+        await asyncio.gather(heartbeat, return_exceptions=True)
+
+
+async def _launch(session_id: str, graph_input: RecoveryState | None) -> None:
+    _task_errors.pop(session_id, None)
+    lease = await _durability_log().claim(session_id, process_id())
+    task = asyncio.create_task(_run_attempt(session_id, graph_input, lease))
+    _active_tasks[session_id] = task
+    task.add_done_callback(lambda completed: _record_task_result(session_id, completed))
+
+
+async def status(session_id: str) -> dict[str, Any]:
+    graph = await _graph()
+    snapshot = await graph.aget_state(recovery_config(session_id))
+    durability = await _durability_log().state(session_id)
+    values = snapshot.values if isinstance(snapshot.values, dict) else {}
+    outputs = list(values.get("outputs") or [])
+    next_steps = list(snapshot.next)
+    worker_active = _task_active(session_id)
+    owner_active = durability.status == "running"
+    error = _task_errors.get(session_id)
+    if error:
+        state = "failed"
+    elif len(outputs) == len(_STEP_TOOLS):
+        state = "completed"
+    elif worker_active or owner_active:
+        state = "running"
+    elif next_steps:
+        state = "stopped" if durability.status == "stopped" else "waiting_for_start"
+    else:
+        state = "not_started"
+    current_step = next_steps[0] if next_steps else None
+    if worker_active and current_step is None and len(outputs) < len(_STEP_TOOLS):
+        current_step = step_names()[len(outputs)]
+    return {
+        "session_id": session_id,
+        "status": state,
+        "steps": step_names(),
+        "outputs": outputs,
+        "current_step": current_step,
+        "worker_active": worker_active,
+        "owner_active": owner_active,
+        "needs_resume": bool(next_steps and not owner_active and not error),
+        "error": error,
+        "instance_id": process_id(),
+        "step_seconds": step_seconds(),
+        "execution_id": durability.execution_id,
+        "attempt": durability.attempt,
+        "owner_id": durability.owner_id,
+        "heartbeat_at": durability.heartbeat_at,
+        "heartbeat_age_seconds": durability.heartbeat_age_seconds,
+        "heartbeat_fresh": durability.heartbeat_fresh,
+        "heartbeat_interval_seconds": heartbeat_seconds(),
+        "stale_after_seconds": stale_seconds(),
+        "durability_event_count": durability.event_count,
+        "recent_durability_events": durability.recent_events,
+        "claim_mode": "session_store_last_writer_wins",
+        "atomic_claim": False,
+    }
+
+
+async def start(session_id: str) -> dict[str, Any]:
+    current = await status(session_id)
+    if current["status"] in {"running", "completed"}:
+        return current
+    graph_input: RecoveryState | None = (
+        {"session_id": session_id, "outputs": []} if current["status"] == "not_started" else None
+    )
+    await _launch(session_id, graph_input)
+    await asyncio.sleep(0)
+    return await status(session_id)
+
+
+async def resume(session_id: str) -> dict[str, Any]:
+    current = await status(session_id)
+    if current["worker_active"] or current["status"] == "completed":
+        return current
+    if not current["needs_resume"]:
+        raise ValueError(f"No incomplete recovery sequence exists for session {session_id!r}.")
+    await _launch(session_id, None)
+    await asyncio.sleep(0)
+    return await status(session_id)

--- a/integrations/mason/src/databricks_mason/runtime/session_store.py
+++ b/integrations/mason/src/databricks_mason/runtime/session_store.py
@@ -1,0 +1,469 @@
+"""Conversation session store for the agent.
+
+LangGraph persists conversation state through a **checkpointer** keyed by a ``thread_id`` (passed in
+the run config), not through a session object. ``checkpointer()`` returns the checkpointer the agent
+is built with, and ``thread_config(session_id)`` maps a session id onto that thread.
+
+Default (no config): an in-memory checkpointer (``InMemorySaver``) — multi-turn history is preserved
+within a single running process, no database. It does NOT survive restarts or span replicas.
+
+Durable (``AGENT_SESSION_STORE`` set): a ``DatabricksSessionStoreSaver``. Instead of a database the
+app connects to directly, it serializes each LangGraph checkpoint into ordered **session items** and
+stores them through the managed Session Store REST API. Full graph state — including human-in-the-loop
+pauses (pending writes + interrupts) — is durable across restarts and replicas, over RPCs only (no
+Lakebase/Postgres connection). Setting the env var is the only change; the agent code is identical.
+
+The saver is adapted from the first-party ``databricks_agent_client.langgraph`` prototype, over a
+vendored REST client (``session_store_client.py``) so the template needs no unpublished dependency;
+swap both for the published package when it lands.
+"""
+
+from __future__ import annotations
+
+import base64
+import builtins
+import hashlib
+import os
+import random
+from collections import defaultdict
+from typing import Any, Iterator, Optional, Sequence
+
+from langchain_core.runnables import RunnableConfig
+from langgraph.checkpoint.base import (
+    BaseCheckpointSaver,
+    ChannelVersions,
+    Checkpoint,
+    CheckpointMetadata,
+    CheckpointTuple,
+    SerializerProtocol,
+    get_checkpoint_id,
+    get_checkpoint_metadata,
+)
+from langgraph.checkpoint.memory import InMemorySaver
+
+from databricks_mason.runtime.session_store_client import Session, SessionStoreClient
+
+_SESSION_STORE_ENV = "AGENT_SESSION_STORE"
+
+# Discriminators stored inside each session item's `data` JSON.
+_EVENT_CHECKPOINT = "checkpoint"
+_EVENT_CHANNEL_DATA = "channel_data"
+_EVENT_WRITES = "writes"
+
+# Sentinel for a channel that has a version bump but no materialized value yet.
+_EMPTY_CHANNEL_VALUE = "__databricks_empty_channel__"
+
+# Fetch items oldest-first so replaying them reconstructs state in write order.
+_ORDER_BY = "create_time asc"
+
+# One saver per process, opened lazily on first use and shared thereafter — that's what makes
+# multi-turn work in-process (and, for the durable saver, reuses one client/session cache).
+_saver: BaseCheckpointSaver | None = None
+
+
+def checkpointer() -> BaseCheckpointSaver:
+    """The checkpointer the agent persists conversation state to (built once, then shared).
+
+    In-memory by default; a durable ``DatabricksSessionStoreSaver`` when ``AGENT_SESSION_STORE`` names
+    a managed Session Store.
+    """
+    global _saver
+    if _saver is None:
+        store = os.getenv(_SESSION_STORE_ENV)
+        _saver = DatabricksSessionStoreSaver(store) if store else InMemorySaver()
+    return _saver
+
+
+def thread_config(session_id: str) -> dict:
+    """Run config that anchors this request to ``session_id``'s conversation thread.
+
+    Includes ``actor_id`` because the durable saver maps it onto the Session's actor; it's ignored by
+    the in-memory default. ``AGENT_SESSION_ACTOR_ID`` selects the actor partition; without it, each
+    session id is its own actor for backward compatibility.
+    """
+    actor_id = os.getenv("AGENT_SESSION_ACTOR_ID") or session_id
+    return {"configurable": {"thread_id": session_id, "actor_id": actor_id}}
+
+
+class DatabricksSessionStoreSaver(BaseCheckpointSaver[str]):
+    """LangGraph ``BaseCheckpointSaver`` over the Databricks Session Store REST API.
+
+    A single ``put`` fans out into several session items so large, immutable channel values are stored
+    once per version rather than copied into every checkpoint: one ``checkpoint`` item (the checkpoint
+    dict minus ``channel_values`` + metadata), one ``channel_data`` item per changed channel, and
+    ``writes`` items (via ``put_writes``). Each item's ``data`` is plain JSON with an ``event_type``
+    discriminator, because the Session Store treats item ``data`` as opaque JSON. Both ``thread_id``
+    and ``actor_id`` are required in the run config's ``configurable`` section.
+    """
+
+    def __init__(
+        self,
+        session_store_name: str,
+        *,
+        client: Optional[SessionStoreClient] = None,
+        workspace_client: Optional[Any] = None,
+        serde: Optional[SerializerProtocol] = None,
+    ) -> None:
+        super().__init__(serde=serde)
+        if not session_store_name:
+            raise ValueError("session_store_name is required")
+        self._client = (client or SessionStoreClient(workspace_client)).set_session_store(
+            session_store_name
+        )
+        # Cache resolved Session objects per derived session_id to avoid re-resolving every put/get.
+        self._sessions: dict[str, Session] = {}
+
+    # ----- write path ---------------------------------------------------------
+
+    def put(
+        self,
+        config: RunnableConfig,
+        checkpoint: Checkpoint,
+        metadata: CheckpointMetadata,
+        new_versions: ChannelVersions,
+    ) -> RunnableConfig:
+        """Persist a checkpoint and its changed channel values."""
+        thread_id, actor_id, checkpoint_ns = _parse_config(config)
+        session = self._resolve_session(thread_id, actor_id, checkpoint_ns)
+
+        checkpoint_copy = dict(checkpoint)
+        channel_values = checkpoint_copy.pop("channel_values", {}) or {}
+
+        items: list[dict[str, Any]] = [
+            self._channel_data_item(
+                channel, str(version), channel_values.get(channel, _EMPTY_CHANNEL_VALUE)
+            )
+            for channel, version in new_versions.items()
+        ]
+        items.append(
+            self._checkpoint_item(
+                checkpoint_id=checkpoint["id"],
+                checkpoint_data=checkpoint_copy,
+                metadata=dict(get_checkpoint_metadata(config, metadata)),  # type: ignore[arg-type]
+                parent_checkpoint_id=get_checkpoint_id(config),
+            )
+        )
+        self._client.append_items(session, items=items)
+
+        return {
+            "configurable": {
+                "thread_id": thread_id,
+                "actor_id": actor_id,
+                "checkpoint_ns": checkpoint_ns,
+                "checkpoint_id": checkpoint["id"],
+            }
+        }
+
+    def put_writes(
+        self,
+        config: RunnableConfig,
+        writes: Sequence[tuple[str, Any]],
+        task_id: str,
+        task_path: str = "",
+    ) -> None:
+        """Persist pending intermediate writes for a checkpoint."""
+        thread_id, actor_id, checkpoint_ns = _parse_config(config)
+        checkpoint_id = get_checkpoint_id(config)
+        if not checkpoint_id:
+            raise ValueError("checkpoint_id is required in config for put_writes")
+
+        session = self._resolve_session(thread_id, actor_id, checkpoint_ns)
+        item = {
+            "event_type": _EVENT_WRITES,
+            "checkpoint_id": checkpoint_id,
+            "writes": [
+                {
+                    "task_id": task_id,
+                    "task_path": task_path,
+                    "channel": channel,
+                    "value": self._serialize(value),
+                }
+                for channel, value in writes
+            ],
+        }
+        self._client.append_items(session, items=[item])
+
+    def delete_thread(self, thread_id: str, actor_id: str = "") -> None:
+        """Remove all checkpoints and writes for a thread (via ClearSessionItems)."""
+        session = self._resolve_session(thread_id, actor_id, "")
+        self._client.clear_items(session)
+
+    # ----- read path ----------------------------------------------------------
+
+    def get_tuple(self, config: RunnableConfig) -> Optional[CheckpointTuple]:
+        """Return the checkpoint named in ``config``, or the latest one."""
+        thread_id, actor_id, checkpoint_ns = _parse_config(config)
+        session = self._resolve_session(thread_id, actor_id, checkpoint_ns)
+        checkpoints, writes_by_ckpt, channel_data = self._read(session)
+        if not checkpoints:
+            return None
+
+        wanted = get_checkpoint_id(config)
+        if wanted:
+            event = checkpoints.get(wanted)
+            if event is None:
+                return None
+        else:
+            event = checkpoints[max(checkpoints)]
+
+        return self._build_tuple(
+            event,
+            writes_by_ckpt.get(event["checkpoint_id"], []),
+            channel_data,
+            thread_id,
+            actor_id,
+            checkpoint_ns,
+        )
+
+    def list(
+        self,
+        config: RunnableConfig | None,
+        *,
+        filter: Optional[dict[str, Any]] = None,
+        before: RunnableConfig | None = None,
+        limit: Optional[int] = None,
+    ) -> Iterator[CheckpointTuple]:
+        """Yield stored checkpoints newest-first, honoring ``before``/``limit``."""
+        if config is None:
+            raise ValueError("config with a thread_id is required to list checkpoints")
+        thread_id, actor_id, checkpoint_ns = _parse_config(config)
+        session = self._resolve_session(thread_id, actor_id, checkpoint_ns)
+        checkpoints, writes_by_ckpt, channel_data = self._read(session)
+
+        before_id = get_checkpoint_id(before) if before else None
+        count = 0
+        for checkpoint_id in sorted(checkpoints, reverse=True):
+            if before_id and checkpoint_id >= before_id:
+                continue
+            if limit is not None and count >= limit:
+                break
+            yield self._build_tuple(
+                checkpoints[checkpoint_id],
+                writes_by_ckpt.get(checkpoint_id, []),
+                channel_data,
+                thread_id,
+                actor_id,
+                checkpoint_ns,
+            )
+            count += 1
+
+    def get_next_version(self, current: Optional[Any], channel: Optional[str] = None) -> str:
+        """Monotonic version string, matching LangGraph's default scheme."""
+        if current is None:
+            current_v = 0
+        elif isinstance(current, int):
+            current_v = current
+        else:
+            current_v = int(str(current).split(".")[0])
+        return f"{current_v + 1:032}.{random.random():016}"
+
+    # ----- async wrappers (the Session Store client is synchronous) -----------
+
+    async def aget_tuple(self, config: RunnableConfig) -> Optional[CheckpointTuple]:
+        return await _run_sync(self.get_tuple, config)
+
+    async def alist(
+        self,
+        config: RunnableConfig | None,
+        *,
+        filter: Optional[dict[str, Any]] = None,
+        before: RunnableConfig | None = None,
+        limit: Optional[int] = None,
+    ):
+        for item in await _run_sync(
+            lambda: list(self.list(config, filter=filter, before=before, limit=limit))
+        ):
+            yield item
+
+    async def aput(
+        self,
+        config: RunnableConfig,
+        checkpoint: Checkpoint,
+        metadata: CheckpointMetadata,
+        new_versions: ChannelVersions,
+    ) -> RunnableConfig:
+        return await _run_sync(self.put, config, checkpoint, metadata, new_versions)
+
+    async def aput_writes(
+        self,
+        config: RunnableConfig,
+        writes: Sequence[tuple[str, Any]],
+        task_id: str,
+        task_path: str = "",
+    ) -> None:
+        return await _run_sync(self.put_writes, config, writes, task_id, task_path)
+
+    async def adelete_thread(self, thread_id: str, actor_id: str = "") -> None:
+        await _run_sync(self.delete_thread, thread_id, actor_id)
+
+    # ----- internals ----------------------------------------------------------
+
+    def _resolve_session(self, thread_id: str, actor_id: str, checkpoint_ns: str) -> Session:
+        session_id = _session_id(thread_id, checkpoint_ns)
+        cached = self._sessions.get(session_id)
+        if cached is not None:
+            return cached
+        try:
+            session = self._client.get_session(session_id=session_id)
+        except tuple(_not_found_errors()) as _:  # type: ignore[misc]
+            session = self._client.create_session(
+                actor_id=actor_id,
+                session_id=session_id,
+                metadata={"langgraph_thread_id": thread_id, "checkpoint_ns": checkpoint_ns},
+            )
+        self._sessions[session_id] = session
+        return session
+
+    def _read(
+        self, session: Session
+    ) -> tuple[
+        dict[str, dict[str, Any]],
+        dict[str, builtins.list[dict[str, Any]]],
+        dict[tuple[str, str], Any],
+    ]:
+        """List items and group them into checkpoints, writes, and channel data."""
+        checkpoints: dict[str, dict[str, Any]] = {}
+        writes_by_ckpt: dict[str, list[dict[str, Any]]] = defaultdict(list)
+        channel_data: dict[tuple[str, str], Any] = {}
+
+        for item in self._client.list_items(session, order_by=_ORDER_BY):
+            data = item.data
+            event_type = data.get("event_type")
+            if event_type == _EVENT_CHECKPOINT:
+                checkpoints[data["checkpoint_id"]] = data
+            elif event_type == _EVENT_WRITES:
+                writes_by_ckpt[data["checkpoint_id"]].extend(data["writes"])
+            elif event_type == _EVENT_CHANNEL_DATA and data["value"] != _EMPTY_CHANNEL_VALUE:
+                channel_data[(data["channel"], data["version"])] = self._deserialize(data["value"])
+        return checkpoints, writes_by_ckpt, channel_data
+
+    def _build_tuple(
+        self,
+        checkpoint_event: dict[str, Any],
+        writes: builtins.list[dict[str, Any]],
+        channel_data: dict[tuple[str, str], Any],
+        thread_id: str,
+        actor_id: str,
+        checkpoint_ns: str,
+    ) -> CheckpointTuple:
+        checkpoint = dict(self._deserialize(checkpoint_event["checkpoint_data"]))
+        channel_values: dict[str, Any] = {}
+        for channel, version in checkpoint.get("channel_versions", {}).items():
+            key = (channel, str(version))
+            if key in channel_data:
+                channel_values[channel] = channel_data[key]
+        checkpoint["channel_values"] = channel_values
+
+        pending_writes = [
+            (w["task_id"], w["channel"], self._deserialize(w["value"])) for w in writes
+        ]
+
+        parent_config = None
+        if checkpoint_event.get("parent_checkpoint_id"):
+            parent_config = _config(
+                thread_id, actor_id, checkpoint_ns, checkpoint_event["parent_checkpoint_id"]
+            )
+
+        return CheckpointTuple(
+            config=_config(thread_id, actor_id, checkpoint_ns, checkpoint_event["checkpoint_id"]),
+            checkpoint=checkpoint,  # type: ignore[arg-type]
+            metadata=self._deserialize(checkpoint_event["metadata"]),
+            parent_config=parent_config,
+            pending_writes=pending_writes,
+        )
+
+    def _checkpoint_item(
+        self,
+        *,
+        checkpoint_id: str,
+        checkpoint_data: dict[str, Any],
+        metadata: dict[str, Any],
+        parent_checkpoint_id: Optional[str],
+    ) -> dict[str, Any]:
+        return {
+            "event_type": _EVENT_CHECKPOINT,
+            "checkpoint_id": checkpoint_id,
+            "checkpoint_data": self._serialize(checkpoint_data),
+            "metadata": self._serialize(metadata),
+            "parent_checkpoint_id": parent_checkpoint_id,
+        }
+
+    def _channel_data_item(self, channel: str, version: str, value: Any) -> dict[str, Any]:
+        stored = value if value == _EMPTY_CHANNEL_VALUE else self._serialize(value)
+        return {
+            "event_type": _EVENT_CHANNEL_DATA,
+            "channel": channel,
+            "version": version,
+            "value": stored,
+        }
+
+    def _serialize(self, value: Any) -> dict[str, str]:
+        """Serialize via the LangGraph serde into JSON-safe ``{type, data}``."""
+        type_tag, blob = self.serde.dumps_typed(value)
+        return {"type": type_tag, "data": base64.b64encode(blob).decode("utf-8")}
+
+    def _deserialize(self, serialized: dict[str, str]) -> Any:
+        return self.serde.loads_typed((serialized["type"], base64.b64decode(serialized["data"])))
+
+
+# ----- module-level helpers --------------------------------------------------
+
+
+def _parse_config(config: RunnableConfig | dict[str, Any] | None) -> tuple[str, str, str]:
+    configurable = (config or {}).get("configurable", {}) if config else {}
+    thread_id = configurable.get("thread_id")
+    actor_id = configurable.get("actor_id")
+    if not thread_id:
+        raise ValueError("config must contain configurable.thread_id")
+    if not actor_id:
+        raise ValueError("config must contain configurable.actor_id")
+    return thread_id, actor_id, configurable.get("checkpoint_ns", "") or ""
+
+
+def _session_id(thread_id: str, checkpoint_ns: str) -> str:
+    """Deterministic session id for a (thread_id, checkpoint_ns) pair.
+
+    With a namespace we hash the pair so the id stays within the store's id constraints and never
+    collides with the bare ``thread_id`` used for the default namespace.
+    """
+    if checkpoint_ns:
+        return hashlib.sha256(f"{thread_id}\x1f{checkpoint_ns}".encode()).hexdigest()
+    return thread_id
+
+
+def _config(
+    thread_id: str, actor_id: str, checkpoint_ns: str, checkpoint_id: str
+) -> RunnableConfig:
+    return {
+        "configurable": {
+            "thread_id": thread_id,
+            "actor_id": actor_id,
+            "checkpoint_ns": checkpoint_ns,
+            "checkpoint_id": checkpoint_id,
+        }
+    }
+
+
+def _not_found_errors() -> tuple[type, ...]:
+    """Exception types that mean 'session does not exist yet'."""
+    try:
+        from databricks.sdk.errors import NotFound
+
+        return (NotFound,)
+    except ImportError:  # pragma: no cover - SDK always present in practice
+        return (_SessionNotFound,)
+
+
+class _SessionNotFound(Exception):
+    """Fallback 'not found' used only when databricks.sdk is unavailable."""
+
+
+async def _run_sync(fn, *args):
+    import asyncio
+
+    loop = asyncio.get_running_loop()
+    return (
+        await loop.run_in_executor(None, fn, *args)
+        if args
+        else await loop.run_in_executor(None, fn)
+    )

--- a/integrations/mason/src/databricks_mason/runtime/session_store_client.py
+++ b/integrations/mason/src/databricks_mason/runtime/session_store_client.py
@@ -1,0 +1,120 @@
+"""Minimal Databricks Session Store REST client (vendored).
+
+Wraps the managed Session Store API (``/api/agents/v1/session-stores``) — the SDK-agnostic durable
+store for agent session history — with just the calls the LangGraph saver needs: resolve a store,
+get-or-create a session, and append / list / clear its ordered items. Auth/host come from a
+``databricks.sdk.WorkspaceClient`` (default credentials).
+
+This is a trimmed stand-in for the first-party ``databricks_agent_client.SessionStoreClient``; when
+that package is published, import it instead and delete this file. Item ``data`` is opaque JSON, so
+callers store whatever shape they like (the saver stores checkpoint fragments).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Iterator, Optional, Sequence
+
+from databricks.sdk import WorkspaceClient
+
+from databricks_mason.runtime.workspace import workspace_client as default_workspace_client
+
+_API_ROOT = "/api/agents/v1"
+
+
+@dataclass(frozen=True)
+class Session:
+    """A durable interaction within a Session Store, addressed by (store, session_id)."""
+
+    session_store_name: str
+    session_id: str
+    actor_id: str
+    metadata: dict[str, str] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class SessionItem:
+    """One opaque, ordered history entry. ``data`` is arbitrary JSON."""
+
+    item_id: str
+    data: Any
+
+
+class SessionStoreClient:
+    """Thin REST client over the managed Session Store API."""
+
+    def __init__(self, workspace_client: Optional[WorkspaceClient] = None) -> None:
+        self._api = (workspace_client or default_workspace_client()).api_client
+        self._store_name: Optional[str] = None
+
+    def set_session_store(self, session_store_name: str) -> "SessionStoreClient":
+        """Bind this client to a store; returns self so it doubles as the store handle."""
+        if not session_store_name:
+            raise ValueError("session_store_name is required")
+        self._store_name = session_store_name
+        return self
+
+    def get_session(self, *, session_id: str) -> Session:
+        resp: dict[str, Any] = self._api.do("GET", f"{self._sessions_path()}/{session_id}")  # type: ignore[assignment]
+        return self._session(resp)
+
+    def create_session(
+        self,
+        *,
+        actor_id: str,
+        session_id: Optional[str] = None,
+        metadata: Optional[dict[str, str]] = None,
+    ) -> Session:
+        body: dict[str, Any] = {"actor_id": actor_id}
+        if metadata:
+            body["metadata"] = metadata
+        query = {"session_id": session_id} if session_id else None
+        resp: dict[str, Any] = self._api.do("POST", self._sessions_path(), query=query, body=body)  # type: ignore[assignment]
+        return self._session(resp)
+
+    def append_items(self, session: Session, *, items: Sequence[Any]) -> None:
+        if not items:
+            raise ValueError("at least one item is required")
+        self._api.do(
+            "POST",
+            f"{self._items_path(session)}:append",
+            body={"items": [{"data": item} for item in items]},
+        )
+
+    def list_items(
+        self, session: Session, *, order_by: Optional[str] = None
+    ) -> Iterator[SessionItem]:
+        """Yield the session's items (paginating transparently)."""
+        page_token: Optional[str] = None
+        while True:
+            query = {k: v for k, v in {"order_by": order_by, "page_token": page_token}.items() if v}
+            resp: dict[str, Any] = self._api.do(
+                "GET", self._items_path(session), query=query or None
+            )  # type: ignore[assignment]
+            for item in resp.get("session_items", []):
+                if "data" in item:
+                    yield SessionItem(item_id=item.get("item_id", ""), data=item["data"])
+            page_token = resp.get("next_page_token")
+            if not page_token:
+                return
+
+    def clear_items(self, session: Session) -> None:
+        self._api.do("POST", f"{self._items_path(session)}:clear", body={})
+
+    # ----- internals ----------------------------------------------------------
+
+    def _sessions_path(self) -> str:
+        if not self._store_name:
+            raise ValueError("call set_session_store() before using the client")
+        return f"{_API_ROOT}/session-stores/{self._store_name}/sessions"
+
+    def _items_path(self, session: Session) -> str:
+        return f"{self._sessions_path()}/{session.session_id}/items"
+
+    def _session(self, resp: dict[str, Any]) -> Session:
+        return Session(
+            session_store_name=resp.get("session_store_name", self._store_name or ""),
+            session_id=resp["session_id"],
+            actor_id=resp.get("actor_id", ""),
+            metadata=dict(resp.get("metadata", {})),
+        )

--- a/integrations/mason/src/databricks_mason/runtime/tool_manifest.py
+++ b/integrations/mason/src/databricks_mason/runtime/tool_manifest.py
@@ -1,0 +1,143 @@
+"""Read the framework-neutral tool bindings in the project's ``agent.toml``."""
+
+from __future__ import annotations
+
+import os
+import pathlib
+from dataclasses import dataclass
+from typing import Any, cast
+
+try:
+    import tomllib  # ty: ignore[unresolved-import]
+except ModuleNotFoundError:
+    import tomli as tomllib
+
+
+@dataclass(frozen=True)
+class ScopeRecord:
+    kind: str
+    value: str
+    permission: str
+
+
+@dataclass(frozen=True)
+class ToolRecord:
+    id: str
+    kind: str
+    service: str | None = None
+    function: str | None = None
+    entrypoint: str | None = None
+    downscope: tuple[ScopeRecord, ...] = ()
+
+
+def project_root() -> pathlib.Path:
+    """Resolve the project containing ``agent.toml`` without writing it."""
+    configured = os.getenv("MASON_PROJECT_ROOT")
+    if configured:
+        root = pathlib.Path(configured).expanduser().resolve()
+        if (root / "agent.toml").is_file():
+            return root
+        raise RuntimeError(f"MASON_PROJECT_ROOT has no agent.toml: {root}")
+
+    for candidate in pathlib.Path(__file__).resolve().parents:
+        if (candidate / "agent.toml").is_file():
+            return candidate
+    raise RuntimeError("Could not locate agent.toml; set MASON_PROJECT_ROOT to the project root.")
+
+
+def _required_string(value: object, description: str) -> str:
+    if not isinstance(value, str) or not value:
+        raise RuntimeError(f"agent.toml must declare {description}.")
+    return value
+
+
+def _scope(value: object) -> ScopeRecord:
+    if not isinstance(value, dict):
+        raise RuntimeError("agent.toml downscope entries must be tables.")
+    value = cast(dict[str, Any], value)
+    resource = _required_string(value.get("resource"), "a downscope resource")
+    kind, separator, resource_value = resource.partition(":")
+    if not separator or kind not in {"table", "volume", "workspace"} or not resource_value:
+        raise RuntimeError(f"Invalid agent.toml downscope resource: {resource!r}.")
+    permission = _required_string(value.get("permission", "read_only"), "a permission")
+    if permission not in {"read_only", "read_write"}:
+        raise RuntimeError(f"Invalid agent.toml downscope permission: {permission!r}.")
+    return ScopeRecord(kind=kind, value=resource_value, permission=permission)
+
+
+def _tool(value: object) -> ToolRecord:
+    if not isinstance(value, dict):
+        raise RuntimeError("agent.toml tools must be tables.")
+    value = cast(dict[str, Any], value)
+    source = value.get("source")
+    if not isinstance(source, dict):
+        raise RuntimeError("Each agent.toml tool must declare a source table.")
+    source = cast(dict[str, Any], source)
+    policy = value.get("policy", {})
+    if not isinstance(policy, dict):
+        raise RuntimeError("agent.toml tool policy must be a table.")
+    policy = cast(dict[str, Any], policy)
+    raw_downscope = policy.get("downscope", [])
+    if not isinstance(raw_downscope, list):
+        raise RuntimeError("agent.toml policy.downscope must be an array.")
+    record = ToolRecord(
+        id=_required_string(value.get("id"), "a tool id"),
+        kind=_required_string(source.get("kind"), "a tool source kind"),
+        service=source.get("service") if isinstance(source.get("service"), str) else None,
+        function=source.get("function") if isinstance(source.get("function"), str) else None,
+        entrypoint=source.get("entrypoint") if isinstance(source.get("entrypoint"), str) else None,
+        downscope=tuple(_scope(item) for item in raw_downscope),
+    )
+    if record.kind == "sandbox" and (record.service != "system.ai.sandbox" or not record.downscope):
+        raise RuntimeError("Sandbox bindings require system.ai.sandbox and a downscope.")
+    if record.kind == "mcp" and not record.service:
+        raise RuntimeError("MCP bindings require source.service.")
+    if record.kind == "uc_function" and not record.function:
+        raise RuntimeError("UC function bindings require source.function.")
+    if record.kind == "python" and not record.entrypoint:
+        raise RuntimeError("Python bindings require source.entrypoint.")
+    if record.kind not in {"sandbox", "mcp", "uc_function", "python"}:
+        raise RuntimeError(f"Unsupported agent.toml tool kind: {record.kind!r}.")
+    if record.kind != "sandbox" and record.downscope:
+        raise RuntimeError("Only sandbox bindings accept policy.downscope.")
+    return record
+
+
+def load_tools(*, expected_framework: str) -> tuple[ToolRecord, ...]:
+    """Load a fresh immutable view so direct manifest edits apply on the next request."""
+    path = project_root() / "agent.toml"
+    try:
+        with path.open("rb") as input_file:
+            document: dict[str, Any] = tomllib.load(input_file)
+    except (OSError, tomllib.TOMLDecodeError) as exc:
+        raise RuntimeError(f"Could not read {path}: {exc}") from exc
+    if document.get("schema_version") != 1:
+        raise RuntimeError(f"Unsupported agent.toml schema in {path}; expected schema_version = 1.")
+    agent = document.get("agent")
+    if not isinstance(agent, dict) or agent.get("framework") != expected_framework:
+        actual = agent.get("framework") if isinstance(agent, dict) else None
+        raise RuntimeError(
+            f"agent.toml framework {actual!r} does not match runtime {expected_framework!r}."
+        )
+    raw_tools = document.get("tools", [])
+    if not isinstance(raw_tools, list):
+        raise RuntimeError("agent.toml tools must be an array of tables.")
+    tools = tuple(_tool(item) for item in raw_tools)
+    ids = [tool.id for tool in tools]
+    if len(ids) != len(set(ids)):
+        raise RuntimeError("agent.toml tool ids must be unique.")
+    return tools
+
+
+def downscope_wire(tool: ToolRecord) -> dict[str, list[dict[str, str]]]:
+    """Convert protected policy into the system.ai.sandbox MCP ``_meta`` shape."""
+    fields = {
+        "table": ("tables", "name"),
+        "volume": ("volumes", "name"),
+        "workspace": ("workspace_paths", "path"),
+    }
+    result: dict[str, list[dict[str, str]]] = {}
+    for scope in tool.downscope:
+        group, field = fields[scope.kind]
+        result.setdefault(group, []).append({field: scope.value, "permission": scope.permission})
+    return result

--- a/integrations/mason/src/databricks_mason/runtime/tool_manifest.py
+++ b/integrations/mason/src/databricks_mason/runtime/tool_manifest.py
@@ -31,7 +31,12 @@ class ToolRecord:
 
 
 def project_root() -> pathlib.Path:
-    """Resolve the project containing ``agent.toml`` without writing it."""
+    """Resolve the agent project containing ``agent.toml``.
+
+    This module ships in the databricks-mason package, not inside the agent project, so locate the
+    project relative to where the agent runs (the current working directory) — not this file's
+    location. ``MASON_PROJECT_ROOT`` overrides for cases where the process starts elsewhere.
+    """
     configured = os.getenv("MASON_PROJECT_ROOT")
     if configured:
         root = pathlib.Path(configured).expanduser().resolve()
@@ -39,7 +44,8 @@ def project_root() -> pathlib.Path:
             return root
         raise RuntimeError(f"MASON_PROJECT_ROOT has no agent.toml: {root}")
 
-    for candidate in pathlib.Path(__file__).resolve().parents:
+    cwd = pathlib.Path.cwd().resolve()
+    for candidate in (cwd, *cwd.parents):
         if (candidate / "agent.toml").is_file():
             return candidate
     raise RuntimeError("Could not locate agent.toml; set MASON_PROJECT_ROOT to the project root.")

--- a/integrations/mason/src/databricks_mason/runtime/tracing.py
+++ b/integrations/mason/src/databricks_mason/runtime/tracing.py
@@ -1,0 +1,44 @@
+"""MLflow tracing setup — opt-in, enabled when MLflow has both a destination and an experiment.
+
+Tracing turns on only when a full config is present: a destination (``MLFLOW_TRACKING_URI`` or
+``MLFLOW_TRACING_DESTINATION``) AND an experiment (``MLFLOW_EXPERIMENT_ID`` or
+``MLFLOW_EXPERIMENT_NAME``) — whichever pair the user or the Apps resource binding provides. MLflow
+resolves the specific value itself; this only decides on/off. Requiring both halves avoids the
+half-configured case where traces silently export to a local file store instead of the workspace.
+When unconfigured, tracing is disabled outright so the per-request span ``runtime/runtime.py`` opens
+has nothing to export to. No user decision lives here — it's all driven by env — so this whole module
+is a candidate to move behind an SDK helper.
+"""
+
+import os
+
+import mlflow
+
+# Destination and experiment can each be named more than one way; accept any combination MLflow
+# understands (see mlflow.tracking.fluent._get_experiment_id_from_env for the experiment resolution).
+_DESTINATION_VARS = ("MLFLOW_TRACKING_URI", "MLFLOW_TRACING_DESTINATION")
+_EXPERIMENT_VARS = ("MLFLOW_EXPERIMENT_ID", "MLFLOW_EXPERIMENT_NAME")
+
+# Snapshotted once by configure() at startup (after .env is loaded) rather than at import, so this
+# module has no import-time side effects and load order does not matter.
+_enabled = False
+
+
+def configure() -> None:
+    """Wire up tracing. Call once at startup."""
+    global _enabled
+    has_destination = any(os.getenv(v) for v in _DESTINATION_VARS)
+    has_experiment = any(os.getenv(v) for v in _EXPERIMENT_VARS)
+    _enabled = has_destination and has_experiment
+    if _enabled:
+        mlflow.langchain.autolog()
+    else:
+        # runtime/runtime.py wraps every request in a span regardless; without an experiment it
+        # would try to export to a missing one (INVALID_PARAMETER_VALUE), so disable.
+        mlflow.tracing.disable()
+
+
+def tag_session(session_id: str) -> None:
+    """Tag the active MLflow trace with the session id, when tracing is enabled."""
+    if _enabled and session_id:
+        mlflow.update_current_trace(metadata={"mlflow.trace.session": session_id})

--- a/integrations/mason/src/databricks_mason/runtime/workspace.py
+++ b/integrations/mason/src/databricks_mason/runtime/workspace.py
@@ -1,0 +1,27 @@
+"""Construct Databricks SDK clients with workspace routing when required."""
+
+from __future__ import annotations
+
+import os
+
+from databricks.sdk import WorkspaceClient
+
+
+def workspace_headers() -> dict[str, str]:
+    """Return headers required to route an account-host request to its workspace."""
+    workspace_id = os.getenv("DATABRICKS_WORKSPACE_ID", "").strip()
+    return {"X-Databricks-Org-Id": workspace_id} if workspace_id else {}
+
+
+def workspace_client() -> WorkspaceClient:
+    """Return the environment-authenticated client for the active workspace.
+
+    ``databricks apps run-local`` can authenticate through an account-level vanity host while
+    exposing the target workspace through ``DATABRICKS_WORKSPACE_ID``. The SDK needs the same
+    routing header as the Databricks CLI for those profiles. Ordinary workspace hosts and deployed
+    Apps continue to use the SDK's default authentication chain.
+    """
+    headers = workspace_headers()
+    if not headers:
+        return WorkspaceClient()
+    return WorkspaceClient(custom_headers=headers)

--- a/integrations/mason/tests/unit_tests/init_test.py
+++ b/integrations/mason/tests/unit_tests/init_test.py
@@ -11,6 +11,7 @@ import json
 import pathlib
 from unittest import mock
 
+import pytest
 import tomli
 from click.testing import CliRunner
 
@@ -38,6 +39,31 @@ def test_framework_specs_have_repo_ref_path():
         init_mod._CHAT_APP_TEMPLATES["langgraph"]
         == "integrations/mason/templates/ui/agent-langgraph"
     )
+
+
+def test_template_ref_pins_versioned_template_to_release_tag(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr(init_mod, "_installed_version", lambda _: "0.3.0")
+    # A released CLI fetches the template tagged for its own version.
+    assert init_mod._template_ref("langgraph") == "databricks-mason-v0.3.0"
+    # An unversioned framework (different repo, not tagged in lockstep) keeps its default ref.
+    assert init_mod._template_ref("openai") == "main"
+
+
+@pytest.mark.parametrize("installed", ["0.1.0.dev0", "0.2.0+local"])
+def test_template_ref_falls_back_to_main_for_unreleased_builds(
+    installed: str, monkeypatch: pytest.MonkeyPatch
+):
+    # Dev/editable/local-version builds have no matching release tag, so fetch `main`.
+    monkeypatch.setattr(init_mod, "_installed_version", lambda _: installed)
+    assert init_mod._template_ref("langgraph") == "main"
+
+
+def test_template_ref_falls_back_when_package_not_installed(monkeypatch: pytest.MonkeyPatch):
+    def _raise(_):
+        raise init_mod.PackageNotFoundError("databricks-mason")
+
+    monkeypatch.setattr(init_mod, "_installed_version", _raise)
+    assert init_mod._template_ref("langgraph") == "main"
 
 
 def test_init_scaffolds_default_directory(tmp_path: pathlib.Path):


### PR DESCRIPTION
Adds a databricks_mason.runtime subpackage containing the agent-side runtime helpers a deployed Mason agent uses — session_store, session_store_client, memory, tracing, background, mcp, durability, long_running, recovery, tool_manifest, workspace — behind a new [runtime] optional-dependencies extra that carries the agent stack. Moves all `template/agent/mason` files to the mason package. No template changes until follow up PR.

Follow-up PR — once published, delete the vendored agent/mason/, rewire the template to databricks_mason.runtime, pin the published version, and remove the init.py codegen.

Tested e2e from follow up PR:
* add mcps and add tools
* session store and memory store
* tracing