### PR TITLE
[mason] deploy: merge app resources, confirm destructive ops, validate names/stores

### DIFF
--- a/integrations/mason/src/databricks_mason/deploy.py
+++ b/integrations/mason/src/databricks_mason/deploy.py
@@ -67,11 +67,35 @@ def _app_compute_state(name: str, profile: Optional[str]) -> Optional[str]:
         return None
 
 
-def _wait_for_running(name: str, profile: Optional[str], timeout_s: int = 300) -> None:
-    """Block until a just-created app's compute is RUNNING (or raise on timeout).
+def _validate_deployment_name(name: str) -> str:
+    """Reject an empty or unsafe deployment name before it reaches a URL / workspace path."""
+    if (
+        not (name or "").strip()
+        or name != name.strip()
+        or any(token in name for token in ("/", "\\", ".."))
+        or any(character.isspace() for character in name)
+    ):
+        raise AgentCliError(
+            f"Invalid deployment name {name!r}.",
+            hint="Use a non-empty name of letters, digits, and hyphens "
+            "(no slashes, spaces, or '..').",
+        )
+    return name
 
-    `apps create` returns before compute is provisioned, but `apps deploy` requires RUNNING — so a
-    first deploy races without this wait.
+
+def _confirm_destroy(target: str, *, assume_yes: bool) -> None:
+    """Prompt before a destructive deployment op; --yes/-y skips it (for scripts)."""
+    if assume_yes:
+        return
+    if not click.confirm(f"{target}? This cannot be undone.", default=False):
+        raise click.Abort()
+
+
+def _wait_for_running(name: str, profile: Optional[str], timeout_s: int = 300) -> None:
+    """Block until a just-created app's compute is ACTIVE (or raise on timeout).
+
+    `apps create` returns before compute is provisioned, but `apps deploy` requires the app to be
+    ACTIVE — so a first deploy races without this wait.
     """
     deadline = time.monotonic() + timeout_s
     while time.monotonic() < deadline:
@@ -207,6 +231,16 @@ def resolve_store_env(
     if session_store:
         if create_stores:
             _ensure_session_store(client, session_store)
+        else:
+            # Validate existence up front so a typo fails at deploy time, not at runtime.
+            try:
+                client.get_session_store(session_store)
+            except AgentCliError as exc:
+                raise AgentCliError(
+                    f"Session store '{session_store}' does not exist "
+                    "(create it with --create-stores).",
+                    error_code=exc.error_code,
+                ) from exc
         env[_SESSION_ENV] = session_store
     if traces_destination:
         env[TRACES_DEST_ENV] = traces_destination
@@ -328,6 +362,7 @@ def deploy(
     workspace_path,
 ) -> None:
     """Deploy an agent: provision its stores, wire them in, and roll out the deployment."""
+    _validate_deployment_name(name)
     source_dir = pathlib.Path(source)
     client = obj.client()
 
@@ -470,6 +505,7 @@ def deployments_list(obj) -> None:
 @click.pass_obj
 def deployments_get(obj, name) -> None:
     """Get an agent deployment's details."""
+    _validate_deployment_name(name)
     result = _databricks(["apps", "get", name, "-o", "json"], obj.profile, capture=True)
     data = json.loads(result.stdout or "{}")
     if obj.output == "json":
@@ -495,6 +531,7 @@ def deployments_get(obj, name) -> None:
 @click.pass_obj
 def deployments_logs(obj, name) -> None:
     """Stream a deployment's logs."""
+    _validate_deployment_name(name)
     _databricks(["apps", "logs", name], obj.profile)
 
 
@@ -503,6 +540,7 @@ def deployments_logs(obj, name) -> None:
 @click.pass_obj
 def deployments_start(obj, name) -> None:
     """Start a deployment."""
+    _validate_deployment_name(name)
     _databricks(["apps", "start", name], obj.profile)
     if obj.output == "json":
         render.emit_json({"started": name})
@@ -512,9 +550,12 @@ def deployments_start(obj, name) -> None:
 
 @deployments.command("stop")
 @click.argument("name")
+@click.option("--yes", "-y", is_flag=True, help="Skip the confirmation prompt.")
 @click.pass_obj
