### PR TITLE
[mason] tools/dev ergonomics: arg validation, idempotency, clearer errors

### DIFF
--- a/integrations/mason/src/databricks_mason/agent_project.py
+++ b/integrations/mason/src/databricks_mason/agent_project.py
@@ -291,7 +291,8 @@ class AgentProject:
         except FileNotFoundError as exc:
             raise AgentCliError(
                 f"Could not find agent.toml in {project_root}.",
-                hint="Run `mason init` or use a legacy compatibility command.",
+                hint="This command needs a Mason project. Run `mason init` to create one, "
+                "or point at an existing project with --source <dir>.",
             ) from exc
         except (OSError, ParseError) as exc:
             raise AgentCliError(f"Could not read agent manifest at {path}: {exc}.") from exc
@@ -334,7 +335,17 @@ class AgentProject:
                 continue
             if existing == spec:
                 return False
-            raise AgentCliError(f"Tool id {spec.id!r} already exists with different configuration.")
+
+            def _summary(s: ToolSpec) -> str:
+                src = s.source
+                return src.service or src.function or src.entrypoint or src.kind
+
+            raise AgentCliError(
+                f"Tool id {spec.id!r} already exists with a different configuration "
+                f"(existing: {_summary(existing)}; requested: {_summary(spec)}).",
+                hint="Use --name to add it under a different id, or remove the existing "
+                "tool from agent.toml first.",
+            )
         raw_tools = self._document.get("tools")
         if raw_tools is None:
             raw_tools = tomlkit.aot()

