### PR TITLE
mason: grant store access over psycopg instead of the psql binary

### DIFF
--- a/integrations/mason/pyproject.toml
+++ b/integrations/mason/pyproject.toml
@@ -10,6 +10,7 @@ requires-python = ">=3.10"
 dependencies = [
     "click>=8.1",
     "databricks-sdk>=0.49",
+    "psycopg[binary]>=3.1",
     "PyYAML>=6.0",
     "rich>=13.7",
     "tomli>=2.0",

--- a/integrations/mason/src/databricks_mason/deploy.py
+++ b/integrations/mason/src/databricks_mason/deploy.py
@@ -411,7 +411,7 @@ def deploy(
         steps.insert(
             0,
             "The app's service principal needs read/write on its store tables; that grant couldn't "
-            "be applied automatically (it requires store ownership and psql). "
+            "be applied automatically (it requires store ownership). "
             f"Cause: {grant_error}",
         )
     if grants_stores and grant_error is None:

--- a/integrations/mason/src/databricks_mason/store_access.py
+++ b/integrations/mason/src/databricks_mason/store_access.py
@@ -4,7 +4,8 @@ A managed store (session or memory) is backed by a per-store Lakebase database i
 service-managed project. The store's tables are owned by whoever created the store (the deploying
 user), so giving the deployed app's service principal access takes TWO steps:
   1. a `postgres` app resource so the SP gets a Lakebase role and CONNECT on the database, and
-  2. a table GRANT (issued over psql as the store owner) so the SP can read/write the tables.
+  2. a table GRANT (issued over a Postgres connection as the store owner) so the SP can read/write
+     the tables.
 With only (1) the SP connects but hits "permission denied" on the tables; with only (2) it can't
 connect at all. Both are best-effort — deploy proceeds and reports if either step can't be applied.
 
@@ -15,11 +16,11 @@ supply the per-store project/schema/table specifics.
 from __future__ import annotations
 
 import json
-import os
-import shutil
 import subprocess
 from dataclasses import dataclass
 from typing import Optional
+
+import psycopg
 
 from databricks_mason.errors import AgentCliError
 
@@ -131,13 +132,13 @@ def _mint_token(backend: LakebaseBackend, profile: Optional[str]) -> Optional[st
 def grant_tables(
     backend: LakebaseBackend, sp_client_id: str, owner: str, profile: Optional[str]
 ) -> Optional[str]:
-    """Grant the app's SP read/write on the backend's tables (owner-issued, over psql).
+    """Grant the app's SP read/write on the backend's tables (owner-issued, over a pg connection).
 
-    Returns None on success, or a human-readable reason if the grant couldn't be applied. Deploy
-    proceeds regardless — the app runs, but the store's durable path fails until the SP has access.
+    Uses psycopg (a bundled dependency) rather than the psql binary so no system Postgres client is
+    required. Returns None on success, or a human-readable reason if the grant couldn't be applied.
+    Deploy proceeds regardless — the app runs, but the store's durable path fails until the SP has
+    access.
     """
-    if shutil.which("psql") is None:
-        return "psql not found on PATH (needed to grant the app SP access to the store)."
     host = _resolve_pg_host(backend, profile)
     if not host:
         return "could not resolve the store's Lakebase endpoint."
@@ -155,13 +156,20 @@ def grant_tables(
         f" ALTER DEFAULT PRIVILEGES IN SCHEMA {backend.schema}"
         f' GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO "{sp_client_id}";'
     )
-    conn = f"host={host} port=5432 dbname={backend.database} user={owner} sslmode=require"
-    result = subprocess.run(
-        ["psql", conn, "-v", "ON_ERROR_STOP=1", "-c", grants],
-        env={**os.environ, "PGPASSWORD": token},
-        text=True,
-        capture_output=True,
-    )
-    if result.returncode == 0:
-        return None
-    return (result.stderr or result.stdout or "").strip() or "unknown error"
+    try:
+        # The password token is scoped to this endpoint; the SP's role name is its client id.
+        with psycopg.connect(
+            host=host,
+            port=5432,
+            dbname=backend.database,
+            user=owner,
+            password=token,
+            sslmode="require",
+            autocommit=True,
+        ) as conn:
+            # Encode to bytes: the GRANT is composed at runtime (not a LiteralString), which the
+            # str overload of execute() rejects; the bytes overload takes a composed query as-is.
+            conn.execute(grants.encode())
+    except psycopg.Error as exc:
+        return str(exc).strip() or "unknown error"
+    return None

--- a/integrations/mason/tests/unit_tests/store_access_test.py
+++ b/integrations/mason/tests/unit_tests/store_access_test.py
@@ -1,9 +1,11 @@
-"""Unit tests for the store-access grant plumbing (postgres resource + owner-issued psql GRANT)."""
+"""Unit tests for the store-access grant plumbing (postgres resource + owner-issued GRANT)."""
 
 from __future__ import annotations
 
 import json
 import types
+
+import psycopg
 
 from databricks_mason import memory_store_access, session_store_access
 from databricks_mason import store_access as sa
@@ -46,35 +48,57 @@ def test_apply_postgres_resources_sends_all_backends_in_one_update(monkeypatch):
     assert names == {"postgres", "postgres-memory"}  # one update carries both
 
 
-def test_grant_tables_runs_scoped_psql_grant(monkeypatch):
-    monkeypatch.setattr(sa.shutil, "which", lambda _: "/usr/bin/psql")
+class _FakeConn:
+    """Stand-in for a psycopg connection: records the connect kwargs and executed SQL."""
+
+    def __init__(self, captured):
+        self._captured = captured
+
+    def execute(self, sql):
+        # store_access encodes the composed GRANT to bytes; decode so assertions read as text.
+        self._captured["sql"] = sql.decode() if isinstance(sql, bytes) else sql
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+
+def test_grant_tables_runs_scoped_grant_over_psycopg(monkeypatch):
     monkeypatch.setattr(sa, "_resolve_pg_host", lambda b, p: "ep-x.databricks.com")
     monkeypatch.setattr(sa, "_mint_token", lambda b, p: "tok")
     captured = {}
 
-    def fake_run(cmd, env=None, **kw):
-        captured["cmd"] = cmd
-        captured["pgpassword"] = (env or {}).get("PGPASSWORD")
-        return types.SimpleNamespace(returncode=0, stdout="GRANT", stderr="")
+    def fake_connect(**kwargs):
+        captured["connect"] = kwargs
+        return _FakeConn(captured)
 
-    monkeypatch.setattr(sa.subprocess, "run", fake_run)
+    monkeypatch.setattr(sa.psycopg, "connect", fake_connect)
 
     err = sa.grant_tables(memory_store_access.backend("memory-x"), "sp-1", "me@x.com", "prof")
 
     assert err is None
-    assert captured["cmd"][0] == "psql"
-    assert "dbname=memory-x" in captured["cmd"][1]  # connects to the per-store database
-    assert captured["pgpassword"] == "tok"
-    sql = captured["cmd"][-1]
+    assert captured["connect"]["dbname"] == "memory-x"  # connects to the per-store database
+    assert captured["connect"]["password"] == "tok"
+    assert captured["connect"]["user"] == "me@x.com"
+    assert captured["connect"]["autocommit"] is True  # DDL applies without an explicit commit
+    sql = captured["sql"]
     # tables are schema-qualified so the SP's search_path doesn't matter.
     assert 'ON memory.memory_entries TO "sp-1"' in sql
     assert "USAGE ON SCHEMA memory" in sql
 
 
-def test_grant_tables_reports_missing_psql(monkeypatch):
-    monkeypatch.setattr(sa.shutil, "which", lambda _: None)
+def test_grant_tables_reports_connection_error(monkeypatch):
+    monkeypatch.setattr(sa, "_resolve_pg_host", lambda b, p: "ep-x.databricks.com")
+    monkeypatch.setattr(sa, "_mint_token", lambda b, p: "tok")
+
+    def fake_connect(**kwargs):
+        raise psycopg.OperationalError("connection refused")
+
+    monkeypatch.setattr(sa.psycopg, "connect", fake_connect)
     err = sa.grant_tables(session_store_access.backend("s"), "sp", "me@x.com", "prof")
-    assert err is not None and "psql" in err
+    assert err is not None and "connection refused" in err
 
 
 def test_resolve_pg_host_reads_endpoint(monkeypatch):


### PR DESCRIPTION
Removes the system psql dependency for store deploys by issuing the owner GRANT through psycopg (a bundled dependency), so no Postgres client needs to be on PATH.