### PR TITLE
[ML-69249] mason: fix `mason tracing list` against current mlflow

### DIFF
--- a/integrations/mason/src/databricks_mason/tracing.py
+++ b/integrations/mason/src/databricks_mason/tracing.py
@@ -250,8 +250,15 @@ def tracing_list(obj, experiment, limit) -> None:
     mlflow = _mlflow()
     _configure(mlflow, obj.profile, None)
     exp_name = experiment or _DEFAULT_EXPERIMENT
-    traces = mlflow.search_traces(
-        experiment_names=[exp_name], max_results=limit, return_type="list"
+    # search_traces selects experiments by id, not name, so resolve first. A missing experiment means
+    # no traces have been recorded there yet — show an empty list rather than erroring.
+    exp = mlflow.get_experiment_by_name(exp_name)
+    traces = (
+        mlflow.search_traces(
+            experiment_ids=[exp.experiment_id], max_results=limit, return_type="list"
+        )
+        if exp
+        else []
     )
 
     if obj.output == "json":

--- a/integrations/mason/tests/unit_tests/tracing_test.py
+++ b/integrations/mason/tests/unit_tests/tracing_test.py
@@ -164,6 +164,47 @@ def test_setup_requires_mlflow_when_absent():
     assert result.exit_code != 0
 
 
+def test_list_resolves_experiment_name_to_id_for_search():
+    # search_traces selects by experiment_ids, not names, so list must resolve the name first.
+    from unittest import mock
+
+    mlflow = mock.Mock()
+    mlflow.get_experiment_by_name.return_value = mock.Mock(experiment_id="eid-9")
+    mlflow.search_traces.return_value = []
+    with (
+        mock.patch.object(tracing_mod, "_mlflow", return_value=mlflow),
+        mock.patch.object(tracing_mod, "_configure"),
+    ):
+        result = CliRunner().invoke(
+            tracing_mod.tracing_list, ["--experiment", "/Shared/x", "--limit", "7"], obj=_Ctx()
+        )
+
+    assert result.exit_code == 0, result.output
+    mlflow.get_experiment_by_name.assert_called_once_with("/Shared/x")
+    _, kwargs = mlflow.search_traces.call_args
+    assert kwargs["experiment_ids"] == ["eid-9"]
+    assert kwargs["max_results"] == 7
+
+
+def test_list_returns_empty_when_experiment_absent():
+    # A not-yet-created experiment has no traces; list should show none, not error.
+    from unittest import mock
+
+    mlflow = mock.Mock()
+    mlflow.get_experiment_by_name.return_value = None
+    with (
+        mock.patch.object(tracing_mod, "_mlflow", return_value=mlflow),
+        mock.patch.object(tracing_mod, "_configure"),
+    ):
+        result = CliRunner().invoke(
+            tracing_mod.tracing_list, ["--experiment", "/Shared/missing"], obj=_Ctx(output="json")
+        )
+
+    assert result.exit_code == 0, result.output
+    assert json.loads(result.output) == []
+    mlflow.search_traces.assert_not_called()
+
+
 def test_status_str_handles_enum_like_and_none():
     class _EnumLike:
         name = "OK"


### PR DESCRIPTION
search_traces takes experiment_ids, not experiment_names (removed in newer mlflow), so tracing list raised TypeError. Resolve the experiment name to its id first, and return an empty list when the experiment doesn't exist yet instead of erroring. Adds regression tests for both paths.