-def deployments_stop(obj, name) -> None:
+def deployments_stop(obj, name, yes) -> None:
     """Stop a deployment."""
+    _validate_deployment_name(name)
+    _confirm_destroy(f"Stop deployment '{name}'", assume_yes=yes)
     _databricks(["apps", "stop", name], obj.profile)
     if obj.output == "json":
         render.emit_json({"stopped": name})
@@ -524,9 +565,12 @@ def deployments_stop(obj, name) -> None:
 
 @deployments.command("delete")
 @click.argument("name")
+@click.option("--yes", "-y", is_flag=True, help="Skip the confirmation prompt.")
 @click.pass_obj
-def deployments_delete(obj, name) -> None:
+def deployments_delete(obj, name, yes) -> None:
     """Delete a deployment."""
+    _validate_deployment_name(name)
+    _confirm_destroy(f"Delete deployment '{name}'", assume_yes=yes)
     _databricks(["apps", "delete", name], obj.profile)
     if obj.output == "json":
         render.emit_json({"deleted": name})

--- a/integrations/mason/src/databricks_mason/store_access.py
+++ b/integrations/mason/src/databricks_mason/store_access.py
@@ -80,9 +80,7 @@ class LakebaseBackend:
 
 def _current_app_resources(app: str, profile: Optional[str]) -> list[dict]:
     """Read the app's existing resources array (empty list if it can't be read)."""
-    result = _databricks(
-        ["apps", "get", app, "-o", "json"], profile, capture=True, check=False
-    )
+    result = _databricks(["apps", "get", app, "-o", "json"], profile, capture=True, check=False)
     if result.returncode != 0:
         return []
     try:

--- a/integrations/mason/src/databricks_mason/store_access.py
+++ b/integrations/mason/src/databricks_mason/store_access.py
@@ -78,15 +78,38 @@ class LakebaseBackend:
         }
 
 
+def _current_app_resources(app: str, profile: Optional[str]) -> list[dict]:
+    """Read the app's existing resources array (empty list if it can't be read)."""
+    result = _databricks(
+        ["apps", "get", app, "-o", "json"], profile, capture=True, check=False
+    )
+    if result.returncode != 0:
+        return []
+    try:
+        resources = json.loads(result.stdout or "{}").get("resources", [])
+    except (json.JSONDecodeError, AttributeError):
+        return []
+    return resources if isinstance(resources, list) else []
+
+
 def apply_postgres_resources(
     app: str, backends: list[LakebaseBackend], profile: Optional[str]
 ) -> Optional[str]:
     """Bind each backend's database as a `postgres` app resource in one update.
 
-    `apps update --json` replaces the whole resources array, so all needed backends must be applied
-    together. Returns None on success or a human-readable reason on failure.
+    `apps update --json` REPLACES the whole resources array, so we must send the complete set:
+    read the app's current resources, drop the ones we manage (matched by name) so re-deploys
+    update rather than duplicate them, keep every other (user-owned) resource, and append ours.
+    Returns None on success or a human-readable reason on failure.
     """
-    payload = {"resources": [b.postgres_resource() for b in backends]}
+    ours = [b.postgres_resource() for b in backends]
+    our_names = {r["name"] for r in ours}
+    preserved = [
+        r
+        for r in _current_app_resources(app, profile)
+        if isinstance(r, dict) and r.get("name") not in our_names
+    ]
+    payload = {"resources": preserved + ours}
     result = _databricks(
         ["apps", "update", app, "--json", json.dumps(payload)], profile, capture=True, check=False
     )

--- a/integrations/mason/tests/unit_tests/deploy_bugfix_test.py
+++ b/integrations/mason/tests/unit_tests/deploy_bugfix_test.py
@@ -10,6 +10,7 @@ import pytest
 from click.testing import CliRunner
 
 from databricks_mason import deploy as deploy_mod
+from databricks_mason import session_store_access
 from databricks_mason import store_access as sa
 from databricks_mason.errors import AgentCliError
 
@@ -70,7 +71,9 @@ def test_delete_proceeds_with_yes(monkeypatch):
 
 def test_resolve_store_env_validates_session_store_on_non_create_path():
     client = mock.Mock()
