### PR TITLE
[mason] CLI ergonomics: delete confirmations, optional --store, help, aliases, fork arg

### DIFF
--- a/integrations/mason/src/databricks_mason/memory.py
+++ b/integrations/mason/src/databricks_mason/memory.py
@@ -7,9 +7,37 @@ from typing import Any
 import click
 
 from databricks_mason import render, timefmt
+from databricks_mason.errors import AgentCliError
 from databricks_mason.render import field
 
 _BREADCRUMB = "Agent Memory"
+
+# Friendly aliases for the memory-entry source type, mapped to the API enum values.
+_SOURCE_TYPES = {
+    "agent": "MANAGED_MEMORY_ENTRY_SOURCE_TYPE_AGENT",
+    "unspecified": "MANAGED_MEMORY_ENTRY_SOURCE_TYPE_UNSPECIFIED",
+}
+
+
+def _normalize_source_type(value):
+    """Accept a friendly alias ('agent'/'unspecified') or the full enum; None passes through."""
+    if value is None:
+        return None
+    key = value.strip().lower()
+    if key in _SOURCE_TYPES:
+        return _SOURCE_TYPES[key]
+    if value in _SOURCE_TYPES.values():
+        return value
+    raise AgentCliError(f"Invalid --source-type {value!r}. Choose one of: agent, unspecified.")
+
+
+def _require_entry_store(store, entry) -> None:
+    """A store is needed unless the entry is a full `memory-stores/.../entries/...` name."""
+    if not store and not str(entry).strip().startswith("memory-stores/"):
+        raise AgentCliError(
+            "Provide --store, or pass the full entry resource name "
+            "(memory-stores/<store>/entries/<id>)."
+        )
 
 
 def _store_id(store: dict) -> str:
@@ -88,8 +116,14 @@ def _render_store_detail(obj, store: dict) -> None:
 
 
 @stores.command("create")
-@click.option("--display-name", required=True, help="Workspace-unique display name.")
-@click.option("--description", default=None)
+@click.option(
+    "--display-name",
+    "--name",
+    "display_name",
+    required=True,
+    help="Workspace-unique display name (--name is accepted as an alias).",
+)
+@click.option("--description", default=None, help="Optional human-readable description.")
 @click.pass_obj
 def stores_create(obj, display_name, description) -> None:
     """Create a memory store."""
@@ -171,9 +205,11 @@ def stores_update(obj, name, display_name, description) -> None:
 
 @stores.command("delete")
 @click.argument("name")
+@click.option("--yes", "-y", is_flag=True, help="Skip the confirmation prompt.")
 @click.pass_obj
-def stores_delete(obj, name) -> None:
+def stores_delete(obj, name, yes) -> None:
     """Delete (soft-delete) a memory store."""
+    render.confirm_destroy(f"memory store '{name}'", assume_yes=yes)
     obj.client().delete_memory_store(name)
     if obj.output == "json":
         render.emit_json({"deleted": name})
@@ -205,17 +241,15 @@ def _render_entry_detail(entry: dict) -> None:
 
 @entries.command("create")
 @click.option("--store", required=True, help="Store id or resource name.")
-@click.option("--actor-id", required=True)
+@click.option("--actor-id", required=True, help="Actor (partition) this entry belongs to.")
 @click.option("--path", required=True, help="Absolute path, e.g. /preferences/style.md.")
