### PR TITLE
[mason] Error hygiene: JSON-mode errors, id validation, friendly no-op update

### DIFF
--- a/integrations/mason/src/databricks_mason/cli.py
+++ b/integrations/mason/src/databricks_mason/cli.py
@@ -10,6 +10,7 @@ from typing import Optional
 
 import click
 
+from databricks_mason import errors
 from databricks_mason.auth import load_default_profile, login, logout
 from databricks_mason.client import MasonClient
 from databricks_mason.deploy import deploy, deployments
@@ -56,6 +57,8 @@ def mason(ctx: click.Context, profile: Optional[str], output: str) -> None:
     .databrickscfg profile (pass --profile / -p, run `mason login` to save a default,
     or rely on the SDK's default resolution).
     """
+    # Let errors render to match the selected output mode (JSON errors for -o json).
+    errors.set_output_mode(output)
     ctx.obj = CliContext(profile=profile or load_default_profile(), output=output)
 
 

--- a/integrations/mason/src/databricks_mason/client.py
+++ b/integrations/mason/src/databricks_mason/client.py
@@ -36,15 +36,39 @@ def _as(cls: type, resp: Any) -> Any:
 
 
 def memory_store_path(name: str) -> str:
-    """Normalize a store id or name into the `memory-stores/{id}` resource segment."""
-    name = name.strip().strip("/")
-    return name if name.startswith("memory-stores/") else f"memory-stores/{name}"
+    """Normalize a store id or name into the `memory-stores/{id}` resource segment.
+
+    Validates client-side so an empty or wrong-typed argument raises a clear error
+    instead of building a URL like `memory-stores/` and leaking a raw ENDPOINT_NOT_FOUND.
+    """
+    raw = (name or "").strip()
+    if raw.startswith("memory-stores/"):
+        raw = raw[len("memory-stores/") :]
+    raw = raw.strip().strip("/")
+    if not raw:
+        raise AgentCliError("A memory store id or resource name is required.")
+    if "/" in raw:
+        raise AgentCliError(f"Invalid memory store id or resource name: {name!r}")
+    return f"memory-stores/{raw}"
+
+
+def session_store_path(name: str) -> str:
+    """Normalize/validate a session store name into the `session-stores/{name}` segment."""
+    raw = (name or "").strip()
+    if raw.startswith("session-stores/"):
+        raw = raw[len("session-stores/") :]
+    raw = raw.strip().strip("/")
+    if not raw:
+        raise AgentCliError("A session store name is required.")
+    return f"session-stores/{raw}"
 
 
 def memory_entry_path(store: str, entry: str) -> str:
-    entry = entry.strip().strip("/")
+    entry = (entry or "").strip().strip("/")
     if entry.startswith("memory-stores/"):
         return entry
+    if not entry:
+        raise AgentCliError("A memory entry id or resource name is required.")
     return f"{memory_store_path(store)}/entries/{entry}"
 
 
@@ -162,6 +186,10 @@ class MasonClient:
         self, name: str, display_name: Optional[str] = None, description: Optional[str] = None
     ) -> models.MemoryStore:
         body = _query(display_name=display_name, description=description)
+        if not body:
+            raise AgentCliError(
+                "No fields to update. Provide a display name and/or description."
+            )
         mask = ",".join(body.keys())
         return _as(
             models.MemoryStore,
@@ -247,6 +275,8 @@ class MasonClient:
         description: Optional[str] = None,
     ) -> models.MemoryEntry:
         body = _query(content=content, description=description)
+        if not body:
+            raise AgentCliError("No fields to update. Provide content and/or a description.")
         return _as(
             models.MemoryEntry,
             self._do("PATCH", f"{_BASE}/{memory_entry_path(store, entry)}", body=body),
@@ -269,7 +299,7 @@ class MasonClient:
         )
 
     def get_session_store(self, name: str) -> models.SessionStore:
-        return _as(models.SessionStore, self._do("GET", f"{_BASE}/session-stores/{name}"))
+        return _as(models.SessionStore, self._do("GET", f"{_BASE}/{session_store_path(name)}"))
 
     def list_session_stores(
         self, page_size: Optional[int] = None, page_token: Optional[str] = None
@@ -287,16 +317,23 @@ class MasonClient:
         self, name: str, description: Optional[str] = None, metadata: Optional[dict] = None
     ) -> models.SessionStore:
         body = _query(description=description, metadata=metadata)
+        if not body:
+            raise AgentCliError(
+                "No fields to update. Provide a description and/or metadata."
+            )
         mask = ",".join(body.keys())
         return _as(
             models.SessionStore,
             self._do(
-                "PATCH", f"{_BASE}/session-stores/{name}", query=_query(update_mask=mask), body=body
+                "PATCH",
+                f"{_BASE}/{session_store_path(name)}",
+                query=_query(update_mask=mask),
+                body=body,
             ),
         )
 
     def delete_session_store(self, name: str) -> dict:
-        return self._do("DELETE", f"{_BASE}/session-stores/{name}")
+        return self._do("DELETE", f"{_BASE}/{session_store_path(name)}")
 
     # --- sessions ------------------------------------------------------------
 

--- a/integrations/mason/src/databricks_mason/client.py
+++ b/integrations/mason/src/databricks_mason/client.py
@@ -187,9 +187,7 @@ class MasonClient:
     ) -> models.MemoryStore:
         body = _query(display_name=display_name, description=description)
         if not body:
-            raise AgentCliError(
-                "No fields to update. Provide a display name and/or description."
-            )
+            raise AgentCliError("No fields to update. Provide a display name and/or description.")
         mask = ",".join(body.keys())
         return _as(
             models.MemoryStore,
@@ -318,9 +316,7 @@ class MasonClient:
     ) -> models.SessionStore:
         body = _query(description=description, metadata=metadata)
         if not body:
-            raise AgentCliError(
-                "No fields to update. Provide a description and/or metadata."
-            )
+            raise AgentCliError("No fields to update. Provide a description and/or metadata.")
         mask = ",".join(body.keys())
         return _as(
             models.SessionStore,

--- a/integrations/mason/src/databricks_mason/errors.py
+++ b/integrations/mason/src/databricks_mason/errors.py
@@ -27,6 +27,7 @@ def set_output_mode(mode: str) -> None:
     global _OUTPUT_MODE
     _OUTPUT_MODE = mode
 
+
 _PREVIEW_HINT = (
     "These agents/v1 APIs are in preview and gated per workspace. This handler is "
     "not enabled on the target workspace yet — try a different --profile or contact "

--- a/integrations/mason/src/databricks_mason/errors.py
+++ b/integrations/mason/src/databricks_mason/errors.py
@@ -6,6 +6,7 @@ one-liner (plus an optional hint) and exits non-zero, instead of dumping a trace
 
 from __future__ import annotations
 
+import json
 from typing import Optional
 
 import click
@@ -14,6 +15,17 @@ from rich.text import Text
 
 # Error codes indicating that a preview API is unavailable in the workspace.
 _PREVIEW_ERROR_CODES = frozenset({"NOT_IMPLEMENTED", "UNIMPLEMENTED", "FEATURE_DISABLED"})
+
+# Process-global output mode, set once by the root CLI group. When "json", errors are
+# emitted as a machine-readable JSON object instead of the styled text one-liner, so a
+# script driving `mason -o json` can parse failures instead of scraping human text.
+_OUTPUT_MODE = "text"
+
+
+def set_output_mode(mode: str) -> None:
+    """Record the CLI's --output mode so errors can render to match it."""
+    global _OUTPUT_MODE
+    _OUTPUT_MODE = mode
 
 _PREVIEW_HINT = (
     "These agents/v1 APIs are in preview and gated per workspace. This handler is "
@@ -33,6 +45,14 @@ class AgentCliError(click.ClickException):
         self.hint = hint
 
     def show(self, file=None) -> None:
+        if _OUTPUT_MODE == "json":
+            payload: dict = {"message": self.message}
+            if self.error_code:
+                payload["code"] = self.error_code
+            if self.hint:
+                payload["hint"] = self.hint
+            click.echo(json.dumps({"error": payload}, indent=2), err=True)
+            return
         console = Console(stderr=True)
         label = f"Error [{self.error_code}]" if self.error_code else "Error"
         console.print(Text(f"{label}: ", style="bold red") + Text(self.message))

--- a/integrations/mason/tests/unit_tests/client_test.py
+++ b/integrations/mason/tests/unit_tests/client_test.py
@@ -223,6 +223,4 @@ def test_update_memory_entry_no_fields_raises_without_calling_api(workspace_clie
 def test_delete_session_store_normalizes_path(workspace_client):
     c, do = _client(workspace_client)
     c.delete_session_store("session-stores/s1")
-    do.assert_called_once_with(
-        "DELETE", "/api/agents/v1/session-stores/s1", query=None, body=None
-    )
+    do.assert_called_once_with("DELETE", "/api/agents/v1/session-stores/s1", query=None, body=None)

--- a/integrations/mason/tests/unit_tests/client_test.py
+++ b/integrations/mason/tests/unit_tests/client_test.py
@@ -4,11 +4,14 @@ from __future__ import annotations
 
 from unittest import mock
 
+import pytest
+
 from databricks_mason.client import (
     MasonClient,
     _workspace_client,
     memory_entry_path,
     memory_store_path,
+    session_store_path,
 )
 from databricks_mason.errors import AgentCliError
 
@@ -167,3 +170,59 @@ def test_path_helpers():
     assert memory_store_path("memory-stores/abc") == "memory-stores/abc"
     assert memory_entry_path("s", "e") == "memory-stores/s/entries/e"
     assert memory_entry_path("s", "memory-stores/s/entries/e") == "memory-stores/s/entries/e"
+
+
+def test_memory_store_path_rejects_empty_and_wrong_type():
+    # Empty / whitespace-only ids must not build a "memory-stores/" URL (ML-69222).
+    for bad in ["", "   ", "/", "memory-stores/"]:
+        with pytest.raises(AgentCliError):
+            memory_store_path(bad)
+    # A wrong-typed resource name is rejected rather than nested into the URL.
+    with pytest.raises(AgentCliError):
+        memory_store_path("session-stores/abc")
+
+
+def test_session_store_path_rejects_empty():
+    for bad in ["", "   ", "/", "session-stores/"]:
+        with pytest.raises(AgentCliError):
+            session_store_path(bad)
+    assert session_store_path("s1") == "session-stores/s1"
+    assert session_store_path("session-stores/s1") == "session-stores/s1"
+
+
+def test_memory_entry_path_rejects_empty_entry():
+    with pytest.raises(AgentCliError):
+        memory_entry_path("s", "")
+
+
+@mock.patch("databricks_mason.client.WorkspaceClient")
+def test_update_memory_store_no_fields_raises_without_calling_api(workspace_client):
+    c, do = _client(workspace_client)
+    with pytest.raises(AgentCliError):
+        c.update_memory_store("abc")  # no display_name / description
+    do.assert_not_called()
+
+
+@mock.patch("databricks_mason.client.WorkspaceClient")
+def test_update_session_store_no_fields_raises_without_calling_api(workspace_client):
+    c, do = _client(workspace_client)
+    with pytest.raises(AgentCliError):
+        c.update_session_store("s1")  # no description / metadata
+    do.assert_not_called()
+
+
+@mock.patch("databricks_mason.client.WorkspaceClient")
+def test_update_memory_entry_no_fields_raises_without_calling_api(workspace_client):
+    c, do = _client(workspace_client)
+    with pytest.raises(AgentCliError):
+        c.update_memory_entry("s", "memory-stores/s/entries/e")
+    do.assert_not_called()
+
+
+@mock.patch("databricks_mason.client.WorkspaceClient")
+def test_delete_session_store_normalizes_path(workspace_client):
+    c, do = _client(workspace_client)
+    c.delete_session_store("session-stores/s1")
+    do.assert_called_once_with(
+        "DELETE", "/api/agents/v1/session-stores/s1", query=None, body=None
+    )

--- a/integrations/mason/tests/unit_tests/errors_test.py
+++ b/integrations/mason/tests/unit_tests/errors_test.py
@@ -1,0 +1,45 @@
+"""Unit tests for AgentCliError rendering across output modes."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from databricks_mason import errors
+from databricks_mason.errors import AgentCliError
+
+
+@pytest.fixture(autouse=True)
+def _reset_output_mode():
+    # Keep the process-global output mode from leaking between tests.
+    yield
+    errors.set_output_mode("text")
+
+
+def test_error_renders_json_object_in_json_mode(capsys):
+    errors.set_output_mode("json")
+    AgentCliError("store not found", error_code="NOT_FOUND", hint="check the id").show()
+    captured = capsys.readouterr()
+    # JSON errors go to stderr so stdout stays a clean success channel.
+    payload = json.loads(captured.err)
+    assert payload == {
+        "error": {"message": "store not found", "code": "NOT_FOUND", "hint": "check the id"}
+    }
+
+
+def test_error_json_omits_absent_code_and_hint(capsys):
+    errors.set_output_mode("json")
+    AgentCliError("boom").show()
+    payload = json.loads(capsys.readouterr().err)
+    assert payload == {"error": {"message": "boom"}}
+
+
+def test_error_renders_text_in_text_mode(capsys):
+    errors.set_output_mode("text")
+    AgentCliError("boom", error_code="NOT_FOUND").show()
+    err = capsys.readouterr().err
+    assert "boom" in err and "NOT_FOUND" in err
+    # Not JSON in text mode.
+    with pytest.raises(json.JSONDecodeError):
+        json.loads(err)


### PR DESCRIPTION
Three error-handling fixes in the Mason CLI (ML-69221, ML-69222, ML-69223).

- **ML-69221** In `-o json` mode, errors are now emitted as a JSON object `{"error": {message, code, hint}}` on stderr instead of styled text, so scripts driving `mason -o json` can parse failures. Text mode is unchanged.
- **ML-69222** Store id / resource name is validated client-side: empty or wrong-typed ids raise a clear error instead of building a URL like `.../memory-stores/` and leaking a raw `ENDPOINT_NOT_FOUND`. Covers memory stores, session stores, and memory entries.
- **ML-69223** A no-op `update` (no mutable fields) now raises a friendly "No fields to update…" message instead of surfacing the internal `update_mask is required`.

Tests: `client_test.py` (path + no-op cases), new `errors_test.py` (both output modes). Full suite green; verified live.

This pull request and its description were written by Isaac.