### PR TITLE
Exclude incomplete psycopg 3.3.5 release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ file = "LICENSE.txt"
 
 [project.optional-dependencies]
 memory = [
-  "psycopg[binary,pool]>=3.2.10",
+  "psycopg[binary,pool]>=3.2.10,!=3.3.5",
   "sqlalchemy[asyncio]>=2.0.0",
 ]
 agent-server = [


### PR DESCRIPTION
## What did you change, and why?

**Change:** Exclude `psycopg 3.3.5` from the existing memory extra while continuing to allow newer compatible releases.

**Why:** The 3.3.5 release currently lacks Linux x86_64 wheels for `psycopg-binary`, so all CI jobs that resolve the memory extra fail before tests. The same failure occurs on `main` and on the Mason version-bump PR.

## How do you know it works?

- The highest compatible resolution selects `psycopg 3.3.4` and `psycopg-binary 3.3.4`.
- The exact previously failing highest-resolution memory-extra environment installs successfully.
- 292 core tests passed before the remaining local run was stopped while waiting on an unrelated Databricks SDK clock.