-@click.option("--content", default=None)
-@click.option("--description", default=None)
-@click.option("--session-id", default=None)
+@click.option("--content", default=None, help="Entry content (inline text).")
+@click.option("--description", default=None, help="Optional human-readable description.")
+@click.option("--session-id", default=None, help="Optional session id to associate the entry with.")
 @click.option(
     "--source-type",
     default=None,
-    type=click.Choice(
-        ["MANAGED_MEMORY_ENTRY_SOURCE_TYPE_AGENT", "MANAGED_MEMORY_ENTRY_SOURCE_TYPE_UNSPECIFIED"]
-    ),
+    help="Origin of the entry: 'agent' or 'unspecified'.",
 )
 @click.pass_obj
 def entries_create(
@@ -223,7 +257,7 @@ def entries_create(
 ) -> None:
     """Create a memory entry."""
     data = obj.client().create_memory_entry(
-        store, actor_id, path, content, description, session_id, source_type
+        store, actor_id, path, content, description, session_id, _normalize_source_type(source_type)
     )
     if obj.output == "json":
         render.emit_json(data)
@@ -232,11 +266,12 @@ def entries_create(
 
 
 @entries.command("get")
-@click.option("--store", required=True)
+@click.option("--store", default=None, help="Store id/name (optional if ENTRY is a full resource name).")
 @click.argument("entry")
 @click.pass_obj
 def entries_get(obj, store, entry) -> None:
     """Get an entry by id or resource name (includes content)."""
+    _require_entry_store(store, entry)
     data = obj.client().get_memory_entry(store, entry)
     if obj.output == "json":
         render.emit_json(data)
@@ -253,7 +288,7 @@ def entries_get(obj, store, entry) -> None:
 @click.option("--page-token", default=None)
 @click.pass_obj
 def entries_list(obj, store, actor_id, path_prefix, session_id, page_size, page_token) -> None:
-    """List entries for an actor (content omitted)."""
+    """List entries for an actor. The text view omits content; `-o json` includes it."""
     data = obj.client().list_memory_entries(
         store, actor_id, path_prefix, session_id, page_size, page_token
     )
@@ -315,13 +350,14 @@ def entries_search(obj, store, actor_id, query, limit) -> None:
 
 
 @entries.command("update")
-@click.option("--store", required=True)
+@click.option("--store", default=None, help="Store id/name (optional if ENTRY is a full resource name).")
 @click.argument("entry")
-@click.option("--content", default=None)
-@click.option("--description", default=None)
+@click.option("--content", default=None, help="New entry content.")
+@click.option("--description", default=None, help="New description.")
 @click.pass_obj
 def entries_update(obj, store, entry, content, description) -> None:
     """Update an entry's content and/or description."""
+    _require_entry_store(store, entry)
     data = obj.client().update_memory_entry(store, entry, content, description)
     if obj.output == "json":
         render.emit_json(data)
@@ -330,11 +366,14 @@ def entries_update(obj, store, entry, content, description) -> None:
 
 
 @entries.command("delete")
-@click.option("--store", required=True)
+@click.option("--store", default=None, help="Store id/name (optional if ENTRY is a full resource name).")
 @click.argument("entry")
+@click.option("--yes", "-y", is_flag=True, help="Skip the confirmation prompt.")
 @click.pass_obj
-def entries_delete(obj, store, entry) -> None:
+def entries_delete(obj, store, entry, yes) -> None:
     """Delete a memory entry."""
+    _require_entry_store(store, entry)
+    render.confirm_destroy(f"memory entry '{entry}'", assume_yes=yes)
     obj.client().delete_memory_entry(store, entry)
     if obj.output == "json":
         render.emit_json({"deleted": entry})

--- a/integrations/mason/src/databricks_mason/memory.py
+++ b/integrations/mason/src/databricks_mason/memory.py
@@ -266,7 +266,9 @@ def entries_create(
 
 
 @entries.command("get")
-@click.option("--store", default=None, help="Store id/name (optional if ENTRY is a full resource name).")
+@click.option(
+    "--store", default=None, help="Store id/name (optional if ENTRY is a full resource name)."
+)
 @click.argument("entry")
 @click.pass_obj
 def entries_get(obj, store, entry) -> None:
@@ -350,7 +352,9 @@ def entries_search(obj, store, actor_id, query, limit) -> None:
 
 
 @entries.command("update")
-@click.option("--store", default=None, help="Store id/name (optional if ENTRY is a full resource name).")
+@click.option(
+    "--store", default=None, help="Store id/name (optional if ENTRY is a full resource name)."
+)
 @click.argument("entry")
 @click.option("--content", default=None, help="New entry content.")
 @click.option("--description", default=None, help="New description.")
@@ -366,7 +370,9 @@ def entries_update(obj, store, entry, content, description) -> None:
 
 
 @entries.command("delete")
-@click.option("--store", default=None, help="Store id/name (optional if ENTRY is a full resource name).")
+@click.option(
+    "--store", default=None, help="Store id/name (optional if ENTRY is a full resource name)."
+)
 @click.argument("entry")
 @click.option("--yes", "-y", is_flag=True, help="Skip the confirmation prompt.")
 @click.pass_obj

--- a/integrations/mason/src/databricks_mason/render.py
+++ b/integrations/mason/src/databricks_mason/render.py
@@ -45,6 +45,19 @@ def emit_json(data: Any) -> None:
     click.echo(json.dumps(data, indent=2, default=str))
 
 
+def confirm_destroy(target: str, *, assume_yes: bool) -> None:
+    """Guard a destructive action with a confirmation prompt.
+
+    No-op when `assume_yes` is set (the `--yes/-y` flag, for scripts). Otherwise prompts
+    on the terminal and aborts unless the user answers yes. A non-interactive stdin (a
+    pipe with no `--yes`) answers no and aborts, which is the safe default.
+    """
+    if assume_yes:
+        return
+    if not click.confirm(f"Delete {target}? This cannot be undone.", default=False):
+        raise click.Abort()
+
+
 def status_pill(status: Optional[str]) -> Text:
     """Create a colored ●/○ status indicator."""
     value = (status or "").strip().upper()

--- a/integrations/mason/src/databricks_mason/sessions.py
+++ b/integrations/mason/src/databricks_mason/sessions.py
@@ -57,7 +57,13 @@ def _render_store_detail(store: dict) -> None:
 
 
 @stores.command("create")
-@click.option("--name", "name", required=True, help="Workspace-unique store name (3-63 chars).")
+@click.option(
+    "--name",
+    "--display-name",
+    "name",
+    required=True,
+    help="Workspace-unique store name, 3-63 chars (--display-name is accepted as an alias).",
+)
 @click.option("--description", default=None)
 @click.option("--metadata", default=None, help="JSON object of string labels.")
 @click.pass_obj
@@ -140,9 +146,11 @@ def stores_update(obj, name, description, metadata) -> None:
 
 @stores.command("delete")
 @click.argument("name")
+@click.option("--yes", "-y", is_flag=True, help="Skip the confirmation prompt.")
 @click.pass_obj
-def stores_delete(obj, name) -> None:
+def stores_delete(obj, name, yes) -> None:
     """Delete a session store."""
+    render.confirm_destroy(f"session store '{name}'", assume_yes=yes)
     obj.client().delete_session_store(name)
     if obj.output == "json":
         render.emit_json({"deleted": name})
@@ -261,10 +269,14 @@ def sessions_list(obj, store, filter_, order_by, page_size, page_token) -> None:
 
 @sessions.command("get")
 @click.argument("session_id")
-@click.option("--store", default=None, help="Store name; omit to resolve by session id.")
+@click.option("--store", default=None, help="Session store name (required in this preview).")
 @click.pass_obj
 def sessions_get(obj, session_id, store) -> None:
     """Get a session by id."""
+    if not store:
+        raise AgentCliError(
+            "Provide --store. Resolving a session by id alone is not supported in this preview."
+        )
     data = obj.client().get_session(session_id, store)
     if obj.output == "json":
         render.emit_json(data)
@@ -292,9 +304,11 @@ def sessions_update(obj, session_id, store, metadata) -> None:
 @click.argument("session_id")
 @click.option("--store", required=True)
 @click.option("--force", is_flag=True, help="Cascade-delete descendant sessions.")
+@click.option("--yes", "-y", is_flag=True, help="Skip the confirmation prompt.")
 @click.pass_obj
-def sessions_delete(obj, session_id, store, force) -> None:
+def sessions_delete(obj, session_id, store, force, yes) -> None:
     """Delete a session."""
+    render.confirm_destroy(f"session '{session_id}'", assume_yes=yes)
     obj.client().delete_session(store, session_id, force)
     if obj.output == "json":
         render.emit_json({"deleted": session_id})
@@ -303,17 +317,39 @@ def sessions_delete(obj, session_id, store, force) -> None:
 
 
 @sessions.command("fork")
+@click.argument("source_session_id_arg", required=False, metavar="[SOURCE_SESSION_ID]")
 @click.option("--store", required=True)
-@click.option("--source-session-id", required=True)
+@click.option(
+    "--source-session-id",
+    "source_session_id_opt",
+    default=None,
+    help="Source session to fork (or pass it as the positional argument).",
+)
 @click.option("--actor-id", required=True)
 @click.option("--up-to-item-id", default=None, help="Copy through this item id inclusively.")
 @click.option("--session-id", default=None, help="Optional id for the fork.")
 @click.option("--metadata", default=None)
 @click.pass_obj
 def sessions_fork(
-    obj, store, source_session_id, actor_id, up_to_item_id, session_id, metadata
+    obj,
+    source_session_id_arg,
+    store,
+    source_session_id_opt,
+    actor_id,
+    up_to_item_id,
+    session_id,
+    metadata,
 ) -> None:
     """Fork a session into a new independent top-level session."""
+    source_session_id = source_session_id_arg or source_session_id_opt
+    if not source_session_id:
+        raise AgentCliError(
+            "Provide the source session id (as the positional argument or --source-session-id)."
+        )
+    if source_session_id_arg and source_session_id_opt:
+        raise AgentCliError(
+            "Pass the source session id once — either positionally or via --source-session-id."
+        )
     data = obj.client().fork_session(
         store, source_session_id, actor_id, up_to_item_id, session_id, _parse_metadata(metadata)
     )

--- a/integrations/mason/tests/unit_tests/cli_ergonomics_test.py
+++ b/integrations/mason/tests/unit_tests/cli_ergonomics_test.py
@@ -64,9 +64,7 @@ def test_source_type_normalization():
 
 def test_entries_get_accepts_full_resource_name_without_store():
     client = _MemClient()
-    result = CliRunner().invoke(
-        entries, ["get", "memory-stores/S/entries/E"], obj=_Ctx(client)
-    )
+    result = CliRunner().invoke(entries, ["get", "memory-stores/S/entries/E"], obj=_Ctx(client))
     assert result.exit_code == 0, result.output
     assert ("get_entry", None, "memory-stores/S/entries/E") in client.calls
 
@@ -166,7 +164,9 @@ def test_fork_still_accepts_flag():
 
 def test_fork_missing_source_errors():
     client = _SessClient()
-    result = CliRunner().invoke(sessions, ["fork", "--store", "s", "--actor-id", "a"], obj=_Ctx(client))
+    result = CliRunner().invoke(
+        sessions, ["fork", "--store", "s", "--actor-id", "a"], obj=_Ctx(client)
+    )
     assert result.exit_code != 0
     assert client.calls == []
 

--- a/integrations/mason/tests/unit_tests/cli_ergonomics_test.py
+++ b/integrations/mason/tests/unit_tests/cli_ergonomics_test.py
@@ -1,0 +1,182 @@
+"""Unit tests for CLI ergonomics fixes: optional --store, friendly source-type,
+delete confirmation, flag aliases, sessions get guard, and fork positional arg."""
+
+from __future__ import annotations
+
+import pytest
+from click.testing import CliRunner
+
+from databricks_mason.errors import AgentCliError
+from databricks_mason.memory import _normalize_source_type, entries, stores
+from databricks_mason.sessions import sessions
+
+
+class _Ctx:
+    def __init__(self, client, output="text"):
+        self._client = client
+        self.output = output
+
+    def client(self):
+        return self._client
+
+
+class _MemClient:
+    host = "https://example.databricks.com"
+
+    def __init__(self):
+        self.calls = []
+
+    def create_memory_store(self, display_name, description=None):
+        self.calls.append(("create", display_name, description))
+        return {"name": "memory-stores/new", "display_name": display_name}
+
+    def delete_memory_store(self, name):
+        self.calls.append(("delete", name))
+        return {}
+
+    def get_memory_entry(self, store, entry):
+        self.calls.append(("get_entry", store, entry))
+        return {"name": entry, "path": "/p.md", "actor_id": "a"}
+
+    def delete_memory_entry(self, store, entry):
+        self.calls.append(("delete_entry", store, entry))
+        return {}
+
+
+# --- friendly source type ----------------------------------------------------
+
+
+def test_source_type_normalization():
+    assert _normalize_source_type("agent") == "MANAGED_MEMORY_ENTRY_SOURCE_TYPE_AGENT"
+    assert _normalize_source_type("AGENT") == "MANAGED_MEMORY_ENTRY_SOURCE_TYPE_AGENT"
+    assert _normalize_source_type(None) is None
+    # The full enum still passes through for backward compatibility.
+    assert (
+        _normalize_source_type("MANAGED_MEMORY_ENTRY_SOURCE_TYPE_AGENT")
+        == "MANAGED_MEMORY_ENTRY_SOURCE_TYPE_AGENT"
+    )
+    with pytest.raises(AgentCliError):
+        _normalize_source_type("bogus")
+
+
+# --- optional --store on entry commands (69227) ------------------------------
+
+
+def test_entries_get_accepts_full_resource_name_without_store():
+    client = _MemClient()
+    result = CliRunner().invoke(
+        entries, ["get", "memory-stores/S/entries/E"], obj=_Ctx(client)
+    )
+    assert result.exit_code == 0, result.output
+    assert ("get_entry", None, "memory-stores/S/entries/E") in client.calls
+
+
+def test_entries_get_bare_id_without_store_errors():
+    client = _MemClient()
+    result = CliRunner().invoke(entries, ["get", "bare-id"], obj=_Ctx(client))
+    assert result.exit_code != 0
+    assert "Provide --store" in result.output
+    assert client.calls == []  # never hit the API
+
+
+# --- delete confirmation (69234) ---------------------------------------------
+
+
+def test_store_delete_aborts_without_confirmation():
+    client = _MemClient()
+    result = CliRunner().invoke(stores, ["delete", "abc"], obj=_Ctx(client), input="n\n")
+    assert result.exit_code != 0  # aborted
+    assert client.calls == []
+
+
+def test_store_delete_proceeds_with_yes_flag():
+    client = _MemClient()
+    result = CliRunner().invoke(stores, ["delete", "abc", "--yes"], obj=_Ctx(client))
+    assert result.exit_code == 0, result.output
+    assert ("delete", "abc") in client.calls
+
+
+def test_entry_delete_confirms_with_short_flag():
+    client = _MemClient()
+    result = CliRunner().invoke(
+        entries, ["delete", "memory-stores/S/entries/E", "-y"], obj=_Ctx(client)
+    )
+    assert result.exit_code == 0, result.output
+    assert ("delete_entry", None, "memory-stores/S/entries/E") in client.calls
+
+
+# --- flag alias (69232) ------------------------------------------------------
+
+
+def test_memory_store_create_accepts_name_alias():
+    client = _MemClient()
+    result = CliRunner().invoke(stores, ["create", "--name", "acme"], obj=_Ctx(client))
+    assert result.exit_code == 0, result.output
+    assert ("create", "acme", None) in client.calls
+
+
+# --- sessions get guard (69231) ----------------------------------------------
+
+
+class _SessClient:
+    host = "https://example.databricks.com"
+
+    def __init__(self):
+        self.calls = []
+
+    def get_session(self, session_id, store=None):
+        self.calls.append(("get", session_id, store))
+        return {"session_id": session_id, "session_store_name": store}
+
+    def fork_session(self, store, source, actor_id, up_to=None, session_id=None, metadata=None):
+        self.calls.append(("fork", store, source, actor_id))
+        return {"session": {"session_id": "forked", "session_store_name": store}}
+
+
+def test_sessions_get_without_store_errors_clearly():
+    client = _SessClient()
+    result = CliRunner().invoke(sessions, ["get", "sid"], obj=_Ctx(client))
+    assert result.exit_code != 0
+    assert "Provide --store" in result.output
+    assert client.calls == []
+
+
+# --- fork positional source id (69233) ---------------------------------------
+
+
+def test_fork_accepts_positional_source_id():
+    client = _SessClient()
+    result = CliRunner().invoke(
+        sessions, ["fork", "src-sid", "--store", "s", "--actor-id", "a"], obj=_Ctx(client)
+    )
+    assert result.exit_code == 0, result.output
+    assert ("fork", "s", "src-sid", "a") in client.calls
+
+
+def test_fork_still_accepts_flag():
+    client = _SessClient()
+    result = CliRunner().invoke(
+        sessions,
+        ["fork", "--source-session-id", "src-sid", "--store", "s", "--actor-id", "a"],
+        obj=_Ctx(client),
+    )
+    assert result.exit_code == 0, result.output
+    assert ("fork", "s", "src-sid", "a") in client.calls
+
+
+def test_fork_missing_source_errors():
+    client = _SessClient()
+    result = CliRunner().invoke(sessions, ["fork", "--store", "s", "--actor-id", "a"], obj=_Ctx(client))
+    assert result.exit_code != 0
+    assert client.calls == []
+
+
+def test_fork_ambiguous_source_errors():
+    client = _SessClient()
+    result = CliRunner().invoke(
+        sessions,
+        ["fork", "pos-sid", "--source-session-id", "opt-sid", "--store", "s", "--actor-id", "a"],
+        obj=_Ctx(client),
+    )
+    assert result.exit_code != 0
+    assert client.calls == []


### PR DESCRIPTION
CLI usability fixes in the Mason CLI (ML-69227, ML-69230, ML-69231, ML-69232, ML-69233, ML-69234, ML-69235).

- **ML-69234** `memory stores/entries delete` and `sessions/sessions stores delete` now confirm before deleting, with `--yes/-y` to skip (via `render.confirm_destroy`).
- **ML-69227** `memory entries get/update/delete` accept a full entry resource name without `--store`; a bare id without `--store` errors clearly.
- **ML-69230** filled in blank flag help; `--source-type` accepts friendly `agent`/`unspecified` (full enum still works).
- **ML-69235** `memory entries list` help no longer claims content is omitted (JSON includes it; text omits it).
- **ML-69231** `sessions get` without `--store` errors clearly instead of contradicting its own help.
- **ML-69232** `memory stores create` accepts `--name`; `sessions stores create` accepts `--display-name`.
- **ML-69233** `sessions fork` accepts the source id positionally (flag still works).

Tests: `cli_ergonomics_test.py`. Full suite green; verified live.

This pull request and its description were written by Isaac.