### PR TITLE
[mason] Render memory-store timestamps and show popped item in text view

### DIFF
--- a/integrations/mason/src/databricks_mason/memory.py
+++ b/integrations/mason/src/databricks_mason/memory.py
@@ -68,6 +68,16 @@ mason memory entries search --store {store_id} --actor-id alice --query "style"
     ]
 
 
+def _store_created(store: dict):
+    # The API returns RFC 3339 `create_time`; older responses used epoch-millis
+    # `created_at`. Read the current field, falling back to the legacy one.
+    return field(store, "create_time") or field(store, "created_at")
+
+
+def _store_updated(store: dict):
+    return field(store, "update_time") or field(store, "updated_at")
+
+
 def _render_store_detail(obj, store: dict) -> None:
     render.detail(
         _BREADCRUMB,
@@ -79,8 +89,8 @@ def _render_store_detail(obj, store: dict) -> None:
             "Owner": field(store, "owner_user_id"),
             "Storage": render.field(field(store, "storage_backend") or {}, "backend_id"),
             "Description": field(store, "description"),
-            "Created": timefmt.absolute(field(store, "created_at")),
-            "Updated": timefmt.absolute(field(store, "updated_at")),
+            "Created": timefmt.absolute(_store_created(store)),
+            "Updated": timefmt.absolute(_store_updated(store)),
         },
         status="ACTIVE",
         snippets=_store_starter_code(obj, store),
@@ -123,8 +133,8 @@ def stores_list(obj, page_size, page_token) -> None:
         [
             field(s, "display_name"),
             _store_id(s),
-            timefmt.relative(field(s, "created_at")),
-            timefmt.relative(field(s, "updated_at")),
+            timefmt.relative(_store_created(s)),
+            timefmt.relative(_store_updated(s)),
             _truncate(field(s, "description"), 40),
         ]
         for s in items

--- a/integrations/mason/src/databricks_mason/sessions.py
+++ b/integrations/mason/src/databricks_mason/sessions.py
@@ -386,7 +386,16 @@ def items_pop(obj, store, session_id) -> None:
         render.emit_json(data)
         return
     item = field(data, "item")
-    render.success("Popped last item" if item else "Session was already empty")
+    if not item:
+        render.success("Session was already empty")
+        return
+    render.success(
+        "Popped last item",
+        fields={
+            "Item ID": field(item, "item_id"),
+            "Data": _truncate(field(item, "data"), 70),
+        },
+    )
 
 
 @items.command("clear")

--- a/integrations/mason/src/databricks_mason/timefmt.py
+++ b/integrations/mason/src/databricks_mason/timefmt.py
@@ -1,9 +1,9 @@
 """Timestamp parsing and humanization for the Mason CLI.
 
-The agents/v1 APIs return timestamps two ways: memory *stores* use epoch-millis
-int64 (`created_at`/`updated_at`), while entries, sessions, and session items use
-`google.protobuf.Timestamp`, which serializes to an RFC 3339 string
-(`2026-08-15T01:29:00Z`). `parse_timestamp` accepts either.
+The agents/v1 APIs return timestamps as `google.protobuf.Timestamp`, which
+serializes to an RFC 3339 string (`2026-08-15T01:29:00Z`) under the fields
+`create_time`/`update_time`. Older memory-store responses used epoch-millis
+int64 (`created_at`/`updated_at`); `parse_timestamp` accepts either form.
 
 `relative` returns concise phrases such as "13 days ago" and "An hour ago".
 """

