### PR TITLE
mason: include the chat app by default; clarify mason dev startup URL

### DIFF
--- a/integrations/mason/README.md
+++ b/integrations/mason/README.md
@@ -75,7 +75,7 @@ accessors (`store.name`) while remaining plain dicts underneath — so `store["n
 mason [-p <profile>] [-o text|json]
   login        [--profile P]
   logout
-  init         [--framework openai|langgraph] [--enable-chat-app]
+  init         [--framework openai|langgraph] [--disable-chat-app]
                [--profile P] [--repo URL] [--ref REF] [directory]
   dev          [--source PATH] [--prepare-environment] [--app-port PORT]
                [--with-memory-store N] [--with-session-store N]
@@ -164,17 +164,19 @@ arguments controlled by the model.
 
 ## Initialize the chat app demo
 
-The chat app is a LangGraph-specific init overlay, not a command that mutates an existing project:
+The chat app is a LangGraph-specific init overlay, not a command that mutates an existing project.
+It is included by default for `--framework langgraph`; pass `--disable-chat-app` to scaffold the
+API-only backend instead.
 
 ```sh
-mason init --framework langgraph --enable-chat-app \
+mason init --framework langgraph \
   --profile <profile> \
   ./my-agent
 cd ./my-agent
 uv run start-server
 ```
 
-`--enable-chat-app` always includes synchronous, SSE streaming, background polling, Session Store,
+The chat app always includes synchronous, SSE streaming, background polling, Session Store,
 Memory Store, HITL resume, Start App, Stop App, heartbeat, and recovery UI. There are no separate
 stop/crash flags. The base agent owns `agent/mason/durability.py`, `agent/mason/recovery.py`, and
 `agent/mason/long_running.py`; the framework-specific overlay only adds `ui/`, `runtime/ui.py`, the

--- a/integrations/mason/src/databricks_mason/dev.py
+++ b/integrations/mason/src/databricks_mason/dev.py
@@ -15,9 +15,13 @@ from typing import Optional
 import click
 import yaml
 
+from databricks_mason import render
 from databricks_mason.deploy import _upsert_manifest_env, resolve_store_env
 from databricks_mason.errors import AgentCliError
 from databricks_mason.store_access import _databricks
+
+# Default local port; `databricks apps run-local` listens here unless --app-port overrides it.
+_DEFAULT_APP_PORT = 8000
 
 # Env vars that pin a package index for the *deployed* Apps build (a cloud-only workaround, see
 # `mason deploy`). They point at an index the deploying environment can reach, which is not
@@ -133,8 +137,25 @@ def dev(
     if entry_point is not None:
         args += ["--entry-point", str(entry_point)]
 
+    # `run-local` prints a generic "go to http://localhost:<port>" line that points at the chat UI —
+    # misleading for an API-only project, which serves no page there (404). Print an accurate line up
+    # front, keyed on whether this project actually carries the chat-app overlay.
+    _announce_local_url(source_dir, app_port or _DEFAULT_APP_PORT)
+
     # Run in the project dir so run-local finds the app; stream output (no capture).
     _databricks(args, obj.profile, cwd=str(source_dir))
+
+
+def _announce_local_url(source_dir: pathlib.Path, port: int) -> None:
+    """Print how to reach the running app: the chat UI if present, else the API endpoint."""
+    base = f"http://localhost:{port}"
+    if (source_dir / "runtime" / "ui.py").is_file():
+        render.success("Starting agent", fields={"Chat UI": base})
+    else:
+        render.success(
+            "Starting API-only agent (no chat UI — see `mason init --help`)",
+            fields={"Invoke": f"POST {base}/invocations"},
+        )
 
 
 def _dev_entry_point(app_yaml: pathlib.Path) -> Optional[pathlib.Path]:

--- a/integrations/mason/src/databricks_mason/init.py
+++ b/integrations/mason/src/databricks_mason/init.py
@@ -164,9 +164,15 @@ def _write_env(dest: pathlib.Path, profile: str) -> bool:
     "immediately (defaults to the profile from -p / `mason login`).",
 )
 @click.option(
+    "--disable-chat-app",
+    is_flag=True,
+    help="Scaffold the API-only backend, without the browser chat app and stop/start durability demo.",
+)
+@click.option(
     "--enable-chat-app",
     is_flag=True,
-    help="Include the framework-specific browser chat app and stop/start durability demo.",
+    hidden=True,
+    help="Deprecated: the chat app is included by default; this flag is a no-op.",
 )
 @click.option("--repo", default=None, help="Override the git repo URL to fetch the template from.")
 @click.option("--ref", default=None, help="Override the branch, tag, or ref to fetch.")
@@ -176,6 +182,7 @@ def init(
     directory: Optional[str],
     framework: str,
     profile: Optional[str],
+    disable_chat_app: bool,
     enable_chat_app: bool,
     repo: Optional[str],
     ref: Optional[str],
@@ -189,11 +196,9 @@ def init(
     Pass --profile (or set a default via `mason login` / -p) to seed a local `.env` so the
     scaffolded project runs with `uv run start-server` right away.
     """
-    if enable_chat_app and framework not in _CHAT_APP_TEMPLATES:
-        raise AgentCliError(
-            f"--enable-chat-app is not available for framework '{framework}'.",
-            hint="Use --framework langgraph.",
-        )
+    # The chat app is included by default for frameworks that have one; --disable-chat-app opts out.
+    # (--enable-chat-app is a deprecated no-op kept for back-compat.)
+    chat_app_enabled = framework in _CHAT_APP_TEMPLATES and not disable_chat_app
 
     spec = _TEMPLATES[framework]
     template_path = spec["path"]
@@ -209,7 +214,7 @@ def init(
             hint="Choose a new directory or remove the existing one.",
         )
 
-    overlay_dirs = (_CHAT_APP_TEMPLATES[framework],) if enable_chat_app else ()
+    overlay_dirs = (_CHAT_APP_TEMPLATES[framework],) if chat_app_enabled else ()
     _fetch_template(
         repo or spec["repo"],
         ref or _template_ref(framework),
@@ -230,14 +235,14 @@ def init(
                 "framework": framework,
                 "template": template_name,
                 "directory": str(dest),
-                "chat_app_enabled": enable_chat_app,
+                "chat_app_enabled": chat_app_enabled,
                 "env_profile": env_profile if wrote_env else None,
             }
         )
         return
 
     fields = {"Framework": framework, "Directory": str(dest)}
-    if enable_chat_app:
+    if chat_app_enabled:
         fields["Chat app"] = "enabled"
     steps = [f"cd {dest}"]
     if wrote_env:
@@ -250,7 +255,7 @@ def init(
             "Set DATABRICKS_CONFIG_PROFILE in .env (or re-run `mason init --profile <profile>`)",
         ]
     steps += ["mason dev        # run locally"]
-    if enable_chat_app:
+    if chat_app_enabled:
         steps.append("Open http://localhost:8000")
     steps.append(f"mason deploy <name> --source {dest}")
     render.success(f"Scaffolded '{template_name}'", fields=fields, next_steps=steps)

--- a/integrations/mason/templates/agent-langgraph/README.md
+++ b/integrations/mason/templates/agent-langgraph/README.md
@@ -135,7 +135,8 @@ poll reaches the same replica, but the run itself does not survive a restart.
 
 ### Chat app state APIs
 
-When initialized with `mason init --framework langgraph --enable-chat-app`, the browser also calls:
+When initialized with the chat app (the default for `mason init --framework langgraph`, unless
+`--disable-chat-app` is passed), the browser also calls:
 
 - `POST /api/session/new` to generate a fresh session id and replace the routing cookie. The request
   has no body-level `session_id`; the response includes the new and previous ids.

--- a/integrations/mason/templates/ui/agent-langgraph/CHAT_APP.md
+++ b/integrations/mason/templates/ui/agent-langgraph/CHAT_APP.md
@@ -1,7 +1,8 @@
 # Mason LangGraph Chat App Overlay
 
-`mason init --framework langgraph --enable-chat-app` copies this framework-specific overlay after
-the base `agent-langgraph` template. It is intentionally not a post-generation mutation command.
+`mason init --framework langgraph` copies this framework-specific overlay after the base
+`agent-langgraph` template (it is included by default; `--disable-chat-app` opts out). It is
+intentionally not a post-generation mutation command.
 
 ## Installed files
 

--- a/integrations/mason/tests/unit_tests/dev_test.py
+++ b/integrations/mason/tests/unit_tests/dev_test.py
@@ -153,6 +153,28 @@ def test_dev_requires_app_yaml(tmp_path: pathlib.Path):
     db.assert_not_called()
 
 
+def test_dev_announces_chat_ui_when_overlay_present(tmp_path: pathlib.Path):
+    (tmp_path / "app.yaml").write_text("command: []\n")
+    (tmp_path / "runtime").mkdir()
+    (tmp_path / "runtime" / "ui.py").write_text("# chat UI\n")
+    with mock.patch.object(dev_mod, "_databricks"):
+        result = CliRunner().invoke(
+            dev_mod.dev, ["--source", str(tmp_path), "--app-port", "9000"], obj=_Ctx()
+        )
+    assert result.exit_code == 0, result.output
+    assert "Chat UI" in result.output
+    assert "http://localhost:9000" in result.output
+
+
+def test_dev_announces_api_endpoint_when_no_ui(tmp_path: pathlib.Path):
+    (tmp_path / "app.yaml").write_text("command: []\n")  # API-only: no runtime/ui.py
+    with mock.patch.object(dev_mod, "_databricks"):
+        result = CliRunner().invoke(dev_mod.dev, ["--source", str(tmp_path)], obj=_Ctx())
+    assert result.exit_code == 0, result.output
+    assert "API-only" in result.output
+    assert "http://localhost:8000/invocations" in result.output
+
+
 def test_dev_runs_from_project_containing_directly_edited_agent_manifest(
     tmp_path: pathlib.Path,
 ):

--- a/integrations/mason/tests/unit_tests/init_test.py
+++ b/integrations/mason/tests/unit_tests/init_test.py
@@ -203,7 +203,36 @@ def test_init_repo_ref_override(tmp_path: pathlib.Path):
     assert f.call_args.args[1] == "wip"
 
 
-def test_init_enable_chat_app_adds_langgraph_overlay(tmp_path: pathlib.Path):
+def test_init_langgraph_includes_chat_app_by_default(tmp_path: pathlib.Path):
+    dest = tmp_path / "chat"
+    with mock.patch.object(init_mod, "_fetch_template", side_effect=lambda *a: a[3].mkdir()) as f:
+        result = CliRunner().invoke(
+            init_mod.init,
+            ["--framework", "langgraph", str(dest)],
+            obj=_Ctx(),
+        )
+
+    assert result.exit_code == 0, result.output
+    assert f.call_args.args[4] == ("integrations/mason/templates/ui/agent-langgraph",)
+    assert "Chat app" in result.output
+
+
+def test_init_disable_chat_app_omits_langgraph_overlay(tmp_path: pathlib.Path):
+    dest = tmp_path / "api-only"
+    with mock.patch.object(init_mod, "_fetch_template", side_effect=lambda *a: a[3].mkdir()) as f:
+        result = CliRunner().invoke(
+            init_mod.init,
+            ["--framework", "langgraph", "--disable-chat-app", str(dest)],
+            obj=_Ctx(),
+        )
+
+    assert result.exit_code == 0, result.output
+    assert f.call_args.args[4] == ()  # no chat-app overlay
+    assert "Chat app" not in result.output
+
+
+def test_init_enable_chat_app_flag_is_accepted_no_op(tmp_path: pathlib.Path):
+    # Deprecated flag: kept so existing invocations don't break; chat app is on by default anyway.
     dest = tmp_path / "chat"
     with mock.patch.object(init_mod, "_fetch_template", side_effect=lambda *a: a[3].mkdir()) as f:
         result = CliRunner().invoke(
@@ -214,20 +243,17 @@ def test_init_enable_chat_app_adds_langgraph_overlay(tmp_path: pathlib.Path):
 
     assert result.exit_code == 0, result.output
     assert f.call_args.args[4] == ("integrations/mason/templates/ui/agent-langgraph",)
-    assert "Chat app" in result.output
 
 
-def test_init_enable_chat_app_rejects_unsupported_framework(tmp_path: pathlib.Path):
-    with mock.patch.object(init_mod, "_fetch_template") as fetched:
+def test_init_openai_has_no_chat_app(tmp_path: pathlib.Path):
+    dest = tmp_path / "proj"
+    with mock.patch.object(init_mod, "_fetch_template", side_effect=lambda *a: a[3].mkdir()) as f:
         result = CliRunner().invoke(
-            init_mod.init,
-            ["--framework", "openai", "--enable-chat-app", str(tmp_path / "chat")],
-            obj=_Ctx(),
+            init_mod.init, ["--framework", "openai", str(dest)], obj=_Ctx(output="json")
         )
-
-    assert result.exit_code != 0
-    assert "not available" in result.output
-    fetched.assert_not_called()
+    assert result.exit_code == 0, result.output
+    assert f.call_args.args[4] == ()  # openai framework has no chat-app overlay
+    assert json.loads(result.output)["chat_app_enabled"] is False
 
 
 def test_init_json_output(tmp_path: pathlib.Path):
@@ -241,7 +267,7 @@ def test_init_json_output(tmp_path: pathlib.Path):
     assert payload["framework"] == "langgraph"
     assert payload["template"] == "agent-langgraph"
     assert payload["directory"] == str(dest)
-    assert payload["chat_app_enabled"] is False
+    assert payload["chat_app_enabled"] is True
 
 
 def test_init_refuses_existing_destination(tmp_path: pathlib.Path):


### PR DESCRIPTION
Invert the chat-app default for `mason init --framework langgraph`: the browser chat app is now scaffolded by default, and `--disable-chat-app` opts out to the API-only backend. `--enable-chat-app` is kept as a hidden deprecated no-op so existing invocations don't break.

`mason dev` now prints its own accurate URL before handing off to `databricks apps run-local` — the chat UI URL when the project carries the UI overlay, or the POST /invocations endpoint for an API-only project — instead of letting the generic 'go to localhost' line mislead API-only users into a 404.


<img width="852" height="156" alt="Screenshot 2026-09-01 at 4 15 01 PM" src="https://github.com/user-attachments/assets/29299fc1-2e51-4aeb-b517-812ee7c0b51b" /> - no UI