--- a/integrations/mason/src/databricks_mason/dev.py
+++ b/integrations/mason/src/databricks_mason/dev.py
@@ -96,7 +96,7 @@ def dev(
     app_yaml = source_dir / "app.yaml"
     if not app_yaml.exists():
         raise AgentCliError(
-            f"No app.yaml in '{source_dir}'.",
+            f"No app.yaml found at {app_yaml}.",
             hint="Run from a scaffolded project, or pass --source <dir> (see `mason init`).",
         )
 
@@ -156,5 +156,8 @@ def _dev_entry_point(app_yaml: pathlib.Path) -> Optional[pathlib.Path]:
         return None  # no index override present — run-local can use app.yaml directly
     doc["env"] = filtered
     dev_yaml = app_yaml.parent / ".mason-dev.app.yaml"
-    dev_yaml.write_text(yaml.safe_dump(doc, sort_keys=False))
+    try:
+        dev_yaml.write_text(yaml.safe_dump(doc, sort_keys=False))
+    except OSError as exc:
+        raise AgentCliError(f"Could not write {dev_yaml}: {exc}") from exc
     return dev_yaml

--- a/integrations/mason/src/databricks_mason/tools.py
+++ b/integrations/mason/src/databricks_mason/tools.py
@@ -30,7 +30,18 @@ def _default_id(resource: str) -> str:
     return _identifier(resource.rsplit(".", 1)[-1])
 
 
+def _require_arg(value: str, label: str) -> str:
+    """Reject an empty/whitespace positional argument with a clear message."""
+    if value is None or not value.strip():
+        raise AgentCliError(f"A {label} is required.")
+    return value
+
+
 def _source_value(spec: ToolSpec) -> str:
+    # For a sandbox tool, the useful detail is the allowed scopes, not the (constant)
+    # 'system.ai.sandbox' service name that duplicates the KIND column.
+    if spec.source.kind == "sandbox" and spec.policy.downscope:
+        return ", ".join(s.resource for s in spec.policy.downscope)
     return spec.source.service or spec.source.function or spec.source.entrypoint or spec.source.kind
 
 
@@ -213,6 +224,7 @@ def add_mcp(
     source: pathlib.Path,
 ) -> None:
     """Bind a Databricks managed MCP SERVICE."""
+    _require_arg(service, "managed MCP service name (e.g. system.ai.web_search)")
     _add_spec(
         obj,
         source.resolve(),
@@ -232,6 +244,7 @@ def add_uc_function(
     source: pathlib.Path,
 ) -> None:
     """Bind an existing three-part Unity Catalog function."""
+    _require_arg(function_name, "Unity Catalog function name (catalog.schema.function)")
     _add_spec(
         obj,
         source.resolve(),
@@ -248,6 +261,7 @@ def add_uc_function(
 @click.pass_obj
 def add_python(obj: Any, name: str, source: pathlib.Path) -> None:
     """Scaffold a framework-native local Python tool and starter test."""
+    _require_arg(name, "tool name")
     project = AgentProject.load(source)
     _require_runtime_adapter(project)
     function = _identifier(name)
@@ -259,7 +273,19 @@ def add_python(obj: Any, name: str, source: pathlib.Path) -> None:
     source_path = project.root / "agent" / "tools" / f"{function}.py"
     test_path = project.root / "tests" / "tools" / f"test_{function}.py"
     if existing == spec:
-        _emit_change(obj, project, spec, [])
+        # Manifest already declares this tool; recreate any scaffold files that went
+        # missing (deleted by the user) rather than silently no-op'ing.
+        missing = {}
+        if not source_path.exists():
+            missing[source_path] = _render_python_template(
+                _PYTHON_TOOL_TEMPLATE, module=function, function=function
+            )
+        if not test_path.exists():
+            missing[test_path] = _render_python_template(
+                _PYTHON_TEST_TEMPLATE, module=function, function=function
+            )
+        recreated = _write_new_files(missing) if missing else []
+        _emit_change(obj, project, spec, recreated)
         return
     if source_path.exists() or test_path.exists():
         existing_path = source_path if source_path.exists() else test_path

--- a/integrations/mason/tests/unit_tests/tools_dev_bugfix_test.py
+++ b/integrations/mason/tests/unit_tests/tools_dev_bugfix_test.py
@@ -1,0 +1,114 @@
+"""Unit tests for the tools/dev ergonomics fixes (ML-69251/69254/69255/69256/69258)."""
+
+from __future__ import annotations
+
+import pathlib
+
+from click.testing import CliRunner
+
+from databricks_mason.agent_project import AgentProject
+from databricks_mason.project_config import write_project_metadata
+from databricks_mason.tools import tools
+
+
+class _Ctx:
+    def __init__(self, output: str = "text"):
+        self.output = output
+
+
+def _project(tmp_path: pathlib.Path, framework: str = "langgraph") -> pathlib.Path:
+    project = tmp_path / f"agent-{framework}"
+    (project / "agent" / "tools").mkdir(parents=True)
+    (project / "tests" / "tools").mkdir(parents=True)
+    (project / "agent" / "mcps.py").write_text("ORIGINAL = True\n", encoding="utf-8")
+    write_project_metadata(project, framework=framework, template=f"agent-{framework}")
+    AgentProject.create(project, framework=framework).write()
+    return project
+
+
+# --- ML-69254: empty-arg validation -----------------------------------------
+
+
+def test_add_mcp_empty_service_is_rejected_clearly(tmp_path):
+    project = _project(tmp_path)
+    result = CliRunner().invoke(
+        tools, ["add", "mcp", "", "--source", str(project)], obj=_Ctx()
+    )
+    assert result.exit_code != 0
+    assert "managed MCP service name" in result.output and "is required" in result.output
+    # Not the cryptic identifier error.
+    assert "Could not derive a Python identifier" not in result.output
+
+
+def test_add_python_empty_name_is_rejected_clearly(tmp_path):
+    project = _project(tmp_path)
+    result = CliRunner().invoke(
+        tools, ["add", "python", "", "--source", str(project)], obj=_Ctx()
+    )
+    assert result.exit_code != 0
+    assert "tool name is required" in result.output
+
+
+# --- ML-69251: idempotency (recreate missing scaffold files) -----------------
+
+
+def test_add_python_recreates_deleted_scaffold_file(tmp_path):
+    project = _project(tmp_path)
+    r1 = CliRunner().invoke(tools, ["add", "python", "greet", "--source", str(project)], obj=_Ctx())
+    assert r1.exit_code == 0, r1.output
+    tool_file = project / "agent" / "tools" / "greet.py"
+    assert tool_file.exists()
+
+    tool_file.unlink()  # user deletes the scaffold file
+    r2 = CliRunner().invoke(tools, ["add", "python", "greet", "--source", str(project)], obj=_Ctx())
+    assert r2.exit_code == 0, r2.output
+    assert tool_file.exists(), "re-running add python should recreate the missing scaffold file"
+
+
+# --- ML-69258: tools list shows sandbox scopes in SOURCE ---------------------
+
+
+def test_tools_list_shows_sandbox_scopes_not_service(tmp_path):
+    project = _project(tmp_path)
+    CliRunner().invoke(
+        tools,
+        ["add", "sandbox", "--scope", "table:samples.nyctaxi.trips", "--source", str(project)],
+        obj=_Ctx(),
+    )
+    result = CliRunner().invoke(tools, ["list", "--source", str(project)], obj=_Ctx())
+    assert result.exit_code == 0, result.output
+    assert "table:samples.nyctaxi.trips" in result.output
+
+
+# --- ML-69256: outside-project hint ------------------------------------------
+
+
+def test_tools_add_outside_project_gives_clear_hint(tmp_path):
+    empty = tmp_path / "not-a-project"
+    empty.mkdir()
+    result = CliRunner().invoke(
+        tools, ["add", "mcp", "system.ai.web_search", "--source", str(empty)], obj=_Ctx()
+    )
+    assert result.exit_code != 0
+    assert "needs a Mason project" in result.output
+    assert "legacy compatibility command" not in result.output
+
+
+# --- ML-69255: conflict error names what differs -----------------------------
+
+
+def test_conflicting_tool_id_reports_what_differs(tmp_path):
+    project = _project(tmp_path)
+    CliRunner().invoke(
+        tools,
+        ["add", "mcp", "system.ai.web_search", "--name", "dup", "--source", str(project)],
+        obj=_Ctx(),
+    )
+    result = CliRunner().invoke(
+        tools,
+        ["add", "mcp", "system.ai.github", "--name", "dup", "--source", str(project)],
+        obj=_Ctx(),
+    )
+    assert result.exit_code != 0
+    # Shows both the existing and requested sources.
+    assert "system.ai.web_search" in result.output and "system.ai.github" in result.output

--- a/integrations/mason/tests/unit_tests/tools_dev_bugfix_test.py
+++ b/integrations/mason/tests/unit_tests/tools_dev_bugfix_test.py
@@ -31,9 +31,7 @@ def _project(tmp_path: pathlib.Path, framework: str = "langgraph") -> pathlib.Pa
 
 def test_add_mcp_empty_service_is_rejected_clearly(tmp_path):
     project = _project(tmp_path)
-    result = CliRunner().invoke(
-        tools, ["add", "mcp", "", "--source", str(project)], obj=_Ctx()
-    )
+    result = CliRunner().invoke(tools, ["add", "mcp", "", "--source", str(project)], obj=_Ctx())
     assert result.exit_code != 0
     assert "managed MCP service name" in result.output and "is required" in result.output
     # Not the cryptic identifier error.
@@ -42,9 +40,7 @@ def test_add_mcp_empty_service_is_rejected_clearly(tmp_path):
 
 def test_add_python_empty_name_is_rejected_clearly(tmp_path):
     project = _project(tmp_path)
-    result = CliRunner().invoke(
-        tools, ["add", "python", "", "--source", str(project)], obj=_Ctx()
-    )
+    result = CliRunner().invoke(tools, ["add", "python", "", "--source", str(project)], obj=_Ctx())
     assert result.exit_code != 0
     assert "tool name is required" in result.output
 


### PR DESCRIPTION
Fixes in the Mason CLI tools/dev surface (ML-69251, ML-69254, ML-69255, ML-69256, ML-69257, ML-69258).

- `tools add {mcp,uc-function,python}`: validate the positional arg is non-empty with a clear message instead of the cryptic "Could not derive a Python identifier from ".
- `tools add python`: on re-run, recreate scaffold files the user deleted instead of silently no-oping.