--- a/integrations/mason/tests/unit_tests/memory_test.py
+++ b/integrations/mason/tests/unit_tests/memory_test.py
@@ -1,0 +1,74 @@
+"""Unit tests for `mason memory` store rendering (timestamp field mapping)."""
+
+from __future__ import annotations
+
+from click.testing import CliRunner
+
+from databricks_mason import memory as memory_mod
+from databricks_mason.memory import stores
+
+
+class _Client:
+    host = "https://example.databricks.com"
+
+    def __init__(self, store=None, page=None):
+        self._store = store
+        self._page = page
+
+    def get_memory_store(self, name):
+        return self._store
+
+    def list_memory_stores(self, page_size=None, page_token=None):
+        return self._page
+
+
+class _Ctx:
+    def __init__(self, client, output="text"):
+        self._client = client
+        self.output = output
+
+    def client(self):
+        return self._client
+
+
+def test_store_created_updated_read_current_and_legacy_fields():
+    # Current API field.
+    assert memory_mod._store_created({"create_time": "2026-08-15T01:29:00Z"}) == "2026-08-15T01:29:00Z"
+    assert memory_mod._store_updated({"update_time": "2026-08-16T01:29:00Z"}) == "2026-08-16T01:29:00Z"
+    # Legacy epoch-millis fallback.
+    assert memory_mod._store_created({"created_at": 1_755_100_000_000}) == 1_755_100_000_000
+    assert memory_mod._store_updated({"updated_at": 1_755_100_000_000}) == 1_755_100_000_000
+    # create_time takes precedence over the legacy field.
+    assert memory_mod._store_created({"create_time": "new", "created_at": 1}) == "new"
+    # Missing -> falsy (renders as em-dash downstream).
+    assert not memory_mod._store_created({})
+
+
+def test_store_get_renders_timestamps_from_create_time():
+    store = {
+        "name": "memory-stores/abc123",
+        "display_name": "demo",
+        "create_time": "2026-08-15T01:29:00Z",
+        "update_time": "2026-08-16T01:29:00Z",
+    }
+    result = CliRunner().invoke(stores, ["get", "abc123"], obj=_Ctx(_Client(store=store)))
+    assert result.exit_code == 0, result.output
+    # Timestamps render (year present) instead of the em-dash placeholder.
+    assert "2026" in result.output
+
+
+def test_store_list_renders_timestamps_from_create_time():
+    page = {
+        "managed_memory_stores": [
+            {
+                "name": "memory-stores/abc123",
+                "display_name": "demo",
+                "create_time": "2026-08-15T01:29:00Z",
+                "update_time": "2026-08-15T01:29:00Z",
+            }
+        ]
+    }
+    result = CliRunner().invoke(stores, ["list"], obj=_Ctx(_Client(page=page)))
+    assert result.exit_code == 0, result.output
+    # A humanized relative time appears rather than "—" for the row.
+    assert "ago" in result.output or "just now" in result.output

--- a/integrations/mason/tests/unit_tests/memory_test.py
+++ b/integrations/mason/tests/unit_tests/memory_test.py
@@ -33,8 +33,12 @@ class _Ctx:
 
 def test_store_created_updated_read_current_and_legacy_fields():
     # Current API field.
-    assert memory_mod._store_created({"create_time": "2026-08-15T01:29:00Z"}) == "2026-08-15T01:29:00Z"
-    assert memory_mod._store_updated({"update_time": "2026-08-16T01:29:00Z"}) == "2026-08-16T01:29:00Z"
+    assert (
+        memory_mod._store_created({"create_time": "2026-08-15T01:29:00Z"}) == "2026-08-15T01:29:00Z"
+    )
+    assert (
+        memory_mod._store_updated({"update_time": "2026-08-16T01:29:00Z"}) == "2026-08-16T01:29:00Z"
+    )
     # Legacy epoch-millis fallback.
     assert memory_mod._store_created({"created_at": 1_755_100_000_000}) == 1_755_100_000_000
     assert memory_mod._store_updated({"updated_at": 1_755_100_000_000}) == 1_755_100_000_000

--- a/integrations/mason/tests/unit_tests/sessions_test.py
+++ b/integrations/mason/tests/unit_tests/sessions_test.py
@@ -1,0 +1,44 @@
+"""Unit tests for `mason sessions items pop` rendering."""
+
+from __future__ import annotations
+
+from click.testing import CliRunner
+
+from databricks_mason.sessions import items
+
+
+class _Client:
+    def __init__(self, pop_result):
+        self._pop_result = pop_result
+
+    def pop_session_item(self, store, session_id):
+        return self._pop_result
+
+
+class _Ctx:
+    def __init__(self, client, output="text"):
+        self._client = client
+        self.output = output
+
+    def client(self):
+        return self._client
+
+
+def test_pop_shows_the_returned_item():
+    client = _Client({"item": {"item_id": "it-1", "data": {"role": "user", "content": "hi"}}})
+    result = CliRunner().invoke(
+        items, ["pop", "--store", "s", "--session-id", "sid"], obj=_Ctx(client)
+    )
+    assert result.exit_code == 0, result.output
+    assert "Popped last item" in result.output
+    # The popped item's id and data are surfaced (previously hidden in text mode).
+    assert "it-1" in result.output
+    assert "role" in result.output and "hi" in result.output
+
+
+def test_pop_empty_session_reports_empty():
+    result = CliRunner().invoke(
+        items, ["pop", "--store", "s", "--session-id", "sid"], obj=_Ctx(_Client({}))
+    )
+    assert result.exit_code == 0, result.output
+    assert "already empty" in result.output


### PR DESCRIPTION
Fixes two rendering bugs in the Mason CLI (ML-69217, ML-69219).

- **ML-69217** memory `stores get`/`list` text view showed `Created —`/`Updated —` even though the JSON had `create_time`/`update_time`. The renderer read the stale `created_at`/`updated_at` keys; now reads `create_time`/`update_time` with a fallback to the legacy keys. (`timefmt` docstring corrected.)
- **ML-69219** `sessions items pop` text view only printed "Popped last item"; it now surfaces the popped item id + data (the `-o json` path already returned them).

Tests: `memory_test.py`, `sessions_test.py`. Full unit suite green; both fixes verified live against eng-ml-inference staging.

This pull request and its description were written by Isaac.