-    client.get_session_store.side_effect = AgentCliError("session store not found", error_code="NOT_FOUND")
+    client.get_session_store.side_effect = AgentCliError(
+        "session store not found", error_code="NOT_FOUND"
+    )
     with pytest.raises(AgentCliError) as exc:
         deploy_mod.resolve_store_env(
             client,
@@ -89,9 +92,8 @@ def test_resolve_store_env_validates_session_store_on_non_create_path():
 
 
 def test_apply_postgres_resources_preserves_existing_and_updates_ours(monkeypatch):
-    backend = types.SimpleNamespace(
-        postgres_resource=lambda: {"name": "postgres", "postgres": {"database": "db-new"}}
-    )
+    # A real (typed) backend; its postgres_resource() is named "postgres".
+    backend = session_store_access.backend("db-new")
     existing = {
         "resources": [
             {"name": "sql-warehouse", "sql_warehouse": {"id": "w1"}},  # user-owned, must survive
@@ -115,4 +117,4 @@ def test_apply_postgres_resources_preserves_existing_and_updates_ours(monkeypatc
     assert "sql-warehouse" in names  # preserved
     assert names.count("postgres") == 1  # not duplicated
     pg = next(r for r in payload["resources"] if r["name"] == "postgres")
-    assert pg["postgres"]["database"] == "db-new"  # updated to ours
+    assert "db-new" in pg["postgres"]["database"]  # updated to ours

--- a/integrations/mason/tests/unit_tests/deploy_bugfix_test.py
+++ b/integrations/mason/tests/unit_tests/deploy_bugfix_test.py
@@ -1,0 +1,118 @@
+"""Unit tests for the deploy bug fixes (ML-69245/69246/69248/69259)."""
+
+from __future__ import annotations
+
+import json
+import types
+from unittest import mock
+
+import pytest
+from click.testing import CliRunner
+
+from databricks_mason import deploy as deploy_mod
+from databricks_mason import store_access as sa
+from databricks_mason.errors import AgentCliError
+
+
+class _Ctx:
+    profile = "prof"
+    output = "text"
+
+
+# --- ML-69259 / 69247: deployment-name validation ---------------------------
+
+
+@pytest.mark.parametrize("bad", ["", "   ", "../../x", "a/b", "a b", "..", "with\ttab"])
+def test_validate_deployment_name_rejects_unsafe(bad):
+    with pytest.raises(AgentCliError):
+        deploy_mod._validate_deployment_name(bad)
+
+
+def test_validate_deployment_name_accepts_good():
+    assert deploy_mod._validate_deployment_name("mason-agent-1") == "mason-agent-1"
+
+
+def test_deployments_get_rejects_empty_name_without_calling_cli(monkeypatch):
+    called = []
+    monkeypatch.setattr(deploy_mod, "_databricks", lambda *a, **k: called.append(a))
+    result = CliRunner().invoke(deploy_mod.deployments_get, [""], obj=_Ctx())
+    assert result.exit_code != 0
+    assert "Invalid deployment name" in result.output
+    assert called == []  # never shelled out to `databricks apps get`
+
+
+# --- ML-69246: confirmation on destructive deployment ops --------------------
+
+
+def test_delete_aborts_without_confirmation(monkeypatch):
+    called = []
+    monkeypatch.setattr(deploy_mod, "_databricks", lambda *a, **k: called.append(a))
+    result = CliRunner().invoke(deploy_mod.deployments_delete, ["myapp"], obj=_Ctx(), input="n\n")
+    assert result.exit_code != 0  # aborted
+    assert called == []
+
+
+def test_delete_proceeds_with_yes(monkeypatch):
+    called = []
+    monkeypatch.setattr(
+        deploy_mod,
+        "_databricks",
+        lambda args, profile, **k: called.append(args)
+        or types.SimpleNamespace(returncode=0, stdout="", stderr=""),
+    )
+    result = CliRunner().invoke(deploy_mod.deployments_delete, ["myapp", "--yes"], obj=_Ctx())
+    assert result.exit_code == 0, result.output
+    assert called and called[0][:3] == ["apps", "delete", "myapp"]
+
+
+# --- ML-69248: session store pre-validation ----------------------------------
+
+
+def test_resolve_store_env_validates_session_store_on_non_create_path():
+    client = mock.Mock()
+    client.get_session_store.side_effect = AgentCliError("session store not found", error_code="NOT_FOUND")
+    with pytest.raises(AgentCliError) as exc:
+        deploy_mod.resolve_store_env(
+            client,
+            app="a",
+            memory_store=None,
+            session_store="ghost",
+            traces_destination=None,
+            traces_experiment=None,
+            create_stores=False,
+        )
+    assert "does not exist" in str(exc.value)
+    client.get_session_store.assert_called_once_with("ghost")
+
+
+# --- ML-69245: postgres resources are MERGED, not replaced -------------------
+
+
+def test_apply_postgres_resources_preserves_existing_and_updates_ours(monkeypatch):
+    backend = types.SimpleNamespace(
+        postgres_resource=lambda: {"name": "postgres", "postgres": {"database": "db-new"}}
+    )
+    existing = {
+        "resources": [
+            {"name": "sql-warehouse", "sql_warehouse": {"id": "w1"}},  # user-owned, must survive
+            {"name": "postgres", "postgres": {"database": "db-old"}},  # ours, must be replaced
+        ]
+    }
+    calls = {}
+
+    def fake_databricks(args, profile, **kw):
+        if args[:2] == ["apps", "get"]:
+            return types.SimpleNamespace(returncode=0, stdout=json.dumps(existing), stderr="")
+        # the update call
+        calls["update"] = args
+        return types.SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(sa, "_databricks", fake_databricks)
+    assert sa.apply_postgres_resources("myapp", [backend], "prof") is None
+
+    payload = json.loads(calls["update"][calls["update"].index("--json") + 1])
+    names = [r["name"] for r in payload["resources"]]
+    assert "sql-warehouse" in names  # preserved
+    assert names.count("postgres") == 1  # not duplicated
+    pg = next(r for r in payload["resources"] if r["name"] == "postgres")
+    assert pg["postgres"]["database"] == "db-new"  # updated to ours

--- a/integrations/mason/tests/unit_tests/deploy_test.py
+++ b/integrations/mason/tests/unit_tests/deploy_test.py
@@ -408,11 +408,11 @@ def test_lifecycle_commands_honor_json_output(monkeypatch):
         "_databricks",
         lambda args, profile, **kw: types.SimpleNamespace(returncode=0, stdout="", stderr=""),
     )
-    for command, key in (
-        (deploy_mod.deployments_start, "started"),
-        (deploy_mod.deployments_stop, "stopped"),
-        (deploy_mod.deployments_delete, "deleted"),
+    for command, key, args in (
+        (deploy_mod.deployments_start, "started", ["myapp"]),
+        (deploy_mod.deployments_stop, "stopped", ["myapp", "--yes"]),  # destructive: needs --yes
+        (deploy_mod.deployments_delete, "deleted", ["myapp", "--yes"]),
     ):
-        result = CliRunner().invoke(command, ["myapp"], obj=_JsonCtx())
+        result = CliRunner().invoke(command, args, obj=_JsonCtx())
         assert result.exit_code == 0, result.output
         assert json.loads(result.output) == {key: "myapp"}


### PR DESCRIPTION
Fixes in the Mason CLI deploy surface (ML-69245, ML-69246, ML-69247, ML-69248, ML-69259, ML-69260).

- **ML-69245 (Critical):** `apps update --json` replaces the whole resources array, so apply_postgres_resources now reads current resources, preserves user-owned ones, replaces only what it manages (by name), and sends the full merged array — instead of clobbering non-mason resources on redeploy.
- `deployments stop`/`delete` now confirm before acting, with `--yes/-y` to skip.
- deployment name is validated (non-empty; no slashes, spaces, or `..`) on deploy and all deployments subcommands.
- deploy validates `--with-session-store` exists on the non---create-stores path (memory was already validated).
- fix the _wait_for_running docstring (compute state is ACTIVE, not RUNNING).

Unit-tested (deploy_bugfix_test.py) AND live-verified on eng-ml-inference: deployed an app carrying a non-mason resource (probe-warehouse), deployed twice with a session store wired in via this build, and confirmed the warehouse survived and exactly one postgres resource was present after each deploy (old code would have dropped the warehouse). Test app + store torn down.

This pull request and its description were written by Isaac.