### PR TITLE
mason: add an OpenAI Agents SDK template mirroring agent-langgraph

### DIFF
--- a/integrations/mason/pyproject.toml
+++ b/integrations/mason/pyproject.toml
@@ -21,14 +21,25 @@ dependencies = [
 tracing = [
     "mlflow[databricks]>=3.9.0",
 ]
-# The agent-side runtime helpers (databricks_mason.runtime) that a deployed agent imports. Kept as
-# an extra so a plain `pip install databricks-mason` (the CLI) stays light; the template depends on
-# `databricks-mason[runtime]`.
+# The agent-side runtime helpers a deployed agent imports. Kept as extras so a plain
+# `pip install databricks-mason` (the CLI) stays light; each template depends on the extra for its
+# framework. `runtime` = the LangGraph adapter (databricks_mason.langgraph); `runtime-openai` = the
+# OpenAI Agents SDK adapter (databricks_mason.openai). Both carry the shared framework-neutral stack
+# (databricks_mason.runtime); the framework SDKs differ, so an agent installs only the one it uses.
 runtime = [
     "databricks-langchain>=0.17.0",
     "langgraph>=1.1.0",
     "langchain>=1.0.0",
     "langchain-mcp-adapters>=0.2.1",
+    "fastapi>=0.129.0",
+    "mlflow>=3.10.1",
+    "uuid-utils>=0.10.0",
+    "opentelemetry-exporter-otlp-proto-grpc>=1.25.0",
+    "databricks-agents>=1.9.3",
+]
+runtime-openai = [
+    "openai-agents>=0.4.1",
+    "databricks-openai>=0.13.0",
     "fastapi>=0.129.0",
     "mlflow>=3.10.1",
     "uuid-utils>=0.10.0",

--- a/integrations/mason/src/databricks_mason/init.py
+++ b/integrations/mason/src/databricks_mason/init.py
@@ -27,16 +27,17 @@ from databricks_mason.errors import AgentCliError
 from databricks_mason.project_config import write_project_metadata
 
 # Each framework's template has its own home: the git repo, ref, and path-within-repo to fetch.
-# (The two basic templates currently live in different repos; this keeps each pointed at its own.)
+# Both basic templates live in this repo, versioned in lockstep with the CLI (see below).
 # `--repo` / `--ref` override the repo/ref here, e.g. to pull from a fork or branch before merge.
+_MASON_REPO = "https://github.com/databricks/databricks-ai-bridge.git"
 _TEMPLATES: dict[str, dict[str, str]] = {
     "openai": {
-        "repo": "https://github.com/databricks/app-templates.git",
+        "repo": _MASON_REPO,
         "ref": "main",
-        "path": "agent-openai-basic",
+        "path": "integrations/mason/templates/agent-openai",
     },
     "langgraph": {
-        "repo": "https://github.com/databricks/databricks-ai-bridge.git",
+        "repo": _MASON_REPO,
         "ref": "main",
         "path": "integrations/mason/templates/agent-langgraph",
     },
@@ -46,13 +47,14 @@ _TEMPLATES: dict[str, dict[str, str]] = {
 # they produce pins `databricks-mason[runtime]` at this package's version, so init fetches the
 # template tagged for the installed CLI (see `_template_ref`) rather than `main`. That keeps a
 # user's scaffold from outrunning the `databricks-mason` they have installed.
-_VERSIONED_TEMPLATES = frozenset({"langgraph"})
+_VERSIONED_TEMPLATES = frozenset({"langgraph", "openai"})
 
 # The release workflow tags each published version `databricks-mason-v<version>`.
 _RELEASE_TAG_PREFIX = "databricks-mason-v"
 
 _CHAT_APP_TEMPLATES = {
     "langgraph": "integrations/mason/templates/ui/agent-langgraph",
+    "openai": "integrations/mason/templates/ui/agent-openai",
 }
 
 

--- a/integrations/mason/src/databricks_mason/openai/__init__.py
+++ b/integrations/mason/src/databricks_mason/openai/__init__.py
@@ -1,0 +1,89 @@
+"""OpenAI Agents SDK adapter for running an agent on Databricks (installed via ``databricks-mason[runtime-openai]``).
+
+Composable pieces you drop into an existing OpenAI Agents SDK agent — a session store, MCP servers
+declared in ``agent.toml``, long-term memory tools, and MLflow tracing. Each maps onto a slot the
+Agents SDK already has, so migrating an existing agent is a graft, not a rewrite::
+
+    from databricks_mason.openai import (
+        session_store,
+        mcp_servers,
+        memory_tools,
+        configure_tracing,
+    )
+
+    configure_tracing()
+    agent = Agent(
+        name="Agent",
+        model="databricks-gpt-5-2",
+        tools=[*your_tools, *memory_tools()],
+        mcp_servers=await mcp_servers(),  # your agent.toml servers + any you pass
+    )
+    result = await Runner.run(agent, messages, session=session_store(session_id))
+
+These need the agent stack (openai-agents, databricks-openai, mlflow), so they sit behind the
+``[runtime-openai]`` extra to keep a plain ``databricks-mason`` CLI install light.
+
+``__all__`` is the curated surface. Other entry points (``DatabricksSessionStore``) are reachable by
+their submodule paths but not re-exported here.
+"""
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from databricks_mason.openai.mcp import mcp_servers
+    from databricks_mason.openai.memory import memory_tools, recall, remember
+    from databricks_mason.openai.sessions import session_store
+    from databricks_mason.runtime import tag_session, workspace_client, workspace_headers
+
+
+def configure_tracing() -> None:
+    """Enable MLflow tracing with OpenAI autologging. Call once at startup.
+
+    Safe to call unconditionally — tracing turns on only when the MLflow destination and experiment
+    are configured in the environment (see :func:`databricks_mason.runtime.configure_tracing`).
+    """
+    import mlflow
+
+    from databricks_mason.runtime import configure_tracing as _configure_tracing
+
+    _configure_tracing(autolog=mlflow.openai.autolog)
+
+
+__all__ = [
+    # MCP servers from agent.toml (plus any you pass) — hand them to Agent(mcp_servers=...).
+    "mcp_servers",
+    # Long-term memory tools (opt-in via AGENT_MEMORY_STORE) — add to your tool list.
+    "memory_tools",
+    "remember",
+    "recall",
+    # Session persistence — pass session_store(session_id) to Runner.run(session=...).
+    "session_store",
+    # MLflow tracing (OpenAI autolog bound in) — call configure_tracing() once at startup.
+    "configure_tracing",
+    "tag_session",
+    # Workspace SDK client construction.
+    "workspace_client",
+    "workspace_headers",
+]
+
+# Re-exports resolved lazily (PEP 562) so importing one submodule (e.g. ``.mcp``) does not eagerly
+# pull in the others' dependencies. ``configure_tracing`` is defined above (binds OpenAI autolog).
+_MODULE_BY_NAME = {
+    "mcp_servers": "databricks_mason.openai.mcp",
+    "memory_tools": "databricks_mason.openai.memory",
+    "remember": "databricks_mason.openai.memory",
+    "recall": "databricks_mason.openai.memory",
+    "session_store": "databricks_mason.openai.sessions",
+    "tag_session": "databricks_mason.runtime",
+    "workspace_client": "databricks_mason.runtime",
+    "workspace_headers": "databricks_mason.runtime",
+}
+
+
+def __getattr__(name: str) -> object:
+    module = _MODULE_BY_NAME.get(name)
+    if module is None:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+    import importlib
+
+    return getattr(importlib.import_module(module), name)

--- a/integrations/mason/src/databricks_mason/openai/mcp.py
+++ b/integrations/mason/src/databricks_mason/openai/mcp.py
@@ -1,0 +1,94 @@
+"""Build MCP servers for the agent from the ones declared in ``agent.toml`` (plus any the agent adds).
+
+``mcp_servers()`` is the entry point: it reads the MCP servers declared in ``agent.toml``
+(sandbox/mcp + uc_function) and returns Agents SDK ``McpServer`` objects, with sandbox downscoping
+applied. Hand them to ``Agent(mcp_servers=...)``; the Agents SDK connects and lists their tools
+lazily inside ``Runner.run``. An agent with its own hand-built servers passes them as
+``extra_servers``; leaving ``agent.toml`` empty simply yields no declared servers. Typical use::
+
+    servers = await mcp_servers()  # just the agent.toml servers
+    servers = await mcp_servers(build_mcp_servers())  # agent.toml servers + the agent's own
+
+Unlike a fetch-once tool list, these are connection objects: open them for the life of the request
+(e.g. via ``AsyncExitStack``), because the SDK lists each server's tools only when the run needs them.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from databricks_openai.agents import McpServer
+
+from databricks_mason.runtime.tool_manifest import ToolRecord, downscope_wire, load_tools
+from databricks_mason.runtime.workspace import workspace_client
+
+logger = logging.getLogger(__name__)
+
+_FRAMEWORK = "openai"
+
+
+class _DownscopedMcpServer(McpServer):
+    """An ``McpServer`` that injects a sandbox downscope into every ``call_tool``.
+
+    The Databricks sandbox MCP applies the downscope from the call's ``_meta``; the Agents SDK does
+    not surface a per-call hook, so bind the manifest's downscope to the server and add it on each
+    invocation. Only sandbox bindings need this — plain MCP / UC-function servers use the base class.
+    """
+
+    def __init__(self, *args: Any, downscope: dict[str, Any], **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+        self._downscope = downscope
+
+    async def call_tool(self, tool_name, arguments, **kwargs):
+        meta = {**(kwargs.pop("meta", None) or {}), "downscope": self._downscope}
+        return await super().call_tool(tool_name, arguments, meta=meta, **kwargs)
+
+
+def _server_from_tool(tool: ToolRecord) -> McpServer | None:
+    client = workspace_client()
+    host = client.config.host.rstrip("/")
+    if tool.kind in {"sandbox", "mcp"}:
+        url = f"{host}/ai-gateway/mcp-services/{tool.service}"
+        if tool.kind == "sandbox":
+            return _DownscopedMcpServer(
+                url=url,
+                name=tool.id,
+                workspace_client=client,
+                timeout=120.0,
+                downscope=downscope_wire(tool),
+            )
+        return McpServer(url=url, name=tool.id, workspace_client=client, timeout=120.0)
+    if tool.kind == "uc_function":
+        catalog, schema, function_name = (tool.function or "").split(".")
+        return McpServer.from_uc_function(
+            catalog=catalog,
+            schema=schema,
+            function_name=function_name,
+            name=tool.id,
+            workspace_client=client,
+            timeout=120.0,
+        )
+    return None
+
+
+def _declared_servers() -> list[McpServer]:
+    """The MCP servers declared in the agent's ``agent.toml`` (may be empty)."""
+    tools = load_tools(expected_framework=_FRAMEWORK)
+    return [server for tool in tools if (server := _server_from_tool(tool)) is not None]
+
+
+async def mcp_servers(extra_servers: list[McpServer] | None = None) -> list[McpServer]:
+    """Build the agent's MCP servers (with sandbox downscoping). Fail-open to ``[]``.
+
+    Includes the MCP servers declared in ``agent.toml``; pass ``extra_servers`` to add servers the
+    agent builds itself. Returns an empty list when there are no servers or construction fails, so it
+    is safe to spread straight into ``Agent(mcp_servers=...)``. The SDK connects and lists each
+    server's tools lazily during the run — health-check them at connect time if one bad server must
+    not fail the whole request.
+    """
+    try:
+        return [*_declared_servers(), *(extra_servers or [])]
+    except Exception:
+        logger.warning("Failed to build MCP servers; continuing without them.", exc_info=True)
+        return []

--- a/integrations/mason/src/databricks_mason/openai/memory.py
+++ b/integrations/mason/src/databricks_mason/openai/memory.py
@@ -1,0 +1,63 @@
+"""Long-term memory tools — opt-in, gated on ``AGENT_MEMORY_STORE``.
+
+Unlike the session store (short-term transcript for one conversation), long-term memory is exposed
+to the model as two tools — ``remember`` and ``recall`` — over the Databricks managed memory store's
+``agents/v1`` entries API. Facts persist across conversations.
+
+``memory_tools()`` returns the tools when ``AGENT_MEMORY_STORE`` is set, else an empty list, so the
+model never sees them when memory is unconfigured. The agent composes them into its tool list. This
+is a stand-in for a future ``databricks-openai`` memory helper — when the SDK provides one, swap the
+import in ``agent.py`` and delete this file.
+
+Memory entries are per-actor. This uses the store name as the actor id, giving the agent one shared
+long-term memory; change ``_actor_id`` to scope per user (e.g. from request context) if needed.
+"""
+
+import os
+
+from agents import FunctionTool, function_tool
+
+from databricks_mason.runtime.workspace import workspace_client
+
+_AGENTS_V1 = "/api/agents/v1"
+
+
+def _actor_id() -> str:
+    return os.getenv("AGENT_MEMORY_ACTOR_ID", "agent")
+
+
+def _store_path() -> str:
+    return f"{_AGENTS_V1}/memory-stores/{os.environ['AGENT_MEMORY_STORE']}"
+
+
+def _api():
+    # Build the client lazily (needs workspace auth) so importing this module stays cheap.
+    return workspace_client().api_client
+
+
+@function_tool
+def remember(fact: str, topic: str) -> str:
+    """Persist a durable fact about the user in long-term memory."""
+    _api().do(
+        "POST",
+        f"{_store_path()}/entries",
+        body={"actor_id": _actor_id(), "path": f"/{topic}/{fact[:8]}.md", "content": fact},
+    )
+    return "stored"
+
+
+@function_tool
+def recall(query: str) -> str:
+    """Search the user's long-term memory for facts relevant to the query."""
+    data = _api().do(
+        "POST",
+        f"{_store_path()}/entries:search",
+        body={"actor_id": _actor_id(), "query": query, "limit": 5},
+    )
+    entries = data.get("managed_memory_entries") or []
+    return "\n".join(f"- {e.get('content')}" for e in entries) or "No relevant memories."
+
+
+def memory_tools() -> list[FunctionTool]:
+    """The long-term-memory tools when ``AGENT_MEMORY_STORE`` is set, else none."""
+    return [remember, recall] if os.getenv("AGENT_MEMORY_STORE") else []

--- a/integrations/mason/src/databricks_mason/openai/sessions.py
+++ b/integrations/mason/src/databricks_mason/openai/sessions.py
@@ -1,0 +1,159 @@
+"""Conversation session store for the agent.
+
+The OpenAI Agents SDK persists conversation state through a **Session** — an object with
+``get_items``/``add_items``/``pop_item``/``clear_session`` over a list of Responses input items.
+``Runner.run(..., session=session_store(session_id))`` reads prior turns from it and appends the new
+ones. ``session_store(session_id)`` returns the Session for a given conversation.
+
+Default (no config): an in-process ``SQLiteSession`` backed by ``:memory:``, cached per session id —
+multi-turn history is preserved within a single running process, no database. It does NOT survive
+restarts or span replicas.
+
+Durable (``AGENT_SESSION_STORE`` set): a ``DatabricksSessionStore``. Instead of a database the app
+connects to directly, it stores each Responses item as one **session item** through the managed
+Session Store REST API (over RPCs only — no Lakebase/Postgres connection), so the transcript is
+durable across restarts and replicas. Setting the env var is the only change; the agent code is
+identical.
+
+Note — unlike the LangGraph checkpointer, a Session persists only the conversation transcript, not
+paused human-in-the-loop run state. Durable HITL would need the paused ``RunState`` stashed
+separately; ``agent.py`` keeps pending runs in-process only (see ``PendingRuns``).
+
+The durable store uses a vendored REST client (``session_store_client.py``) so the template needs no
+unpublished dependency; swap it for the published package when it lands.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any, Optional
+
+from agents import SQLiteSession, TResponseInputItem
+from agents.memory import SessionABC
+
+from databricks_mason.runtime.session_store_client import Session as _StoreSession
+from databricks_mason.runtime.session_store_client import SessionStoreClient
+
+_SESSION_STORE_ENV = "AGENT_SESSION_STORE"
+_SESSION_ACTOR_ENV = "AGENT_SESSION_ACTOR_ID"
+
+# Fetch items oldest-first so the transcript replays in write order.
+_ORDER_BY = "create_time asc"
+
+# One in-process Session per session id, built lazily and shared — that's what makes multi-turn work
+# in-process (the durable store needs no cache; each call resolves the same REST-backed session).
+_local_sessions: dict[str, SQLiteSession] = {}
+
+
+def _session_actor(session_id: str) -> str:
+    """Actor partition for the durable store. Defaults to the session id (one actor per session)."""
+    return os.getenv(_SESSION_ACTOR_ENV) or session_id
+
+
+def session_store(session_id: str) -> SessionABC:
+    """The Session the agent persists conversation state to for ``session_id``.
+
+    In-memory ``SQLiteSession`` by default; a durable ``DatabricksSessionStore`` when
+    ``AGENT_SESSION_STORE`` names a managed Session Store.
+    """
+    store = os.getenv(_SESSION_STORE_ENV)
+    if store:
+        return DatabricksSessionStore(session_id, store, actor_id=_session_actor(session_id))
+    cached = _local_sessions.get(session_id)
+    if cached is None:
+        cached = SQLiteSession(session_id)  # ":memory:" — process-local, non-durable
+        _local_sessions[session_id] = cached
+    return cached
+
+
+class DatabricksSessionStore(SessionABC):
+    """An Agents SDK ``Session`` over the Databricks Session Store REST API.
+
+    Each Responses input item is stored as one Session Store item whose ``data`` is the item dict
+    (opaque JSON to the store). ``get_items`` replays them in write order; ``pop_item`` and
+    ``clear_session`` are supported for the SDK's retry rollback path. The session is created on first
+    use (get-or-create), keyed by the conversation's ``session_id`` under the configured actor.
+    """
+
+    def __init__(
+        self,
+        session_id: str,
+        session_store_name: str,
+        *,
+        actor_id: str,
+        client: Optional[SessionStoreClient] = None,
+        workspace_client: Optional[Any] = None,
+    ) -> None:
+        if not session_store_name:
+            raise ValueError("session_store_name is required")
+        self.session_id = session_id
+        self._actor_id = actor_id
+        self._client = (client or SessionStoreClient(workspace_client)).set_session_store(
+            session_store_name
+        )
+        self._session: _StoreSession | None = None
+
+    async def get_items(self, limit: int | None = None) -> list[TResponseInputItem]:
+        items = await _run_sync(self._read_items)
+        return items[-limit:] if limit is not None else items
+
+    async def add_items(self, items: list[TResponseInputItem]) -> None:
+        if not items:
+            return
+        await _run_sync(lambda: self._client.append_items(self._resolve(), items=list(items)))
+
+    async def pop_item(self) -> TResponseInputItem | None:
+        # The REST store has no pop; re-list, clear, and re-append all but the last. Only used on the
+        # SDK's best-effort retry rollback, so the extra round-trip is acceptable and rare.
+        def _pop() -> TResponseInputItem | None:
+            items = self._read_items()
+            if not items:
+                return None
+            session = self._resolve()
+            self._client.clear_items(session)
+            if items[:-1]:
+                self._client.append_items(session, items=items[:-1])
+            return items[-1]
+
+        return await _run_sync(_pop)
+
+    async def clear_session(self) -> None:
+        await _run_sync(lambda: self._client.clear_items(self._resolve()))
+
+    # ----- internals ----------------------------------------------------------
+
+    def _resolve(self) -> _StoreSession:
+        if self._session is not None:
+            return self._session
+        try:
+            self._session = self._client.get_session(session_id=self.session_id)
+        except tuple(_not_found_errors()) as _:  # type: ignore[misc]
+            self._session = self._client.create_session(
+                actor_id=self._actor_id,
+                session_id=self.session_id,
+                metadata={"client": "mason-openai-agent"},
+            )
+        return self._session
+
+    def _read_items(self) -> list[TResponseInputItem]:
+        return [item.data for item in self._client.list_items(self._resolve(), order_by=_ORDER_BY)]
+
+
+def _not_found_errors() -> tuple[type, ...]:
+    """Exception types that mean 'session does not exist yet'."""
+    try:
+        from databricks.sdk.errors import NotFound
+
+        return (NotFound,)
+    except ImportError:  # pragma: no cover - SDK always present in practice
+        return (_SessionNotFound,)
+
+
+class _SessionNotFound(Exception):
+    """Fallback 'not found' used only when databricks.sdk is unavailable."""
+
+
+async def _run_sync(fn):
+    import asyncio
+
+    return await asyncio.get_running_loop().run_in_executor(None, fn)

--- a/integrations/mason/src/databricks_mason/tools.py
+++ b/integrations/mason/src/databricks_mason/tools.py
@@ -75,17 +75,22 @@ def _emit_change(
 
 
 def _add_spec(obj: Any, source: pathlib.Path, spec: ToolSpec) -> None:
+    # mcp / uc_function / sandbox are framework-neutral agent.toml entries — every runtime adapter
+    # reads them from the manifest — so they are added regardless of framework. Only `add python`
+    # scaffolds framework-specific code (see add_python) and is gated separately.
     project = AgentProject.load(source)
-    _require_runtime_adapter(project)
     changed = project.add_tool(spec)
     changed_files = [project.write()] if changed else []
     _emit_change(obj, project, spec, changed_files)
 
 
-def _require_runtime_adapter(project: AgentProject) -> None:
+def _require_python_tool_support(project: AgentProject) -> None:
+    # `tools add python` scaffolds a framework-native tool file; only the LangGraph template is
+    # supported so far (the OpenAI template's tools use @function_tool — a follow-up).
     if project.framework != "langgraph":
         raise AgentCliError(
-            f"Mason tools supports only the 'langgraph' framework; found {project.framework!r}."
+            f"Mason `tools add python` supports only the 'langgraph' framework; "
+            f"found {project.framework!r}."
         )
 
 
@@ -268,7 +273,7 @@ def add_python(obj: Any, name: str, source: pathlib.Path) -> None:
     """Scaffold a framework-native local Python tool and starter test."""
     _require_arg(name, "tool name")
     project = AgentProject.load(source)
-    _require_runtime_adapter(project)
+    _require_python_tool_support(project)
     function = _identifier(name)
     spec = ToolSpec.python(
         name,

--- a/integrations/mason/templates/agent-openai/.env.example
+++ b/integrations/mason/templates/agent-openai/.env.example
@@ -1,0 +1,37 @@
+# Copy to .env for local development:  cp .env.example .env
+#
+# The only required setting for local dev is a Databricks auth profile (used to call the model).
+# Everything else — MLflow tracing, long-term memory — is optional and off by default. Conversation
+# history uses an in-process session (SQLite in :memory:) with no config; durability is one env var.
+
+# Databricks auth profile (from `databricks auth profiles`). Used to call the model endpoint.
+DATABRICKS_CONFIG_PROFILE=DEFAULT
+# Or use explicit host/token instead of a profile:
+# DATABRICKS_HOST=https://<your-workspace>.databricks.com
+# DATABRICKS_TOKEN=dapi...
+
+# --- Optional: MLflow tracing ---
+# Leave UNSET to skip tracing (local dev). To enable, set a destination AND an experiment (either
+# form of each works): destination = MLFLOW_TRACKING_URI or MLFLOW_TRACING_DESTINATION;
+# experiment = MLFLOW_EXPERIMENT_ID or MLFLOW_EXPERIMENT_NAME.
+# MLFLOW_TRACKING_URI="databricks"
+# MLFLOW_EXPERIMENT_ID=
+# MLFLOW_EXPERIMENT_NAME=
+# For fully-local tracing (no workspace), point MLFLOW_TRACKING_URI at a local OSS MLflow server
+# (`mlflow server`), e.g. MLFLOW_TRACKING_URI="http://localhost:5000".
+
+# --- Optional: long-term memory tools ---
+# Leave UNSET to skip. Set to a managed memory store ID to register the remember/recall tools
+# (persist/search facts across conversations); see databricks_mason/openai/memory.py.
+# AGENT_MEMORY_STORE=<memory-store-id>
+# AGENT_MEMORY_ACTOR_ID=alice
+
+# --- Optional: durable state (managed Session Store) ---
+# Leave UNSET to keep the in-process session (SQLiteSession in :memory:): multi-turn works within one
+# process but does not survive restarts/replicas. Set to an existing managed Session Store name to
+# persist the transcript through its REST API (DatabricksSessionStore) — durable conversation history
+# over RPCs (no DB connection). Access uses your normal Databricks auth (must have access to the
+# store). NOTE: this persists the transcript only; paused human-in-the-loop runs are in-process even
+# when this is set. See databricks_mason/openai/sessions.py.
+# AGENT_SESSION_STORE=my-agent-sessions
+# AGENT_SESSION_ACTOR_ID=alice

--- a/integrations/mason/templates/agent-openai/.gitignore
+++ b/integrations/mason/templates/agent-openai/.gitignore
@@ -1,0 +1,195 @@
+# Created by https://www.toptal.com/developers/gitignore/api/python
+# Edit at https://www.toptal.com/developers/gitignore?templates=python
+
+### Python ###
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# poetry
+#   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+#   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
+#poetry.lock
+
+# pdm
+#   Similar to Pipfile.lock, it is generally recommended to include pdm.lock in version control.
+#pdm.lock
+#   pdm stores project-wide configurations in .pdm.toml, but it is recommended to not include it
+#   in version control.
+#   https://pdm.fming.dev/#use-with-ide
+.pdm.toml
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/
+
+# PyCharm
+#  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
+#  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
+#  and can be added to the global gitignore or merged into this file.  For a more nuclear
+#  option (not recommended) you can uncomment the following to ignore the entire idea folder.
+#.idea/
+
+# VS Code
+.vscode/
+
+### Python Patch ###
+# Poetry local configuration file - https://python-poetry.org/docs/configuration/#local-configuration
+poetry.toml
+
+# ruff
+.ruff_cache/
+
+# LSP config files
+pyrightconfig.json
+
+# End of https://www.toptal.com/developers/gitignore/api/python
+
+.DS_*
+
+# Databricks / MLflow local artifacts
+**/mlruns/
+mlflow.db
+**/.databricks
+.claude/
+
+# Environment files
+**/.env
+**/.env.local
+
+# Local (Lakebase-free) SQLite session store
+local_agent_sessions.db
+local_agent_sessions.db-*
+*.db-journal

--- a/integrations/mason/templates/agent-openai/AGENTS.md
+++ b/integrations/mason/templates/agent-openai/AGENTS.md
@@ -1,0 +1,146 @@
+# Agent Development Guide
+
+An OpenAI Agents SDK agent backend for Databricks Apps, served from a FastAPI app (no serving
+framework). Local-first: runs with no database and no setup beyond a Databricks auth profile. MLflow
+tracing is optional.
+
+See `README.md` for the full run / deploy / client-contract docs. This file is the quick map for
+making changes.
+
+## Run it
+
+```bash
+cp .env.example .env          # set DATABRICKS_CONFIG_PROFILE=<your-profile>
+uv run start-server           # http://localhost:8000
+```
+
+No database needed — conversation state uses an in-process session (`SQLiteSession`) by default.
+
+## Sample requests
+
+`input` is a list of message dicts; the reply is `{ "output": [...], "session_id": "..." }` where
+`output` is normalized message dicts (`{role, content, tool_calls?}`). The
+`__Host-databricks-app-router` cookie is both the Apps routing key and application session id; never
+send `session_id` in the JSON body. Use a cookie jar locally so the server's `mason-local-session`
+fallback is reused.
+
+The examples below use local `/invocations` routes. Deployed Databricks Apps also expose the same
+handlers under `/api/invocations` so OAuth Bearer-token calls pass through the Apps API gateway.
+
+```bash
+COOKIE_JAR=/tmp/mason-agent.cookies
+curl -s -c "$COOKIE_JAR" http://localhost:8000/health
+
+# Sync — run a turn to completion
+curl -sb "$COOKIE_JAR" -X POST http://localhost:8000/invocations \
+  -H "Content-Type: application/json" \
+  -d '{"input": [{"role": "user", "content": "What time is it? Use your tool."}]}'
+
+# Streaming — SSE frames ending with `data: [DONE]`
+curl -sNb "$COOKIE_JAR" -X POST http://localhost:8000/invocations \
+  -H "Content-Type: application/json" \
+  -d '{"input": [{"role": "user", "content": "Count to 3."}], "stream": true}'
+# frames: {"type":"message","message":{...}} (completed) and {"type":"delta","content":"...","id":"..."}
+
+# Background — returns an inv_ id immediately; poll it
+curl -sb "$COOKIE_JAR" -X POST http://localhost:8000/invocations \
+  -H "Content-Type: application/json" \
+  -d '{"input": [{"role": "user", "content": "Do something slow."}], "background": true}'
+# -> {"id": "inv_1a2b3c4d5e6f7g8h9i0j1k2l", "status": "in_progress"}
+curl -sb "$COOKIE_JAR" http://localhost:8000/invocations/inv_1a2b3c4d5e6f7g8h9i0j1k2l
+# -> {"id": "inv_1a2b3c4d5e6f7g8h9i0j1k2l", "status": "completed", "output": [...], "session_id": "..."}
+
+# Human-in-the-loop — the gated send_message tool pauses for approval
+curl -sb "$COOKIE_JAR" -X POST http://localhost:8000/invocations \
+  -H "Content-Type: application/json" \
+  -d '{"input": [{"role": "user", "content": "Send a message to alice@x.com saying hi. Use send_message."}]}'
+# -> {"output": [..., {"type":"interrupt","id":"call_...","value":{"action_requests":[...]}}], "session_id":"S", "status":"interrupted"}
+# Resume with the same cookie and a decision (approve | reject):
+curl -sb "$COOKIE_JAR" -X POST http://localhost:8000/invocations \
+  -H "Content-Type: application/json" \
+  -d '{"resume": {"decisions": [{"type": "approve"}]}}'
+# -> {"output": [...], "session_id": "S", "status": "completed"}
+# NOTE: paused runs are in-process only — resume on the same process (see README HITL note).
+
+# Multi-turn — reuse the same cookie jar (same process; in-memory session)
+curl -sb "$COOKIE_JAR" -X POST http://localhost:8000/invocations \
+  -H "Content-Type: application/json" \
+  -d '{"input": [{"role": "user", "content": "My name is Alice."}]}'
+curl -sb "$COOKIE_JAR" -X POST http://localhost:8000/invocations \
+  -H "Content-Type: application/json" \
+  -d '{"input": [{"role": "user", "content": "What is my name?"}]}'
+```
+
+## Where things live
+
+| You want to… | Edit |
+| --- | --- |
+| Change model / instructions | `agent/agent.py` (`create_agent`) |
+| Add a function tool | new `*.py` in `agent/tools/` with a `@function_tool` function (auto-collected) |
+| Require human approval for a tool | `needs_approval=True` on the tool + its name in `REQUIRE_APPROVAL` (`agent/agent.py`) |
+| Add an MCP server | append an `McpServer` to `build_mcp_servers()` in `agent/mcps.py` |
+| Change how a request maps to a run | `agent/agent.py` (`invoke_handler` / `stream_handler`) |
+| Change the conversation session | `databricks_mason/openai/sessions.py` |
+| Change the HTTP surface (routes, SSE, background wiring) | `runtime/runtime.py` |
+| Change the background-run store (make it durable) | `databricks_mason/runtime/background.py` |
+| Add a test | `tests/` (hermetic; gate model calls on a workspace profile — see `test_agent.py`) |
+
+`runtime/runtime.py` is **SDK-agnostic** — it wires two generic handlers (`invoke_handler`/`stream_handler`,
+plain `dict -> dict` / `dict -> AsyncGenerator[dict]`) to the endpoints. The agent SDK lives entirely
+behind those handlers in `agent/agent.py`, so the serving layer is the same regardless of SDK.
+
+`databricks_mason.runtime` (from the `databricks-mason` package) holds framework-neutral plumbing
+(tracing, workspace client, background store), and `databricks_mason.openai` holds the OpenAI-specific
+pieces (session store, MCP servers, memory tools), so the template ships only your agent code.
+
+## How tools register
+
+`agent/tools/all_tools()` auto-imports every module in the package and collects every
+`@function_tool`-decorated `FunctionTool` it finds. So a tool registers just by existing in a file
+there — `create_agent()` calls `all_tools()`. **Do not** edit `agent/agent.py` to add a tool — just
+add a file to `agent/tools/`.
+
+## Sessions
+
+- Default: `databricks_mason/openai/sessions.py`'s `session_store()` returns an in-process
+  `SQLiteSession` (`:memory:`), cached per session id — no database, multi-turn works in-process.
+- The `__Host-databricks-app-router` cookie is both the Apps routing key and the session id. The
+  runtime injects it into the internal handler request; body `session_id` values are ignored.
+- TODO: replace the cookie with `X-Routing-Key` when Databricks Apps supports it.
+- For durable history, set `AGENT_SESSION_STORE` to a managed Session Store name: `session_store()`
+  returns a `DatabricksSessionStore` — an Agents SDK `Session` that stores each Responses item via the
+  Session Store REST API (no DB connection), so the transcript survives restarts/replicas. Over a
+  vendored REST client (`session_store_client.py`); swap for the published package when it lands.
+  `AGENT_SESSION_ACTOR_ID` selects the actor partition.
+- Background mode is in-memory / single-process — non-durable. The store is
+  `databricks_mason/runtime/background.py` (wired in `runtime/runtime.py`); swap it for a durable
+  backend for cross-restart/replica recovery.
+- Human-in-the-loop: tools with `needs_approval=True` (and listed in `REQUIRE_APPROVAL`,
+  `agent/agent.py`) pause via the Agents SDK. The paused `RunState` is stashed **in-process** keyed by
+  session id and resumed by sending `resume` with the same cookie. Unlike the transcript, a paused run
+  is **not** durable — it does not survive a restart or reach another replica, even with
+  `AGENT_SESSION_STORE` set, because an Agents SDK `Session` persists conversation items, not run
+  state.
+
+## MLflow tracing
+
+Optional. Set both a destination (`MLFLOW_TRACKING_URI` or `MLFLOW_TRACING_DESTINATION`) and an
+experiment (`MLFLOW_EXPERIMENT_ID` or `MLFLOW_EXPERIMENT_NAME`) to enable (`mlflow.openai.autolog()`);
+leave either half unset to skip. `runtime/runtime.py` opens a per-request span regardless.
+
+## Quick commands
+
+| Task | Command |
+| --- | --- |
+| Run locally | `uv run start-server` |
+| Test | `uv run pytest` (hermetic; live model test runs only with a profile) |
+| Deploy | `mason deploy agent-openai --source .` |
+
+## Notes for maintainers
+
+- The event serialization in `agent/agent.py` (`_serialize_events`) is Agents-SDK-specific: it turns
+  the SDK's `raw_response_event`/`run_item_stream_event` stream into the runtime's generic JSON
+  contract (token `delta`s, normalized `message` dicts, and an `interrupt` for a pending approval),
+  without leaking SDK item types to the client. `runtime/runtime.py` is SDK-agnostic.
+- Message normalization (`_normalize_item`) maps Agents SDK run items to `{role, content, tool_calls?}`
+  so the browser UI — shared in shape with the LangGraph template — renders them unchanged.

--- a/integrations/mason/templates/agent-openai/CLAUDE.md
+++ b/integrations/mason/templates/agent-openai/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/integrations/mason/templates/agent-openai/README.md
+++ b/integrations/mason/templates/agent-openai/README.md
@@ -236,9 +236,9 @@ Deploy with the [Mason](../../README.md) CLI:
 mason deploy agent-openai --source .
 ```
 
-Add `--with-memory-store <name> --with-session-store <name> --actor-id <actor>` to wire managed
-state. Mason provisions or resolves the stores, injects the store/actor env vars, and deploys the
-App.
+Add `--memory <name> --session <name> --actor-id <actor>` to wire managed state. Mason
+provisions or resolves the stores (creating them if missing), injects the store/actor env vars, and
+deploys the App.
 
 `app.yaml` carries the app's start command and env. By default the deployed app is the same lean
 backend: in-process session state, tracing off.

--- a/integrations/mason/templates/agent-openai/README.md
+++ b/integrations/mason/templates/agent-openai/README.md
@@ -1,0 +1,311 @@
+# Agent — OpenAI Agents SDK (FastAPI)
+
+An [OpenAI Agents SDK](https://openai.github.io/openai-agents-python/) agent **backend** for
+Databricks Apps, served from a **FastAPI app** — no serving framework. It runs locally with **no
+database and no setup** — just an auth profile. The model runs on Databricks (via
+`databricks-openai`), and `POST /invocations` takes an `input` list of message dicts (streaming via
+SSE, plus an in-memory `background` mode with `GET /invocations/{id}`).
+
+The HTTP surface is hand-written in `runtime/runtime.py` (routes, SSE framing, tracing spans,
+background wiring), so the template shows exactly how the agent is served — request and response
+bodies are plain dicts, no wrapper types. The agent translates the Agents SDK's native run events
+into that generic contract in `agent/agent.py`, so the serving layer stays SDK-agnostic.
+
+This template is API-first. Call it with `curl` or use it from your own client.
+
+Local clients can use `/invocations`. For a deployed Databricks App, use the equivalent
+`/api/invocations` route with an OAuth Bearer token; Databricks Apps reserves `/api/*` for
+programmatic token authentication. Polling and health checks likewise have `/api` aliases.
+
+## Project layout
+
+```
+agent/                 # the agent (reasoning plane) — this is what you edit
+  agent.py             #   invoke / stream handlers + create_agent() + event serialization
+  tools/               #   function tools — drop a *.py file here to add one (auto-collected)
+    sample_tool.py     #     get_current_time — a working example (@function_tool)
+    send_message.py    #     a side-effecting tool gated by human approval (needs_approval=True)
+  mcps.py              #   MCP servers: none by default; add to build_mcp_servers() to offer some
+runtime/               # the HTTP surface — SDK-agnostic; rarely edited
+  runtime.py           #   build_app(): FastAPI routes, SSE framing, tracing spans, background wiring
+  main.py              #   entry point: loads config, builds the app, runs uvicorn
+tests/
+  test_agent.py        #   hermetic smoke tests + one gated live model call
+```
+
+You edit `agent/agent.py`, `agent/tools/`, and `agent/mcps.py`; the plumbing (session store, tracing,
+MCP server construction, background store) lives in the `databricks-mason` package —
+framework-neutral pieces under `databricks_mason.runtime`, OpenAI-specific ones under
+`databricks_mason.openai` — so the template ships only your agent code. `runtime/runtime.py` is the
+SDK-agnostic HTTP surface — it wires two generic handlers (`invoke_handler`/`stream_handler`) to the
+endpoints, so the agent SDK lives entirely behind them in `agent/agent.py`. `tools/` is a drop-in
+package: add a `*.py` with a `@function_tool` function and it's auto-collected (no edits to existing
+code). `mcps.py` exposes `build_mcp_servers()` (empty by default — add servers to offer them).
+
+## Run locally
+
+No database required. Conversation state is kept in an in-process session (`SQLiteSession` backed by
+`:memory:`).
+
+```bash
+# 1. Configure a Databricks auth profile (used only to call the model)
+cp .env.example .env
+# edit .env: set DATABRICKS_CONFIG_PROFILE=<your-profile>
+
+# 2. Start the server (installs deps via uv on first run)
+uv run start-server        # serves at http://localhost:8000
+
+# 3. Send a request
+curl -X POST http://localhost:8000/invocations \
+  -H "Content-Type: application/json" \
+  -d '{"input": [{"role": "user", "content": "What time is it? Use your tool."}]}'
+```
+
+The model call goes to your Databricks workspace (via the profile). Everything else — session
+storage, tracing — is off by default and requires no setup.
+
+## Client contract
+
+The Databricks Apps `__Host-databricks-app-router` cookie is the single session identifier. It both
+keeps requests on the same App replica and keys the conversation session, resumes, and Session Store
+records. Do **not** send `session_id` in request bodies. The runtime ignores an old body value and
+injects the cookie value before calling the agent. Browsers resend the Apps cookie automatically; API
+clients must preserve it in a cookie jar. Localhost has no Apps router, so the server sets an
+HTTP-only `mason-local-session` fallback cookie instead.
+
+TODO: switch the client contract to `X-Routing-Key` when Databricks Apps supports it. Until then use
+the [documented Apps routing cookie](https://docs.databricks.com/aws/en/dev-tools/databricks-apps/horizontal-scaling#api-clients).
+
+```bash
+curl -X POST "https://<app>.databricksapps.com/invocations" \
+  -H "Authorization: Bearer <token>" \
+  -H "Content-Type: application/json" \
+  -b "__Host-databricks-app-router=<routing-key>" \
+  -d '{"input":[{"role":"user","content":"hi"}]}'
+```
+
+The examples below use a localhost cookie jar so every request addresses the same session:
+
+```bash
+BASE=http://localhost:8000
+COOKIE_JAR=/tmp/mason-agent.cookies
+curl -s -c "$COOKIE_JAR" "$BASE/health"
+```
+
+When the chat app is enabled, `GET /api/demo/config` returns the resolved `session_id`, process
+`instance_id`, the signed-in viewer, and the enabled state for streaming, background, Session Store,
+and Memory Store. The UI uses this response to color capability indicators automatically. Only the
+sync/streaming/background selector is a manual client choice.
+
+**Non-streaming:**
+
+```bash
+curl -s -b "$COOKIE_JAR" -X POST "$BASE/invocations" \
+  -H "Content-Type: application/json" \
+  -d '{"input":[{"role":"user","content":"hi"}]}'
+```
+
+The response is `{ "output": [...], "session_id": "...", "status": "completed" }`. `output` contains
+normalized message dictionaries (`{role, content, tool_calls?}`).
+
+**Streaming** adds `"stream": true` and returns SSE. Completed messages use
+`data: {"type":"message","message":{...}}`; token chunks use
+`data: {"type":"delta","content":"...","id":"..."}`; interruptions use
+`data: {"type":"interrupt",...}`; the final frame is `data: [DONE]`.
+
+```bash
+curl -sN -b "$COOKIE_JAR" -X POST "$BASE/invocations" \
+  -H "Content-Type: application/json" \
+  -d '{"input":[{"role":"user","content":"Count to three"}],"stream":true}'
+```
+
+**Background** (add `"background": true`) returns an `inv_...` id immediately; poll it:
+
+```bash
+curl -s -b "$COOKIE_JAR" -X POST "$BASE/invocations" \
+  -H "Content-Type: application/json" \
+  -d '{"input":[{"role":"user","content":"do something"}],"background":true}'
+# -> {"id":"inv_...","status":"in_progress"}
+
+curl -s -b "$COOKIE_JAR" "$BASE/invocations/inv_..."
+# -> in_progress, completed + output, or failed + error
+```
+
+Background runs and polling are in-memory and single-process. The routing cookie is required so the
+poll reaches the same replica, but the run itself does not survive a restart.
+
+### Chat app state APIs
+
+When initialized with the chat app (the default for `mason init --framework openai`, unless
+`--disable-chat-app` is passed), the browser also calls:
+
+- `POST /api/session/new` to generate a fresh session id and replace the routing cookie. The request
+  has no body-level `session_id`; the response includes the new and previous ids.
+- `POST /api/demo/sessions` to create or resolve the current cookie-backed managed session.
+- `GET /api/demo/sessions` to list recent sessions for the configured actor. In local in-memory mode
+  it returns only the current browser session.
+- `POST /api/demo/sessions/{session_id}/open` to verify an actor-scoped managed session, replace the
+  routing cookie, and load that session's transcript.
+- `GET /api/demo/session/items` to load the current transcript. Without a managed Session Store it
+  reconstructs messages from the in-process session. Managed responses filter out non-message items
+  before returning items to the UI.
+- `POST /api/demo/session/items` to mirror user, assistant, tool, and human-decision items into the
+  managed Session Store.
+- `GET /api/demo/memory/entries`, `POST /api/demo/memory/entries`, and
+  `POST /api/demo/memory/search` for managed long-term memory. Created entries are tagged with the
+  current cookie-backed session id; actor partitioning comes from `AGENT_MEMORY_ACTOR_ID`.
+
+### Human-in-the-loop (tool approval)
+
+Tools declared with `needs_approval=True` (and named in `REQUIRE_APPROVAL` in `agent/agent.py`) pause
+for human approval before they run. The template ships with one gated demo tool, `send_message` — ask
+the agent to send a message and instead of running the tool, the run **pauses** and emits an
+`interrupt` event describing the pending call:
+
+```json
+{ "type": "interrupt", "id": "call_...",
+  "value": { "action_requests": [{ "name": "send_message",
+             "args": { "recipient": "alice@x.com", "body": "hi" } }] } }
+```
+
+**Resume** with the same cookie and a decision payload — one decision per pending call:
+
+```bash
+# Approve — the tool runs
+curl -s -b "$COOKIE_JAR" -X POST "$BASE/invocations" \
+  -H "Content-Type: application/json" \
+  -d '{"resume":{"decisions":[{"type":"approve"}]}}'
+
+# Reject — the tool is skipped; an optional message is fed back to the model
+#   { "type": "reject", "message": "Not allowed." }
+```
+
+Non-streaming replies to a gated turn come back with `"status": "interrupted"` and the `interrupt`
+event as the last `output` item; approved/rejected resumes return `"status": "completed"`.
+
+To gate more tools, add `needs_approval=True` to the tool and its name to `REQUIRE_APPROVAL`; empty
+the set to disable approval entirely.
+
+> **Paused runs are in-process only.** Unlike the conversation transcript, a paused run (the Agents
+> SDK `RunState`) is held in memory keyed by session id — it does **not** survive a restart or reach
+> another replica, even with `AGENT_SESSION_STORE` set. An Agents SDK `Session` persists the
+> transcript, not paused run state; durable HITL would stash the `RunState` separately. Resume a
+> pause on the same process that created it.
+
+**Multi-turn** needs no body bookkeeping: reuse the same cookie jar for each turn.
+
+```bash
+curl -s -b "$COOKIE_JAR" -X POST "$BASE/invocations" -H "Content-Type: application/json" \
+  -d '{"input":[{"role":"user","content":"My name is Alice"}]}'
+curl -s -b "$COOKIE_JAR" -X POST "$BASE/invocations" -H "Content-Type: application/json" \
+  -d '{"input":[{"role":"user","content":"What is my name?"}]}'
+```
+
+## Customize the agent
+
+- **Model / instructions:** `create_agent()` in `agent/agent.py`.
+- **Add a tool:** drop a new file in `agent/tools/` with a `@function_tool`-decorated function; it's
+  collected automatically (see `agent/tools/sample_tool.py`). No wiring to edit.
+- **Require approval for a tool:** add `needs_approval=True` to the tool and its name to
+  `REQUIRE_APPROVAL` in `agent/agent.py` (see the human-in-the-loop section above); empty the set to
+  disable gating.
+- **Add an MCP server:** append an `McpServer` to `build_mcp_servers()` in `agent/mcps.py`.
+- **Make history durable:** set `AGENT_SESSION_STORE` (see "Enable durable state" below); the session
+  store lives in `databricks_mason/openai/sessions.py`.
+- **Add long-term memory:** set `AGENT_MEMORY_STORE` to a managed memory store ID; `create_agent()`
+  then includes the `remember`/`recall` tools from `databricks_mason/openai/memory.py` (persist/search
+  facts across conversations). Unset → the model isn't offered them.
+- **Change the HTTP surface:** `runtime/runtime.py` — routes, SSE framing, background wiring (the run
+  store itself is `databricks_mason/runtime/background.py`).
+
+## Test
+
+```bash
+uv run pytest                 # hermetic smoke tests (tools, session, event serialization)
+```
+
+The smoke tests need no auth. `tests/test_agent.py` also has one end-to-end test that calls the
+model; it runs only when a workspace profile is configured (`DATABRICKS_CONFIG_PROFILE` or
+`DATABRICKS_HOST`+`DATABRICKS_TOKEN`) and skips otherwise.
+
+## Deploy
+
+Deploy with the [Mason](../../README.md) CLI:
+
+```bash
+mason deploy agent-openai --source .
+```
+
+Add `--with-memory-store <name> --with-session-store <name> --actor-id <actor>` to wire managed
+state. Mason provisions or resolves the stores, injects the store/actor env vars, and deploys the
+App.
+
+`app.yaml` carries the app's start command and env. By default the deployed app is the same lean
+backend: in-process session state, tracing off.
+
+### Enable MLflow tracing (optional)
+
+Tracing turns on when MLflow has **both a destination and an experiment** — set one of each, in
+whichever form you have. The app code needs no change; MLflow resolves the specific value.
+
+- **Destination:** `MLFLOW_TRACKING_URI` (e.g. `"databricks"`) or `MLFLOW_TRACING_DESTINATION`
+  (an experiment id or a `catalog.schema`).
+- **Experiment:** `MLFLOW_EXPERIMENT_ID` or `MLFLOW_EXPERIMENT_NAME`.
+
+Set neither half → tracing stays off. Examples:
+
+- **Local:** `MLFLOW_TRACKING_URI="databricks"` + `MLFLOW_EXPERIMENT_ID=<id>` (or `..._NAME=<name>`)
+  in `.env`, pointing at an experiment in the workspace your profile targets.
+- **Deployed:** set the same env in `app.yaml` and attach an `experiment` resource (its `valueFrom`
+  binding injects `MLFLOW_EXPERIMENT_ID`).
+
+When both halves are present the agent enables MLflow autolog (`mlflow.openai.autolog()`) and tags
+each trace with the session id. Otherwise it disables tracing outright, so the per-request span
+`runtime/runtime.py` opens has nothing to export and no traces are created.
+
+### Enable durable state (optional)
+
+By default the agent uses an in-process session (`SQLiteSession` backed by `:memory:`) — multi-turn
+history works within a running process but does not survive restarts or span replicas.
+
+Set **`AGENT_SESSION_STORE`** to a managed [Session Store](../../README.md) name and
+`databricks_mason/openai/sessions.py` returns a `DatabricksSessionStore` instead. It's an Agents
+SDK `Session` that stores each Responses item as an ordered **session item** through the managed
+Session Store **REST API** — no database the app connects to directly. The conversation transcript is
+durable across restarts and replicas, over RPCs only. No agent code changes; the session swap is the
+only difference.
+
+> The session store is over a small vendored REST client
+> (`databricks_mason/runtime/session_store_client.py`) so the template needs no unpublished
+> dependency. Swap it for the published package when it lands. The store must already exist; access
+> uses the caller's normal Databricks auth (the deployed app's service principal, or your profile
+> locally — whichever the Session Store grants).
+>
+> **It persists the transcript, not paused runs.** An Agents SDK `Session` stores conversation items
+> only, so a paused human-in-the-loop run stays in-process even when this is set (see the HITL note
+> above).
+
+## Configuration
+
+| Variable | Default | Purpose |
+| --- | --- | --- |
+| `DATABRICKS_CONFIG_PROFILE` | `DEFAULT` | Auth profile used to call the model (local dev) |
+| `PORT` | `8000` | Port the server listens on |
+| `AGENT_MEMORY_STORE` | _unset_ | Managed memory store ID → registers `remember`/`recall` long-term-memory tools |
+| `AGENT_MEMORY_ACTOR_ID` | `agent` | Actor partition used by memory tools |
+| `AGENT_SESSION_STORE` | _unset_ | Managed Session Store name → durable transcript (REST-backed); unset = in-process `SQLiteSession` |
+| `AGENT_SESSION_ACTOR_ID` | session id | Actor used by the durable session store |
+| `MLFLOW_TRACKING_URI` | _unset_ | Trace destination (e.g. `databricks`). A destination + an experiment enables tracing |
+| `MLFLOW_TRACING_DESTINATION` | _unset_ | Alt destination — experiment id or `catalog.schema` (either destination var works) |
+| `MLFLOW_EXPERIMENT_ID` | _unset_ | Experiment to trace to (by id) |
+| `MLFLOW_EXPERIMENT_NAME` | _unset_ | Experiment to trace to (by name; alternative to the id) |
+
+## Notes
+
+- **The event serialization in `agent/agent.py` (`_serialize_events`) is Agents-SDK-specific** — it
+  turns the SDK's native run events into the runtime's generic JSON contract (normalizing message
+  items to `{role, content, tool_calls?}`), which is why the browser UI is identical across
+  frameworks. **`runtime/runtime.py` is SDK-agnostic** — it hosts any agent exposing the
+  `invoke_handler`/`stream_handler` dict contract.
+- **Background mode is in-memory** (`databricks_mason/runtime/background.py`, wired in
+  `runtime/runtime.py`) — non-durable, single-process; see the note under the client contract.

--- a/integrations/mason/templates/agent-openai/agent/agent.py
+++ b/integrations/mason/templates/agent-openai/agent/agent.py
@@ -1,0 +1,252 @@
+import logging
+import os
+from collections.abc import AsyncGenerator
+from contextlib import AsyncExitStack
+from typing import Any
+
+from agents import Agent, RunResultStreaming, Runner, RunState
+from agents.items import ToolApprovalItem
+from databricks_openai import AsyncDatabricksOpenAI
+from openai.types.responses import ResponseTextDeltaEvent
+
+from databricks_mason import tag_session, workspace_client
+from databricks_mason.openai import configure_tracing, mcp_servers, memory_tools, session_store
+
+from agent.mcps import build_mcp_servers
+
+# Importing the tools package auto-registers every tool module.
+from agent.tools import all_tools
+
+logger = logging.getLogger(__name__)
+
+MODEL = "databricks-gpt-5-2"
+
+# Tools that require human approval before they run. Add a tool's name here and the agent pauses when
+# the model calls it, emitting an `interrupt` event; the client resumes by sending `resume` with the
+# same session id. The tools declare `needs_approval=True` themselves (see agent/tools/); this set is
+# how the runtime knows which pending calls to surface. Empty it to disable approval gating.
+REQUIRE_APPROVAL = {"send_message"}
+
+# Paused runs awaiting human approval, keyed by session id. In-process only — a paused run does NOT
+# survive a restart or reach another replica, even with AGENT_SESSION_STORE set: unlike a LangGraph
+# checkpoint, an Agents SDK Session persists the transcript but not paused RunState. Durable HITL
+# would stash RunState.to_json() separately; this template keeps it simple and in-memory.
+_pending_runs: dict[str, RunState] = {}
+
+
+def configure() -> None:
+    """Wire up global state; call once at server startup (not at import)."""
+    _check_databricks_auth()
+    # Route the Agents SDK's default OpenAI client at the Databricks model endpoint (account-host
+    # routing and auth handled by the SDK), so `Agent(model=MODEL)` resolves to a Databricks model.
+    from agents import set_default_openai_api, set_default_openai_client
+
+    set_default_openai_client(AsyncDatabricksOpenAI())
+    set_default_openai_api("chat_completions")
+    configure_tracing()
+
+
+def _check_databricks_auth() -> None:
+    """Fail fast at startup with a clear message if Databricks auth isn't configured.
+
+    Without this, a missing/invalid profile only surfaces on the first model call — as a generic SDK
+    error buried in a request traceback. Resolving a WorkspaceClient here validates the same config
+    the model client uses, so the failure is immediate and actionable.
+    """
+    try:
+        workspace_client()
+    except Exception as e:
+        profile = os.getenv("DATABRICKS_CONFIG_PROFILE")
+        target = (
+            f"profile {profile!r}" if profile else "the DEFAULT profile / DATABRICKS_HOST+TOKEN"
+        )
+        raise RuntimeError(
+            f"Databricks auth is not configured — the agent can't call the model. Tried {target}.\n"
+            "Fix one of:\n"
+            "  • set DATABRICKS_CONFIG_PROFILE in .env to a profile from `databricks auth profiles`, or\n"
+            "  • run `databricks auth login --profile <name>` to create one, or\n"
+            "  • set DATABRICKS_HOST and DATABRICKS_TOKEN in .env.\n"
+            f"(underlying error: {e})"
+        ) from e
+
+
+def create_agent(mcp=None) -> Agent:
+    """Build the OpenAI Agents SDK agent: local tools + long-term-memory tools + any MCP servers."""
+    return Agent(
+        name="Agent",
+        instructions="You are a helpful assistant.",
+        model=MODEL,
+        tools=[*all_tools(), *memory_tools()],
+        mcp_servers=mcp or [],
+    )
+
+
+def _session_id(request: dict) -> str:
+    """Return the session id derived by the runtime from the Apps routing cookie.
+
+    Clients do not send ``session_id`` in the body. The runtime makes the cookie value available to
+    the handler after resolving the deployed Apps cookie or the local-development fallback cookie.
+    """
+    return str(request["session_id"])
+
+
+async def invoke_handler(request: dict) -> dict:
+    """Run one turn to completion. Called by the runtime for POST /invocations.
+
+    ``request`` is a dict with an ``input`` list of Responses message dicts; the returned dict carries
+    the run's new items (normalized message shape) and the ``session_id`` to pass back next turn. If a
+    gated tool needs approval the run pauses: ``output`` then ends with an ``interrupt`` event and
+    ``status`` is ``"interrupted"`` — resume by calling again with the same session id and a ``resume``
+    payload.
+    """
+    request = {**request, "session_id": _session_id(request)}
+    outputs = [
+        event
+        async for event in stream_handler(request)
+        if event.get("type") in ("message", "interrupt")
+    ]
+    interrupted = bool(outputs and outputs[-1].get("type") == "interrupt")
+    return {
+        "output": [e["message"] if e["type"] == "message" else e for e in outputs],
+        "session_id": request["session_id"],
+        "status": "interrupted" if interrupted else "completed",
+    }
+
+
+async def stream_handler(request: dict) -> AsyncGenerator[dict, None]:
+    """Stream the agent's run events as JSON dicts. Called by the runtime when stream=true."""
+    session_id = _session_id(request)
+    tag_session(session_id)
+
+    # The agent runs inside an AsyncExitStack so any MCP servers stay connected for the whole run —
+    # the Agents SDK lists each server's tools lazily inside Runner.run.
+    async with AsyncExitStack() as stack:
+        # Join the manifest's MCP servers (from agent.toml) with your own hand-declared ones
+        # (mcps.py), then connect them for the life of the run.
+        servers = await mcp_servers(build_mcp_servers())
+        mcp = [await stack.enter_async_context(server) for server in servers]
+        agent = create_agent(mcp)
+
+        # A `resume` payload continues a session paused awaiting approval; otherwise start a new turn
+        # from `input`. A resumed run re-runs the stashed RunState (with decisions applied); a new
+        # turn passes the messages plus the session store so prior history is loaded automatically.
+        resume = request.get("resume")
+        if resume is not None:
+            run_input: Any = _apply_decisions(session_id, resume)
+            result = Runner.run_streamed(agent, run_input)
+        else:
+            result = Runner.run_streamed(
+                agent, request.get("input") or [], session=session_store(session_id)
+            )
+
+        async for event in _serialize_events(result, session_id):
+            yield event
+
+
+def _apply_decisions(session_id: str, resume: dict) -> RunState:
+    """Apply human decisions to the session's paused run and return the RunState to re-run.
+
+    ``resume`` mirrors the LangGraph contract: ``{"decisions": [{"type": "approve"|"reject", ...}]}``,
+    one decision per pending approval, in interruption order. Raises if no paused run is loaded for
+    the session (in-process only — a restart or another replica drops it).
+    """
+    state = _pending_runs.pop(session_id, None)
+    if state is None:
+        raise RuntimeError(
+            "No paused run for this session. HITL pauses are in-process only, so a restart or a "
+            "different replica loses them; retry the turn."
+        )
+    decisions = resume.get("decisions") or []
+    for decision, item in zip(decisions, state.get_interruptions()):
+        if decision.get("type") == "approve":
+            state.approve(item)
+        else:
+            state.reject(item, rejection_message=decision.get("message"))
+    return state
+
+
+async def _serialize_events(
+    result: RunResultStreaming, session_id: str
+) -> AsyncGenerator[dict, None]:
+    """Turn the Agents SDK run's stream events into the runtime's JSON envelope.
+
+    Emits the same shape the LangGraph template does — ``{"type": "delta", ...}`` for token chunks,
+    ``{"type": "message", "message": {...}}`` for completed items, ``{"type": "interrupt", ...}`` for a
+    human-approval pause — so the SDK-agnostic runtime and browser UI are identical across frameworks.
+    Message dicts are normalized to ``{role, content, tool_calls?}`` regardless of the SDK's native
+    item type.
+    """
+    async for event in result.stream_events():
+        if event.type == "raw_response_event":
+            if isinstance(event.data, ResponseTextDeltaEvent) and event.data.delta:
+                yield {"type": "delta", "content": event.data.delta, "id": event.data.item_id}
+        elif event.type == "run_item_stream_event":
+            if message := _normalize_item(event.item):
+                yield {"type": "message", "message": message}
+
+    # After the stream drains, a paused run surfaces as pending interruptions. Stash the RunState
+    # (in-process) so a later resume can apply the decisions, and relay each pending call as an
+    # interrupt event on the session's thread.
+    if result.interruptions:
+        _pending_runs[session_id] = result.to_state()
+        for item in result.interruptions:
+            yield {"type": "interrupt", "id": item.call_id, "value": _approval_value(item)}
+
+
+def _approval_value(item: ToolApprovalItem) -> dict:
+    """The interrupt payload for one pending approval, matching the LangGraph HITL event shape."""
+    return {
+        "action_requests": [{"name": item.tool_name, "args": _tool_args(item)}],
+    }
+
+
+def _tool_args(item: ToolApprovalItem) -> Any:
+    import json
+
+    args = item.arguments
+    if isinstance(args, str):
+        try:
+            return json.loads(args)
+        except json.JSONDecodeError:
+            return {"arguments": args}
+    return args or {}
+
+
+def _normalize_item(item: Any) -> dict | None:
+    """Normalize one Agents SDK run item to the UI's ``{role, content, tool_calls?}`` message shape.
+
+    The browser renders LangChain-native message dicts; normalizing here keeps the frontend identical
+    across frameworks. Only user/assistant/tool items become messages; other run items are dropped.
+    """
+    from agents import ItemHelpers
+    from agents.items import MessageOutputItem, ToolCallItem, ToolCallOutputItem
+
+    if isinstance(item, MessageOutputItem):
+        return {"role": "assistant", "content": ItemHelpers.text_message_output(item)}
+    if isinstance(item, ToolCallItem):
+        return {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [{"name": item.tool_name, "args": _tool_args_from_call(item)}],
+        }
+    if isinstance(item, ToolCallOutputItem):
+        return {"role": "tool", "name": _tool_call_name(item), "content": str(item.output)}
+    return None
+
+
+def _tool_args_from_call(item: Any) -> Any:
+    import json
+
+    raw = item.raw_item
+    args = raw.get("arguments") if isinstance(raw, dict) else getattr(raw, "arguments", None)
+    if isinstance(args, str):
+        try:
+            return json.loads(args)
+        except json.JSONDecodeError:
+            return {"arguments": args}
+    return args or {}
+
+
+def _tool_call_name(item: Any) -> str | None:
+    raw = item.raw_item
+    return raw.get("name") if isinstance(raw, dict) else getattr(raw, "name", None)

--- a/integrations/mason/templates/agent-openai/agent/mcps.py
+++ b/integrations/mason/templates/agent-openai/agent/mcps.py
@@ -1,0 +1,29 @@
+"""MCP servers to offer the agent — this is where you configure them.
+
+Empty by default: the agent runs with only the MCP servers declared in ``agent.toml``. Add servers
+to ``build_mcp_servers`` to offer more; ``agent.py`` passes them to ``mcp_servers``, which joins them
+with the ``agent.toml`` servers. The Agents SDK connects each server and lists its tools lazily
+during the run.
+"""
+
+from databricks_openai.agents import McpServer
+
+
+def build_mcp_servers() -> list[McpServer]:
+    """Return the MCP servers to offer the agent. Empty by default — add your own.
+
+    Example (a Databricks-managed MCP, authed as the app service principal)::
+
+        from databricks.sdk import WorkspaceClient
+
+        client = WorkspaceClient()
+        host = client.config.host.rstrip("/")
+        return [
+            McpServer(
+                url=f"{host}/api/2.0/mcp/functions/system/ai",
+                name="system-ai",
+                workspace_client=client,
+            ),
+        ]
+    """
+    return []

--- a/integrations/mason/templates/agent-openai/agent/tools/__init__.py
+++ b/integrations/mason/templates/agent-openai/agent/tools/__init__.py
@@ -1,0 +1,24 @@
+"""Agent tools package.
+
+Every module here is auto-imported, and every OpenAI Agents SDK ``FunctionTool`` it defines (via the
+``@function_tool`` decorator) is collected by ``all_tools()``. Drop a new ``*.py`` into this folder
+with a ``@function_tool``-decorated function and it's picked up automatically — no wiring to edit.
+``create_agent`` uses ``all_tools()``.
+"""
+
+import importlib
+import inspect
+import pkgutil
+
+from agents import FunctionTool
+
+
+def all_tools() -> list[FunctionTool]:
+    """Every FunctionTool defined across the modules in this package."""
+    tools: list[FunctionTool] = []
+    for module in pkgutil.iter_modules(__path__):
+        mod = importlib.import_module(f"{__name__}.{module.name}")
+        for _, obj in inspect.getmembers(mod, lambda o: isinstance(o, FunctionTool)):
+            if obj not in tools:  # a tool imported into several modules is collected once
+                tools.append(obj)
+    return tools

--- a/integrations/mason/templates/agent-openai/agent/tools/sample_tool.py
+++ b/integrations/mason/templates/agent-openai/agent/tools/sample_tool.py
@@ -1,0 +1,15 @@
+"""Sample tool. A working example — add your own tools as new files in this package.
+
+Decorate a function with ``@function_tool`` (OpenAI Agents SDK) and it becomes an agent tool; the
+package auto-collects it via ``all_tools()``, which ``create_agent`` uses.
+"""
+
+from datetime import datetime
+
+from agents import function_tool
+
+
+@function_tool
+def get_current_time() -> str:
+    """Get the current date and time."""
+    return datetime.now().isoformat()

--- a/integrations/mason/templates/agent-openai/agent/tools/send_message.py
+++ b/integrations/mason/templates/agent-openai/agent/tools/send_message.py
@@ -1,0 +1,18 @@
+"""A side-effecting sample tool, gated by human approval.
+
+Unlike ``get_current_time`` (a harmless read), this tool stands in for an action with real
+consequences — sending a message. ``needs_approval=True`` makes the Agents SDK pause before it runs
+and surface a pending approval; the runtime relays that as an ``interrupt`` event and resumes on an
+approve/reject decision (its name is also listed in ``REQUIRE_APPROVAL`` in ``agent/agent.py``). Swap
+the body for a real send; the approval gate is what the template is demonstrating.
+"""
+
+from agents import function_tool
+
+
+@function_tool(needs_approval=True)
+def send_message(recipient: str, body: str) -> str:
+    """Send a message to a recipient. Use when the user asks to notify or message someone."""
+    # A real implementation would call an email/Slack/SMS API here. The point of this template is the
+    # human-approval gate in front of it (needs_approval=True), not the delivery.
+    return f"Message sent to {recipient}: {body}"

--- a/integrations/mason/templates/agent-openai/app.yaml
+++ b/integrations/mason/templates/agent-openai/app.yaml
@@ -1,0 +1,25 @@
+command: ["uv", "run", "start-server"]
+# databricks apps listen by default on port 8000
+#
+# No env vars are required by default: the app runs the lean backend (in-process session, tracing
+# off). To enable tracing, long-term memory, or durable state, add the matching entries below
+# (literal values):
+#
+# env:
+#   # Tracing (set a destination + an experiment). Destination: MLFLOW_TRACKING_URI or
+#   # MLFLOW_TRACING_DESTINATION. Experiment: MLFLOW_EXPERIMENT_ID or MLFLOW_EXPERIMENT_NAME.
+#   - name: MLFLOW_TRACKING_URI
+#     value: "databricks"
+#   - name: MLFLOW_EXPERIMENT_ID
+#     value: "<experiment-id>"
+#   # Long-term memory tools: a managed memory store ID (registers remember/recall).
+#   - name: AGENT_MEMORY_STORE
+#     value: "<memory-store-id>"
+#   - name: AGENT_MEMORY_ACTOR_ID
+#     value: "alice"
+#   # Durable state: a managed Session Store name → transcript persisted via its REST API
+#   # (durable multi-turn history, no DB connection). Access uses the app's service principal.
+#   - name: AGENT_SESSION_STORE
+#     value: "<session-store-name>"
+#   - name: AGENT_SESSION_ACTOR_ID
+#     value: "alice"

--- a/integrations/mason/templates/agent-openai/pyproject.toml
+++ b/integrations/mason/templates/agent-openai/pyproject.toml
@@ -11,7 +11,7 @@ dependencies = [
     # The agent-side runtime helpers (databricks_mason.runtime) plus the agent stack they need
     # (openai-agents, databricks-openai, fastapi, mlflow, …) come from this extra — see the package's
     # [project.optional-dependencies] runtime-openai.
-    "databricks-mason[runtime-openai]>=0.1.1.dev0",
+    "databricks-mason[runtime-openai]>=0.1.2.dev0",
     "uvicorn>=0.41.0",
     "python-dotenv>=1.2.1",
     "databricks-sdk>=0.79.0",

--- a/integrations/mason/templates/agent-openai/pyproject.toml
+++ b/integrations/mason/templates/agent-openai/pyproject.toml
@@ -1,0 +1,44 @@
+[project]
+name = "agent-openai"
+version = "0.1.0"
+description = "OpenAI Agents SDK agent on a FastAPI server for Databricks Apps"
+readme = "README.md"
+authors = [
+    { name = "Agent Developer", email = "developer@example.com" }
+]
+requires-python = ">=3.11"
+dependencies = [
+    # The agent-side runtime helpers (databricks_mason.runtime) plus the agent stack they need
+    # (openai-agents, databricks-openai, fastapi, mlflow, …) come from this extra — see the package's
+    # [project.optional-dependencies] runtime-openai.
+    "databricks-mason[runtime-openai]>=0.1.1.dev0",
+    "uvicorn>=0.41.0",
+    "python-dotenv>=1.2.1",
+    "databricks-sdk>=0.79.0",
+    "databricks-agents>=1.9.3",
+]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["agent", "runtime"]
+
+
+[dependency-groups]
+dev = [
+    "hatchling>=1.28.0",
+    "pytest>=9.0.2",
+    "pytest-asyncio>=1.3.0",
+]
+
+[tool.uv]
+default-groups = ["dev"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+asyncio_mode = "auto"
+
+[project.scripts]
+start-server = "runtime.main:main"

--- a/integrations/mason/templates/agent-openai/runtime/main.py
+++ b/integrations/mason/templates/agent-openai/runtime/main.py
@@ -1,0 +1,27 @@
+"""Agent server entry point.
+
+Loads config, wires the agent's handlers into the (SDK-agnostic) FastAPI app from
+``runtime/runtime.py``, and runs uvicorn. The handlers live in ``agent/agent.py`` — the only
+SDK-specific piece.
+"""
+
+import os
+from pathlib import Path
+
+# Importing the agent is side-effect-free (no env is read until configure()), so it sits up top.
+import agent.agent
+import uvicorn
+from dotenv import load_dotenv
+
+from runtime.runtime import build_app
+
+# Load .env before configure() reads env (agent client auth + tracing config), then wire the agent.
+load_dotenv(dotenv_path=Path(__file__).parent.parent / ".env", override=True)
+agent.agent.configure()
+
+# Module-level app so uvicorn can import it by string (and to enable multiple workers).
+app = build_app(agent.agent.invoke_handler, agent.agent.stream_handler)
+
+
+def main():
+    uvicorn.run("runtime.main:app", host="0.0.0.0", port=int(os.getenv("PORT", "8000")))

--- a/integrations/mason/templates/agent-openai/runtime/runtime.py
+++ b/integrations/mason/templates/agent-openai/runtime/runtime.py
@@ -1,0 +1,175 @@
+"""The agent's HTTP surface: a hand-written, SDK-agnostic FastAPI app.
+
+``build_app`` wires the endpoints to two handlers with a generic contract:
+
+    invoke_handler(request: dict) -> dict
+    stream_handler(request: dict) -> AsyncGenerator[dict]
+
+Nothing here is SDK-specific — the agent lives entirely behind those handlers (``agent/agent.py``).
+The Databricks Apps ``__Host-databricks-app-router`` cookie is both the replica-affinity key and the
+application session id. Clients never send ``session_id`` in the JSON body. Local development uses
+an HTTP-only fallback cookie because the Apps router is not present.
+
+TODO: Prefer ``X-Routing-Key`` for API clients once Databricks Apps supports it; until then, use the
+documented router cookie for sticky routing.
+
+Endpoints: ``POST /invocations`` (``stream: true`` → SSE ending with ``data: [DONE]``;
+``background: true`` → an ``invocation_id`` to poll), ``GET /invocations/{invocation_id}`` to poll a
+background run, ``POST /api/session/new`` to rotate the routing session, and ``GET /health``. The
+invocation and health routes also have ``/api`` aliases because Databricks Apps accepts programmatic
+Bearer-token authentication only on paths under ``/api/``. Each request is wrapped in an MLflow span
+for tracing.
+"""
+
+import asyncio
+import json
+from collections.abc import AsyncGenerator, Awaitable, Callable
+
+import mlflow
+from databricks_mason.runtime.background import BackgroundRuns
+from fastapi import FastAPI, Request, Response
+from fastapi.responses import JSONResponse, StreamingResponse
+from uuid_utils import uuid7
+
+# Request keys that control transport; stripped before the request reaches the handler.
+_REQUEST_STREAM_PARAM_KEY = "stream"
+_REQUEST_BACKGROUND_PARAM_KEY = "background"
+_REQUEST_SESSION_ID_HEADER_KEY = (
+    "X-Routing-Key"  # carries the session id (generic for Apps + Agents)
+)
+_TRACE_NAME_TAG = "mlflow.traceName"
+_ROUTING_COOKIE = "__Host-databricks-app-router"
+_LOCAL_SESSION_COOKIE = "mason-local-session"
+
+# TODO: Replace the Apps routing cookie with X-Routing-Key when Databricks Apps supports it.
+
+InvokeHandler = Callable[[dict], Awaitable[dict]]
+StreamHandler = Callable[[dict], AsyncGenerator[dict, None]]
+
+
+def _sse(data: dict | str) -> str:
+    return f"data: {json.dumps(data) if isinstance(data, dict) else data}\n\n"
+
+
+def _set_trace_name(name: str) -> None:
+    if mlflow.get_current_active_span() is not None:
+        mlflow.update_current_trace(tags={_TRACE_NAME_TAG: name})
+
+
+def rotate_session_cookie(request: Request, response: Response, session_id: str) -> None:
+    if request.cookies.get(_ROUTING_COOKIE):
+        response.set_cookie(
+            _ROUTING_COOKIE,
+            session_id,
+            secure=True,
+            httponly=True,
+            samesite="lax",
+            path="/",
+        )
+        response.delete_cookie(_LOCAL_SESSION_COOKIE, path="/")
+    elif request.cookies.get(_LOCAL_SESSION_COOKIE):
+        response.set_cookie(
+            _LOCAL_SESSION_COOKIE,
+            session_id,
+            httponly=True,
+            samesite="lax",
+            path="/",
+        )
+
+
+def build_app(invoke_handler: InvokeHandler, stream_handler: StreamHandler) -> FastAPI:
+    """Build the FastAPI app wiring the endpoints to the agent's invoke/stream handlers."""
+    app = FastAPI(title="Agent Server")
+    runs = BackgroundRuns()
+
+    @app.middleware("http")
+    async def bind_session(request: Request, call_next):
+        routing_session = request.cookies.get(_ROUTING_COOKIE)
+        local_session = request.cookies.get(_LOCAL_SESSION_COOKIE)
+        request.state.session_id = routing_session or local_session or str(uuid7())
+        response = await call_next(request)
+        if not routing_session and not local_session:
+            response.set_cookie(
+                _LOCAL_SESSION_COOKIE,
+                request.state.session_id,
+                httponly=True,
+                samesite="lax",
+            )
+        return response
+
+    async def _invoke(request: dict) -> dict:
+        with mlflow.start_span(name="invoke_handler") as span:
+            _set_trace_name("invoke_handler")
+            span.set_inputs(request)
+            result = await invoke_handler(request)
+            span.set_outputs(result)
+            return result
+
+    async def _stream(request: dict) -> AsyncGenerator[str, None]:
+        with mlflow.start_span(name="stream_handler") as span:
+            _set_trace_name("stream_handler")
+            span.set_inputs(request)
+            chunks: list[dict] = []
+            try:
+                async for chunk in stream_handler(request):
+                    chunks.append(chunk)
+                    yield _sse(chunk)
+                span.set_outputs(chunks)
+            except Exception as e:  # surface the error in-band, then close the stream
+                yield _sse({"error": str(e)})
+            yield _sse("[DONE]")
+
+    async def _run_background(invocation_id: str, request: dict) -> None:
+        try:
+            runs.complete(invocation_id, await _invoke(request))
+        except Exception as e:
+            runs.fail(invocation_id, str(e))
+
+    @app.post("/api/invocations")
+    @app.post("/invocations")
+    async def invoke(request: Request):
+        data = await request.json()
+        is_stream = bool(data.pop(_REQUEST_STREAM_PARAM_KEY, False))
+        is_background = bool(data.pop(_REQUEST_BACKGROUND_PARAM_KEY, False))
+        data.pop("session_id", None)
+        data["session_id"] = request.state.session_id
+
+        if is_background:
+            invocation_id = runs.start()
+            # Fire-and-forget; the task updates `runs` when it finishes. Non-durable (in-memory).
+            asyncio.create_task(_run_background(invocation_id, data))
+            return JSONResponse({"id": invocation_id, "status": "in_progress"})
+        if is_stream:
+            return StreamingResponse(_stream(data), media_type="text/event-stream")
+        return JSONResponse(await _invoke(data))
+
+    @app.get("/api/invocations/{invocation_id}")
+    @app.get("/invocations/{invocation_id}")
+    async def retrieve(invocation_id: str):
+        run = runs.get(invocation_id)
+        if run is None:
+            return JSONResponse({"error": "unknown invocation id"}, status_code=404)
+        if run["status"] == "completed":
+            return JSONResponse({"id": invocation_id, "status": "completed", **run["output"]})
+        return JSONResponse({"id": invocation_id, "status": run["status"], "error": run["error"]})
+
+    @app.get("/api/health")
+    @app.get("/health")
+    async def health() -> dict[str, str]:
+        return {"status": "ok"}
+
+    @app.post("/api/session/new")
+    async def new_session(request: Request) -> JSONResponse:
+        previous_session_id = request.state.session_id
+        session_id = str(uuid7())
+        request.state.session_id = session_id
+        response = JSONResponse(
+            {
+                "session_id": session_id,
+                "previous_session_id": previous_session_id,
+            }
+        )
+        rotate_session_cookie(request, response, session_id)
+        return response
+
+    return app

--- a/integrations/mason/templates/agent-openai/tests/test_agent.py
+++ b/integrations/mason/templates/agent-openai/tests/test_agent.py
@@ -1,0 +1,189 @@
+"""Smoke tests for the agent.
+
+Hermetic tests import only the leaf modules (tools, session store, event serialization) — no
+Databricks auth needed, so they run anywhere. The live test builds the full agent and calls the
+model; it is skipped unless a workspace profile is configured.
+"""
+
+import os
+
+import pytest
+from agents import FunctionTool
+from agent.agent import _apply_decisions, _normalize_item, _serialize_events, _session_id
+from agent.tools import all_tools
+
+
+def test_tools_autoregister():
+    tools = all_tools()
+    assert tools, "expected the sample tool to auto-register"
+    assert all(isinstance(t, FunctionTool) for t in tools)
+    assert {"get_current_time", "send_message"} <= {t.name for t in tools}
+
+
+def test_gated_tool_needs_approval():
+    # The gated demo tool must exist, be listed for approval, and declare needs_approval, or the HITL
+    # demo does nothing.
+    from agent.agent import REQUIRE_APPROVAL
+
+    assert "send_message" in REQUIRE_APPROVAL
+    send = next(t for t in all_tools() if t.name == "send_message")
+    assert send.needs_approval is True
+
+
+class _FakeItem:
+    """Stand-in for an Agents SDK run item, matched by _normalize_item's isinstance checks."""
+
+
+def test_normalize_message_item():
+    from agents.items import MessageOutputItem
+
+    item = object.__new__(MessageOutputItem)
+    # ItemHelpers.text_message_output reads raw_item.content; give it a text part.
+    from openai.types.responses import ResponseOutputMessage, ResponseOutputText
+
+    item.raw_item = ResponseOutputMessage(
+        id="m1",
+        type="message",
+        role="assistant",
+        status="completed",
+        content=[ResponseOutputText(type="output_text", text="hello", annotations=[])],
+    )
+    assert _normalize_item(item) == {"role": "assistant", "content": "hello"}
+
+
+class _FakeToolApproval:
+    def __init__(self, name, args, call_id):
+        self.tool_name, self.arguments, self.call_id = name, args, call_id
+
+
+class _FakeStreamResult:
+    """Minimal RunResultStreaming stand-in: a delta, a message, then a pending interruption."""
+
+    def __init__(self, events, interruptions, state):
+        self._events, self.interruptions, self._state = events, interruptions, state
+
+    async def stream_events(self):
+        for event in self._events:
+            yield event
+
+    def to_state(self):
+        return self._state
+
+
+@pytest.mark.asyncio
+async def test_serialize_events_relays_interrupt_as_native_event():
+    from agent.agent import _pending_runs
+
+    approval = _FakeToolApproval("send_message", '{"recipient": "x", "body": "y"}', "call-1")
+    sentinel_state = object()
+    result = _FakeStreamResult([], [approval], sentinel_state)
+
+    events = [e async for e in _serialize_events(result, "sess-1")]
+
+    assert events == [
+        {
+            "type": "interrupt",
+            "id": "call-1",
+            "value": {"action_requests": [{"name": "send_message", "args": {"recipient": "x", "body": "y"}}]},
+        }
+    ]
+    # The paused run is stashed in-process, keyed by session id, for a later resume.
+    assert _pending_runs.pop("sess-1") is sentinel_state
+
+
+def test_apply_decisions_approves_pending_run(monkeypatch):
+    from agent.agent import _pending_runs
+
+    approved = []
+
+    class _State:
+        def get_interruptions(self):
+            return ["item-a"]
+
+        def approve(self, item):
+            approved.append(item)
+
+        def reject(self, item, rejection_message=None):
+            raise AssertionError("should not reject on approve")
+
+    _pending_runs["sess-2"] = _State()
+    state = _apply_decisions("sess-2", {"decisions": [{"type": "approve"}]})
+    assert approved == ["item-a"]
+    assert "sess-2" not in _pending_runs  # popped so it can't be resumed twice
+
+
+def test_apply_decisions_without_pending_run_raises():
+    with pytest.raises(RuntimeError, match="No paused run"):
+        _apply_decisions("never-started", {"decisions": [{"type": "approve"}]})
+
+
+def test_configure_raises_clear_error_without_auth(monkeypatch):
+    from agent.agent import configure
+
+    monkeypatch.delenv("DATABRICKS_CONFIG_PROFILE", raising=False)
+    monkeypatch.delenv("DATABRICKS_HOST", raising=False)
+    monkeypatch.delenv("DATABRICKS_TOKEN", raising=False)
+    monkeypatch.setenv("DATABRICKS_CONFIG_FILE", "/nonexistent-databrickscfg")
+    with pytest.raises(RuntimeError, match="Databricks auth is not configured"):
+        configure()
+
+
+def test_session_store_defaults_to_in_process(monkeypatch):
+    import databricks_mason.openai.sessions as ss
+
+    monkeypatch.delenv("AGENT_SESSION_STORE", raising=False)
+    ss._local_sessions.clear()
+    # In-process default: same session id returns the same cached SQLiteSession (multi-turn works).
+    assert ss.session_store("abc-123") is ss.session_store("abc-123")
+
+
+def test_session_store_selects_durable_store(monkeypatch):
+    import databricks_mason.openai.sessions as ss
+
+    monkeypatch.setenv("AGENT_SESSION_STORE", "my-store")
+    monkeypatch.setattr(ss, "SessionStoreClient", lambda *a, **k: _FakeStoreClient())
+    store = ss.session_store("abc-123")
+    assert isinstance(store, ss.DatabricksSessionStore)
+
+
+class _FakeStoreClient:
+    def set_session_store(self, name):
+        return self
+
+
+def test_session_id_from_request():
+    request = {"input": [{"role": "user", "content": "hi"}], "session_id": "abc-123"}
+    assert _session_id(request) == "abc-123"
+
+
+def test_session_id_is_required_from_runtime():
+    with pytest.raises(KeyError):
+        _session_id({"input": [{"role": "user", "content": "hi"}]})
+
+
+def _has_workspace_auth() -> bool:
+    return bool(
+        os.getenv("DATABRICKS_CONFIG_PROFILE")
+        or (os.getenv("DATABRICKS_HOST") and os.getenv("DATABRICKS_TOKEN"))
+    )
+
+
+@pytest.mark.skipif(
+    not _has_workspace_auth(),
+    reason="no Databricks profile configured; skipping live model call",
+)
+@pytest.mark.asyncio
+async def test_agent_responds_end_to_end():
+    from agents import Runner
+
+    from agent.agent import configure, create_agent
+    from databricks_mason.openai import session_store
+
+    configure()
+    agent = create_agent()
+    result = await Runner.run(
+        agent,
+        [{"role": "user", "content": "Reply with the single word: pong"}],
+        session=session_store("test-e2e"),
+    )
+    assert result.final_output

--- a/integrations/mason/templates/agent-openai/tests/test_runtime.py
+++ b/integrations/mason/templates/agent-openai/tests/test_runtime.py
@@ -1,0 +1,22 @@
+from collections.abc import AsyncGenerator
+
+from runtime.runtime import build_app
+
+
+async def _invoke(request: dict) -> dict:
+    return request
+
+
+async def _stream(request: dict) -> AsyncGenerator[dict, None]:
+    yield request
+
+
+def test_invocation_routes_support_local_and_deployed_app_auth_paths() -> None:
+    paths = build_app(_invoke, _stream).openapi()["paths"]
+
+    assert paths["/invocations"]["post"]
+    assert paths["/api/invocations"]["post"]
+    assert paths["/invocations/{invocation_id}"]["get"]
+    assert paths["/api/invocations/{invocation_id}"]["get"]
+    assert paths["/health"]["get"]
+    assert paths["/api/health"]["get"]

--- a/integrations/mason/templates/agent-openai/tests/test_workspace.py
+++ b/integrations/mason/templates/agent-openai/tests/test_workspace.py
@@ -1,0 +1,28 @@
+from databricks_mason.runtime import workspace
+
+
+class _FakeWorkspaceClient:
+    def __init__(self, **kwargs):
+        self.kwargs = kwargs
+
+
+def test_workspace_client_adds_account_routing_header(monkeypatch):
+    monkeypatch.setenv("DATABRICKS_WORKSPACE_ID", " 123456 ")
+    monkeypatch.setattr(workspace, "WorkspaceClient", _FakeWorkspaceClient)
+
+    client = workspace.workspace_client()
+
+    assert client.kwargs == {
+        "custom_headers": {"X-Databricks-Org-Id": "123456"},
+    }
+    assert workspace.workspace_headers() == {"X-Databricks-Org-Id": "123456"}
+
+
+def test_workspace_client_uses_default_sdk_resolution_without_workspace_id(monkeypatch):
+    monkeypatch.delenv("DATABRICKS_WORKSPACE_ID", raising=False)
+    monkeypatch.setattr(workspace, "WorkspaceClient", _FakeWorkspaceClient)
+
+    client = workspace.workspace_client()
+
+    assert client.kwargs == {}
+    assert workspace.workspace_headers() == {}

--- a/integrations/mason/templates/ui/agent-langgraph/ui/app.js
+++ b/integrations/mason/templates/ui/agent-langgraph/ui/app.js
@@ -10,22 +10,17 @@ const elements = {
   copySession: document.querySelector("#copy-session"),
   emptyState: document.querySelector("#empty-state"),
   eventLog: document.querySelector("#event-log"),
-  memoryFact: document.querySelector("#memory-fact"),
   memoryHelp: document.querySelector("#memory-help"),
   memoryMode: document.querySelector("#memory-mode-value"),
-  memoryPath: document.querySelector("#memory-path"),
-  memoryQuery: document.querySelector("#memory-query"),
   memoryResults: document.querySelector("#memory-results"),
   memoryStatus: document.querySelector("#memory-status"),
+  refreshMemory: document.querySelector("#refresh-memory"),
   newSession: document.querySelector("#new-session"),
   promptInput: document.querySelector("#prompt-input"),
-  askMemory: document.querySelector("#ask-memory"),
-  searchMemory: document.querySelector("#search-memory"),
   refreshConfig: document.querySelector("#refresh-config"),
   refreshSession: document.querySelector("#refresh-session"),
   rejectAction: document.querySelector("#reject-action"),
   rejectSession: document.querySelector("#reject-session"),
-  rememberButton: document.querySelector("#remember-button"),
   resumeSession: document.querySelector("#resume-session"),
   runStatus: document.querySelector("#run-status"),
   sendButton: document.querySelector("#send-button"),
@@ -79,9 +74,7 @@ function setBusy(busy, label = "Working") {
   elements.promptInput.disabled = busy;
   elements.approveAction.disabled = busy;
   elements.rejectAction.disabled = busy;
-  elements.rememberButton.disabled = busy || !state.config?.memory.enabled;
-  elements.searchMemory.disabled = busy || !state.config?.memory.enabled;
-  elements.askMemory.disabled = busy || !state.config?.memory.enabled;
+  elements.refreshMemory.disabled = busy || !state.config?.memory.enabled;
   elements.newSession.disabled = busy;
   elements.refreshSession.disabled = busy || !state.config?.session.history;
   elements.resumeSession.disabled = busy || !state.config?.session.durable;
@@ -501,52 +494,6 @@ async function listMemoryEntries() {
   }
 }
 
-async function saveMemoryEntry() {
-  const path = elements.memoryPath.value.trim();
-  const content = elements.memoryFact.value.trim();
-  if (!path || !content) {
-    (path ? elements.memoryFact : elements.memoryPath).focus();
-    return;
-  }
-  stateMessage(elements.memoryResults, "Saving memory entry…", "loading");
-  try {
-    const response = await fetch("/api/demo/memory/entries", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ path, content }),
-    });
-    const result = await jsonResponse(response);
-    addEvent("memory.entry.create", result);
-    elements.memoryHelp.textContent = `Saved ${path} for actor ${state.config.memory.actor}.`;
-    await listMemoryEntries();
-  } catch (error) {
-    stateMessage(elements.memoryResults, error instanceof Error ? error.message : String(error), "error");
-    addEvent("memory.error", { message: String(error) });
-  }
-}
-
-async function searchMemoryEntries() {
-  const query = elements.memoryQuery.value.trim();
-  if (!query) {
-    elements.memoryQuery.focus();
-    return;
-  }
-  stateMessage(elements.memoryResults, "Searching memory…", "loading");
-  try {
-    const response = await fetch("/api/demo/memory/search", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ query, limit: 10 }),
-    });
-    const result = await jsonResponse(response);
-    renderMemoryEntries(memoryEntries(result));
-    addEvent("memory.entries.search", result);
-  } catch (error) {
-    stateMessage(elements.memoryResults, error instanceof Error ? error.message : String(error), "error");
-    addEvent("memory.error", { message: String(error) });
-  }
-}
-
 async function invokeSync(payload) {
   const response = await fetch("/invocations", {
     method: "POST",
@@ -782,9 +729,7 @@ async function loadConfig() {
       config.session.managed ? true : config.session.history ? "degraded" : false,
     );
     setCapability(elements.memoryStatus, config.memory.enabled);
-    elements.rememberButton.disabled = state.busy || !config.memory.enabled;
-    elements.searchMemory.disabled = state.busy || !config.memory.enabled;
-    elements.askMemory.disabled = state.busy || !config.memory.enabled;
+    elements.refreshMemory.disabled = state.busy || !config.memory.enabled;
     elements.newSession.disabled = state.busy;
     elements.refreshSession.disabled = state.busy || !config.session.history;
     elements.resumeSession.disabled = state.busy || !config.session.durable;
@@ -865,13 +810,7 @@ elements.rejectAction.addEventListener("click", () => resume("reject"));
 elements.resumeSession.addEventListener("click", () => resume("approve"));
 elements.rejectSession.addEventListener("click", () => resume("reject"));
 
-elements.rememberButton.addEventListener("click", saveMemoryEntry);
-elements.searchMemory.addEventListener("click", searchMemoryEntries);
-elements.askMemory.addEventListener("click", async () => {
-  const query = elements.memoryQuery.value.trim() || "my saved profile and preferences";
-  clearChat();
-  await sendText(`Use the recall tool to find what you remember about ${query}.`, "sync").catch(() => {});
-});
+elements.refreshMemory.addEventListener("click", listMemoryEntries);
 
 loadConfig().catch((error) => {
   appendError(error);

--- a/integrations/mason/templates/ui/agent-langgraph/ui/app.js
+++ b/integrations/mason/templates/ui/agent-langgraph/ui/app.js
@@ -9,7 +9,6 @@ const elements = {
   composer: document.querySelector("#composer"),
   copySession: document.querySelector("#copy-session"),
   emptyState: document.querySelector("#empty-state"),
-  environmentBadge: document.querySelector("#environment-badge"),
   eventLog: document.querySelector("#event-log"),
   memoryFact: document.querySelector("#memory-fact"),
   memoryHelp: document.querySelector("#memory-help"),
@@ -94,9 +93,11 @@ function setBusy(busy, label = "Working") {
   else if (!elements.runStatus.classList.contains("error")) setStatus("Ready");
 }
 
-function setCapability(element, enabled) {
-  element.classList.toggle("enabled", Boolean(enabled));
-  element.classList.toggle("disabled", !enabled);
+function setCapability(element, state) {
+  const degraded = state === "degraded";
+  element.classList.toggle("enabled", state === true);
+  element.classList.toggle("degraded", degraded);
+  element.classList.toggle("disabled", !state);
 }
 
 function formatJson(value) {
@@ -769,7 +770,6 @@ async function loadConfig() {
     state.config = config;
     state.instanceId = config.instance_id;
     setSessionId(config.session_id);
-    elements.environmentBadge.textContent = config.deployed ? "Databricks App" : "Local runtime";
     elements.viewerValue.textContent = config.viewer;
     elements.streamingMode.textContent = config.streaming.transport;
     elements.backgroundMode.textContent = config.background.durable ? "Durable run store" : "In-process run store";
@@ -777,7 +777,10 @@ async function loadConfig() {
     elements.memoryMode.textContent = config.memory.enabled ? `Managed · actor ${config.memory.actor}` : "Not connected";
     setCapability(elements.streamingStatus, config.streaming.enabled);
     setCapability(elements.backgroundStatus, config.background.enabled);
-    setCapability(elements.sessionStatus, config.session.history);
+    setCapability(
+      elements.sessionStatus,
+      config.session.managed ? true : config.session.history ? "degraded" : false,
+    );
     setCapability(elements.memoryStatus, config.memory.enabled);
     elements.rememberButton.disabled = state.busy || !config.memory.enabled;
     elements.searchMemory.disabled = state.busy || !config.memory.enabled;
@@ -800,7 +803,6 @@ async function loadConfig() {
     else stateMessage(elements.memoryResults, "Connect a Memory Store to manage entries.");
     return config;
   } catch (error) {
-    elements.environmentBadge.textContent = "Runtime unavailable";
     throw error;
   }
 }

--- a/integrations/mason/templates/ui/agent-langgraph/ui/index.html
+++ b/integrations/mason/templates/ui/agent-langgraph/ui/index.html
@@ -151,17 +151,7 @@
           <section class="control-card">
             <div class="control-card-heading">
               <div><p class="eyebrow">Cross-session</p><h2>Long-term memory</h2></div>
-            </div>
-            <label for="memory-path">Entry path</label>
-            <input id="memory-path" value="/profile.md" />
-            <label for="memory-fact">Content</label>
-            <textarea id="memory-fact" rows="2" placeholder="I prefer concise answers with examples."></textarea>
-            <label for="memory-query">Search query</label>
-            <input id="memory-query" value="profile preferences" />
-            <div class="button-row wrap">
-              <button id="remember-button" class="button button-primary" type="button">Save entry</button>
-              <button id="search-memory" class="button button-secondary" type="button">Search</button>
-              <button id="ask-memory" class="button button-secondary" type="button">Ask agent</button>
+              <button id="refresh-memory" class="icon-button" type="button" aria-label="Refresh memory entries">↻</button>
             </div>
             <p id="memory-help" class="supporting-text">Connect a Memory Store to manage entries.</p>
             <div id="memory-results" class="state-list" aria-live="polite">

--- a/integrations/mason/templates/ui/agent-langgraph/ui/index.html
+++ b/integrations/mason/templates/ui/agent-langgraph/ui/index.html
@@ -19,9 +19,6 @@
             <h1>Agent Lab</h1>
           </div>
         </div>
-        <div class="topbar-status" aria-live="polite">
-          <span id="environment-badge" class="badge badge-neutral">Loading runtime</span>
-        </div>
       </header>
 
       <div class="trust-strip">

--- a/integrations/mason/templates/ui/agent-langgraph/ui/styles.css
+++ b/integrations/mason/templates/ui/agent-langgraph/ui/styles.css
@@ -81,7 +81,6 @@ code {
 }
 
 .brand-lockup,
-.topbar-status,
 .section-heading,
 .control-card-heading,
 .button-row,
@@ -144,28 +143,11 @@ h2 {
   line-height: 1.25;
 }
 
-.topbar-status {
-  gap: 10px;
-}
-
-.badge,
 .run-status {
   display: inline-flex;
   align-items: center;
   border-radius: 999px;
   white-space: nowrap;
-}
-
-.badge {
-  min-height: 28px;
-  padding: 4px 10px;
-  font-size: 0.74rem;
-  font-weight: 700;
-}
-
-.badge-neutral {
-  background: var(--surface-muted);
-  color: var(--ink-soft);
 }
 
 .status-orb {
@@ -178,6 +160,11 @@ h2 {
 .status-orb.enabled {
   background: var(--success);
   box-shadow: 0 0 0 4px var(--success-soft);
+}
+
+.status-orb.degraded {
+  background: var(--warning);
+  box-shadow: 0 0 0 4px var(--warning-soft);
 }
 
 .status-orb.disabled {
@@ -981,7 +968,6 @@ h2 {
     padding: 13px 16px;
   }
 
-  .badge-neutral,
   .trust-strip span:last-child {
     display: none;
   }
@@ -1016,10 +1002,6 @@ h2 {
 }
 
 @media (max-width: 560px) {
-  .topbar-status {
-    gap: 4px;
-  }
-
   .left-rail {
     display: flex;
   }

--- a/integrations/mason/templates/ui/agent-openai/CHAT_APP.md
+++ b/integrations/mason/templates/ui/agent-openai/CHAT_APP.md
@@ -1,0 +1,39 @@
+# Mason OpenAI Chat App Overlay
+
+`mason init --framework openai` copies this framework-specific overlay after the base `agent-openai`
+template (it is included by default; `--disable-chat-app` opts out). It is intentionally not a
+post-generation mutation command.
+
+## Installed files
+
+- `ui/` contains the zero-build chat client (shared in shape with the LangGraph template's UI).
+- `runtime/ui.py` serves the assets and exposes demo APIs for memory and sessions.
+- `runtime/main.py` installs the chat routes on the base FastAPI runtime.
+- `tests/test_demo_ui.py` verifies the browser-facing routes.
+
+## Behavior
+
+The capability indicators are automatic. Streaming and background reflect the runtime contract;
+Session reflects transcript history; Memory requires `AGENT_MEMORY_STORE`. The transport selector is
+the only manual capability choice.
+
+The UI reads local history from the agent's in-process session (`SQLiteSession`) and managed history
+from Session Store items. The Databricks Apps `__Host-databricks-app-router` cookie is both the sticky
+routing key and the application session id; request bodies do not carry `session_id`. Local
+development uses the runtime's `mason-local-session` fallback cookie. TODO: switch to `X-Routing-Key`
+when Apps supports it.
+
+The Sessions card calls `POST /api/session/new` to replace that routing cookie with a fresh UUID and
+start an empty conversation. With a managed Session Store, `GET /api/demo/sessions` lists the most
+recent sessions for the configured actor and each Open action calls
+`POST /api/demo/sessions/{session_id}/open`. Opening a listed session verifies that it belongs to the
+same actor, replaces the routing cookie, and reloads its transcript. In local in-memory mode only the
+current browser session can be listed because there is no shared session index.
+
+Transcript responses include only user, assistant, tool, system, and human-decision message items;
+non-message items remain in Session Store but are never returned to the chat UI.
+
+Human-in-the-loop pauses are **in-process only**: a paused run (the Agents SDK `RunState`) is held in
+memory by `agent/agent.py`, not in the session transcript, so — unlike the LangGraph template — it is
+not durable even with a managed Session Store, and the unmanaged history path never reports pending
+interrupts. Resume a pause on the same process that created it.

--- a/integrations/mason/templates/ui/agent-openai/runtime/main.py
+++ b/integrations/mason/templates/ui/agent-openai/runtime/main.py
@@ -1,0 +1,21 @@
+"""Agent server entry point with the optional Mason chat app installed."""
+
+import os
+from pathlib import Path
+
+import agent.agent
+import uvicorn
+from dotenv import load_dotenv
+
+from runtime.runtime import build_app
+from runtime.ui import install_ui
+
+load_dotenv(dotenv_path=Path(__file__).parent.parent / ".env", override=True)
+agent.agent.configure()
+
+app = build_app(agent.agent.invoke_handler, agent.agent.stream_handler)
+install_ui(app)
+
+
+def main():
+    uvicorn.run("runtime.main:app", host="0.0.0.0", port=int(os.getenv("PORT", "8000")))

--- a/integrations/mason/templates/ui/agent-openai/runtime/ui.py
+++ b/integrations/mason/templates/ui/agent-openai/runtime/ui.py
@@ -1,0 +1,374 @@
+"""Browser UI and managed-state demo controls for a Mason agent project."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import uuid
+from functools import lru_cache
+from pathlib import Path
+from typing import Any
+
+from databricks_mason import workspace_client
+from fastapi import FastAPI, HTTPException, Query, Request
+from fastapi.responses import FileResponse, JSONResponse
+from fastapi.staticfiles import StaticFiles
+from pydantic import BaseModel, Field
+from runtime.runtime import rotate_session_cookie
+
+_UI_ROOT = Path(__file__).resolve().parent.parent / "ui"
+_INSTANCE_ID = uuid.uuid4().hex[:12]  # identifies this process in the UI
+_MEMORY_STORE_ENV = "AGENT_MEMORY_STORE"
+_MEMORY_ACTOR_ENV = "AGENT_MEMORY_ACTOR_ID"
+_SESSION_STORE_ENV = "AGENT_SESSION_STORE"
+_SESSION_ACTOR_ENV = "AGENT_SESSION_ACTOR_ID"
+_AGENTS_API = "/api/agents/v1"
+_MESSAGE_ROLES = {
+    "ai",
+    "assistant",
+    "developer",
+    "function",
+    "human",
+    "human_decision",
+    "system",
+    "tool",
+    "user",
+}
+
+
+class MemoryEntryRequest(BaseModel):
+    path: str = Field(min_length=1, pattern=r"^/")
+    content: str = Field(min_length=1)
+    description: str | None = None
+
+
+class MemorySearchRequest(BaseModel):
+    query: str = Field(min_length=1)
+    limit: int = Field(default=10, ge=1, le=100)
+
+
+class SessionItemsRequest(BaseModel):
+    items: list[dict[str, Any]] = Field(min_length=1)
+
+
+def _memory_store() -> str:
+    return os.getenv(_MEMORY_STORE_ENV, "").strip().strip("/")
+
+
+def _memory_actor() -> str:
+    return os.getenv(_MEMORY_ACTOR_ENV, "agent")
+
+
+def _session_store() -> str:
+    return os.getenv(_SESSION_STORE_ENV, "").strip()
+
+
+def _session_actor() -> str:
+    return os.getenv(_SESSION_ACTOR_ENV) or _memory_actor()
+
+
+class _ManagedStateClient:
+    def __init__(self) -> None:
+        self._workspace = workspace_client()
+
+    def _do(
+        self,
+        method: str,
+        path: str,
+        *,
+        query: dict[str, Any] | None = None,
+        body: dict[str, Any] | None = None,
+    ) -> dict:
+        result = self._workspace.api_client.do(method, path, query=query, body=body)
+        if not isinstance(result, dict):
+            raise RuntimeError(
+                f"Expected an object response from {path}, got {type(result).__name__}"
+            )
+        return result
+
+    def create_memory_entry(self, request: MemoryEntryRequest, session_id: str) -> dict:
+        body = {
+            "actor_id": _memory_actor(),
+            "path": request.path,
+            "content": request.content,
+            "session_id": session_id,
+        }
+        if request.description:
+            body["description"] = request.description
+        return self._do("POST", f"{_AGENTS_API}/memory-stores/{_memory_store()}/entries", body=body)
+
+    def list_memory_entries(self, path_prefix: str | None = None) -> dict:
+        query = {"actor_id": _memory_actor(), "page_size": 100}
+        if path_prefix:
+            query["path_prefix"] = path_prefix
+        return self._do(
+            "GET", f"{_AGENTS_API}/memory-stores/{_memory_store()}/entries", query=query
+        )
+
+    def search_memory_entries(self, request: MemorySearchRequest) -> dict:
+        return self._do(
+            "POST",
+            f"{_AGENTS_API}/memory-stores/{_memory_store()}/entries:search",
+            body={
+                "actor_id": _memory_actor(),
+                "query": request.query,
+                "limit": request.limit,
+            },
+        )
+
+    def ensure_session(self, session_id: str) -> dict:
+        try:
+            return self._do(
+                "POST",
+                f"{_AGENTS_API}/session-stores/{_session_store()}/sessions",
+                query={"session_id": session_id},
+                body={
+                    "actor_id": _session_actor(),
+                    "metadata": {"client": "mason-demo-ui"},
+                },
+            )
+        except Exception as exc:
+            code = str(getattr(exc, "error_code", "")).upper()
+            already_exists = code in {"ALREADY_EXISTS", "RESOURCE_ALREADY_EXISTS"}
+            if not already_exists and "already exists" not in str(exc).lower():
+                raise
+            return self._do(
+                "GET",
+                f"{_AGENTS_API}/session-stores/{_session_store()}/sessions/{session_id}",
+            )
+
+    def get_session(self, session_id: str) -> dict:
+        return self._do(
+            "GET",
+            f"{_AGENTS_API}/session-stores/{_session_store()}/sessions/{session_id}",
+        )
+
+    def list_sessions(self) -> dict:
+        return self._do(
+            "GET",
+            f"{_AGENTS_API}/session-stores/{_session_store()}/sessions",
+            query={
+                "filter": f"actor_id = {json.dumps(_session_actor())}",
+                "order_by": "last_activity_time desc",
+                "page_size": 50,
+            },
+        )
+
+    def append_session_items(self, session_id: str, items: list[dict[str, Any]]) -> dict:
+        return self._do(
+            "POST",
+            f"{_AGENTS_API}/session-stores/{_session_store()}/sessions/{session_id}/items:append",
+            body={"items": [{"data": item} for item in items]},
+        )
+
+    def list_session_items(self, session_id: str) -> dict:
+        return self._do(
+            "GET",
+            f"{_AGENTS_API}/session-stores/{_session_store()}/sessions/{session_id}/items",
+            query={"order_by": "create_time asc", "page_size": 100},
+        )
+
+
+@lru_cache(maxsize=1)
+def _state_client() -> _ManagedStateClient:
+    return _ManagedStateClient()
+
+
+async def _managed_call(operation, *args):
+    try:
+        return await asyncio.to_thread(operation, *args)
+    except HTTPException:
+        raise
+    except Exception as exc:
+        code = getattr(exc, "error_code", None)
+        detail = f"{code}: {exc}" if code else str(exc)
+        raise HTTPException(status_code=502, detail=detail) from exc
+
+
+def _require_memory() -> None:
+    if not _memory_store():
+        raise HTTPException(
+            status_code=503,
+            detail=f"Set {_MEMORY_STORE_ENV} by deploying with --with-memory-store.",
+        )
+
+
+def _require_session() -> None:
+    if not _session_store():
+        raise HTTPException(
+            status_code=503,
+            detail=f"Set {_SESSION_STORE_ENV} by deploying with --with-session-store.",
+        )
+
+
+async def _local_history(session_id: str) -> dict[str, Any]:
+    """Reconstruct the transcript from the in-process session (no managed Session Store).
+
+    Reads the Responses items the agent stored in its ``SQLiteSession`` for this routing cookie and
+    shapes each into a ``{item_id, data}`` entry the UI renders. There are no durable interrupts here:
+    a paused human-in-the-loop run is held in-process by ``agent.py`` and is not part of the session
+    transcript, so ``interrupts`` is always empty for the unmanaged path.
+    """
+    from databricks_mason.openai.sessions import session_store
+
+    session = session_store(session_id)
+    items = []
+    for index, message in enumerate(await session.get_items()):
+        data = message if isinstance(message, dict) else {"content": str(message)}
+        items.append({"item_id": str(data.get("id") or index), "data": data})
+    return {"session_id": session_id, "session_items": items, "interrupts": []}
+
+
+def _chat_sessions(result: dict[str, Any]) -> list[dict[str, Any]]:
+    sessions = []
+    for session in result.get("sessions", []):
+        if not isinstance(session, dict):
+            continue
+        metadata = session.get("metadata")
+        metadata = metadata if isinstance(metadata, dict) else {}
+        if metadata.get("public_session_id"):
+            continue
+        sessions.append(session)
+    return sessions
+
+
+def _chat_session_items(result: dict[str, Any]) -> dict[str, Any]:
+    items = []
+    for item in result.get("session_items", []):
+        if not isinstance(item, dict):
+            continue
+        data = item.get("data")
+        if not isinstance(data, dict) or data.get("event_type") or "content" not in data:
+            continue
+        role = str(data.get("role") or data.get("type") or "").lower()
+        if role in _MESSAGE_ROLES:
+            items.append(item)
+    return {**result, "session_items": items}
+
+
+def install_ui(app: FastAPI) -> None:
+    """Mount the Mason demo UI and its runtime control endpoints."""
+    app.mount("/ui-assets", StaticFiles(directory=_UI_ROOT), name="mason-demo-ui-assets")
+
+    @app.get("/", include_in_schema=False)
+    async def index() -> FileResponse:
+        return FileResponse(_UI_ROOT / "index.html")
+
+    @app.get("/api/demo/config", include_in_schema=False)
+    async def demo_config(request: Request) -> dict:
+        viewer = (
+            request.headers.get("x-forwarded-email")
+            or request.headers.get("x-forwarded-user")
+            or "Local developer"
+        )
+        memory_store = _memory_store()
+        session_store = _session_store()
+        return {
+            "session_id": request.state.session_id,
+            "instance_id": _INSTANCE_ID,
+            "viewer": viewer,
+            "deployed": bool(os.getenv("DATABRICKS_APP_NAME")),
+            "streaming": {"enabled": True, "transport": "Server-sent events"},
+            "background": {"enabled": True, "durable": False},
+            "session": {
+                "durable": bool(session_store),
+                "managed": bool(session_store),
+                "history": True,
+                "mode": "Managed Session Store" if session_store else "In-process session",
+                "store": session_store or None,
+                "actor": _session_actor(),
+            },
+            "memory": {
+                "enabled": bool(memory_store),
+                "store": f"memory-stores/{memory_store}" if memory_store else None,
+                "actor": _memory_actor(),
+            },
+        }
+
+    @app.post("/api/demo/memory/entries", include_in_schema=False)
+    async def create_memory_entry(request: Request, payload: MemoryEntryRequest) -> dict:
+        _require_memory()
+        return await _managed_call(
+            _state_client().create_memory_entry, payload, request.state.session_id
+        )
+
+    @app.get("/api/demo/memory/entries", include_in_schema=False)
+    async def list_memory_entries(
+        path_prefix: str | None = Query(default=None),
+    ) -> dict:
+        _require_memory()
+        return await _managed_call(_state_client().list_memory_entries, path_prefix)
+
+    @app.post("/api/demo/memory/search", include_in_schema=False)
+    async def search_memory_entries(request: MemorySearchRequest) -> dict:
+        _require_memory()
+        return await _managed_call(_state_client().search_memory_entries, request)
+
+    @app.post("/api/demo/sessions", include_in_schema=False)
+    async def ensure_session(request: Request) -> dict:
+        _require_session()
+        return await _managed_call(_state_client().ensure_session, request.state.session_id)
+
+    @app.get("/api/demo/sessions", include_in_schema=False)
+    async def list_sessions(request: Request) -> dict:
+        session_id = request.state.session_id
+        if not _session_store():
+            return {
+                "sessions": [
+                    {
+                        "session_id": session_id,
+                        "actor_id": _session_actor(),
+                        "metadata": {"client": "mason-demo-ui-local"},
+                    }
+                ],
+                "current_session_id": session_id,
+                "managed": False,
+            }
+        result = await _managed_call(_state_client().list_sessions)
+        return {
+            **result,
+            "sessions": _chat_sessions(result),
+            "current_session_id": session_id,
+            "managed": True,
+        }
+
+    @app.post("/api/demo/sessions/{session_id}/open", include_in_schema=False)
+    async def open_session(request: Request, session_id: str) -> JSONResponse:
+        _require_session()
+        session = await _managed_call(_state_client().get_session, session_id)
+        if session.get("actor_id") != _session_actor():
+            raise HTTPException(status_code=403, detail="Session belongs to another actor.")
+        previous_session_id = request.state.session_id
+        request.state.session_id = session_id
+        response = JSONResponse(
+            {
+                "session_id": session_id,
+                "previous_session_id": previous_session_id,
+                "managed": True,
+            }
+        )
+        rotate_session_cookie(request, response, session_id)
+        return response
+
+    @app.get("/api/demo/session", include_in_schema=False)
+    async def get_session(request: Request) -> dict:
+        _require_session()
+        return await _managed_call(_state_client().get_session, request.state.session_id)
+
+    @app.post("/api/demo/session/items", include_in_schema=False)
+    async def append_session_items(request: Request, payload: SessionItemsRequest) -> dict:
+        _require_session()
+        return await _managed_call(
+            _state_client().append_session_items,
+            request.state.session_id,
+            payload.items,
+        )
+
+    @app.get("/api/demo/session/items", include_in_schema=False)
+    async def list_session_items(request: Request) -> dict:
+        session_id = request.state.session_id
+        if _session_store():
+            result = await _managed_call(_state_client().list_session_items, session_id)
+            return _chat_session_items(result)
+        return await _local_history(session_id)

--- a/integrations/mason/templates/ui/agent-openai/runtime/ui.py
+++ b/integrations/mason/templates/ui/agent-openai/runtime/ui.py
@@ -190,7 +190,7 @@ def _require_memory() -> None:
     if not _memory_store():
         raise HTTPException(
             status_code=503,
-            detail=f"Set {_MEMORY_STORE_ENV} by deploying with --with-memory-store.",
+            detail=f"Set {_MEMORY_STORE_ENV} by deploying with --memory.",
         )
 
 
@@ -198,7 +198,7 @@ def _require_session() -> None:
     if not _session_store():
         raise HTTPException(
             status_code=503,
-            detail=f"Set {_SESSION_STORE_ENV} by deploying with --with-session-store.",
+            detail=f"Set {_SESSION_STORE_ENV} by deploying with --session.",
         )
 
 

--- a/integrations/mason/templates/ui/agent-openai/tests/test_demo_ui.py
+++ b/integrations/mason/templates/ui/agent-openai/tests/test_demo_ui.py
@@ -1,0 +1,307 @@
+import pytest
+from fastapi.testclient import TestClient
+from runtime import ui
+from runtime.runtime import build_app
+
+
+class _FakeStateClient:
+    def create_memory_entry(self, request, session_id):
+        return {
+            "name": "memory-stores/store/entries/entry",
+            "session_id": session_id,
+            **request.model_dump(),
+        }
+
+    def list_memory_entries(self, path_prefix=None):
+        return {"managed_memory_entries": [{"path": f"{path_prefix or ''}/profile.md"}]}
+
+    def search_memory_entries(self, request):
+        return {"managed_memory_entries": [{"path": "/profile.md", "content": request.query}]}
+
+    def ensure_session(self, session_id):
+        return {"session_id": session_id, "actor_id": "alice"}
+
+    def get_session(self, session_id):
+        return {"session_id": session_id, "actor_id": "alice"}
+
+    def list_sessions(self):
+        return {
+            "sessions": [
+                {
+                    "session_id": "s1",
+                    "actor_id": "alice",
+                    "last_activity_time": "2026-08-28T12:00:00Z",
+                },
+                {
+                    "session_id": "s2",
+                    "actor_id": "alice",
+                    "last_activity_time": "2026-08-27T12:00:00Z",
+                },
+                {
+                    "session_id": "public-s1",
+                    "actor_id": "alice",
+                    "metadata": {"public_session_id": "s1"},
+                    "last_activity_time": "2026-08-28T12:01:00Z",
+                },
+            ]
+        }
+
+    def append_session_items(self, session_id, items):
+        return {"session_items": [{"item_id": "1", "data": item} for item in items]}
+
+    def list_session_items(self, session_id):
+        return {
+            "session_items": [
+                {"item_id": "1", "data": {"role": "user", "content": session_id}},
+                {
+                    "item_id": "2",
+                    "data": {"type": "assistant", "content": "saved reply"},
+                },
+                {
+                    "item_id": "3",
+                    "data": {"event_type": "checkpoint", "checkpoint_id": "checkpoint-1"},
+                },
+            ]
+        }
+
+
+async def _session_history(session_id):
+    return {
+        "session_id": session_id,
+        "session_items": [
+            {"item_id": "1", "data": {"role": "user", "content": session_id}},
+            {"item_id": "2", "data": {"role": "assistant", "content": "in-process reply"}},
+        ],
+        "interrupts": [],
+    }
+
+
+def _client(monkeypatch, *, configured=False, history=False, session_id="routing-session"):
+    if configured:
+        monkeypatch.setenv("AGENT_MEMORY_STORE", "store")
+        monkeypatch.setenv("AGENT_MEMORY_ACTOR_ID", "alice")
+        monkeypatch.setenv("AGENT_SESSION_STORE", "sessions")
+        monkeypatch.setenv("AGENT_SESSION_ACTOR_ID", "alice")
+        monkeypatch.setattr(ui, "_state_client", lambda: _FakeStateClient())
+    else:
+        monkeypatch.delenv("AGENT_MEMORY_STORE", raising=False)
+        monkeypatch.delenv("AGENT_SESSION_STORE", raising=False)
+    if history:
+        monkeypatch.setattr(ui, "_local_history", _session_history)
+
+    async def invoke_handler(request):
+        return {"output": [], "session_id": request["session_id"]}
+
+    async def stream_handler(request):
+        if False:
+            yield request
+
+    app = build_app(invoke_handler, stream_handler)
+    ui.install_ui(app)
+    client = TestClient(app, base_url="https://testserver")
+    client.cookies.set("__Host-databricks-app-router", session_id)
+    return client
+
+
+def test_demo_ui_routes(monkeypatch):
+    client = _client(monkeypatch)
+
+    index = client.get("/")
+    assert index.status_code == 200
+    assert 'id="new-session"' in index.text
+    assert 'id="session-list"' in index.text
+    app_script = client.get("/ui-assets/app.js")
+    assert app_script.status_code == 200
+    assert "refreshSessionView({ hydrateChat: true })" in app_script.text
+    assert 'fetch("/api/session/new"' in app_script.text
+    assert "/api/demo/sessions/${encodeURIComponent(sessionId)}/open" in app_script.text
+    assert "session_id: ensureSessionId()" not in app_script.text
+    styles = client.get("/ui-assets/styles.css").text
+    assert "@media (min-width: 1181px)" in styles
+    assert "scrollbar-gutter: stable" in styles
+
+    config = client.get("/api/demo/config").json()
+    assert config["session_id"] == "routing-session"
+    assert config["deployed"] is False
+    assert config["streaming"]["enabled"] is True
+    assert config["background"]["enabled"] is True
+    assert config["memory"]["enabled"] is False
+    assert config["session"]["managed"] is False
+    assert config["session"]["history"] is True
+    assert config["session"]["mode"] == "In-process session"
+    assert "durability" not in config
+    assert "recovery" not in config
+
+    sessions = client.get("/api/demo/sessions").json()
+    assert sessions == {
+        "sessions": [
+            {
+                "session_id": "routing-session",
+                "actor_id": "agent",
+                "metadata": {"client": "mason-demo-ui-local"},
+            }
+        ],
+        "current_session_id": "routing-session",
+        "managed": False,
+    }
+
+    assert client.post("/api/demo/memory/search", json={"query": "profile"}).status_code == 503
+    assert client.post("/api/demo/sessions", json={"session_id": "ignored"}).status_code == 503
+
+
+def test_unmanaged_local_history_route(monkeypatch):
+    client = _client(monkeypatch, history=True, session_id="local-session")
+
+    config = client.get("/api/demo/config").json()
+    assert config["session"]["managed"] is False
+    assert config["session"]["history"] is True
+
+    result = client.get("/api/demo/session/items")
+    assert result.status_code == 200
+    assert [item["data"]["content"] for item in result.json()["session_items"]] == [
+        "local-session",
+        "in-process reply",
+    ]
+
+
+def test_managed_session_list_is_actor_scoped(monkeypatch):
+    monkeypatch.setenv("AGENT_SESSION_STORE", "sessions")
+    monkeypatch.setenv("AGENT_SESSION_ACTOR_ID", 'alice "demo"')
+    state_client = object.__new__(ui._ManagedStateClient)
+    calls = []
+    state_client._do = lambda method, path, **kwargs: calls.append((method, path, kwargs)) or {
+        "sessions": []
+    }
+
+    assert state_client.list_sessions() == {"sessions": []}
+    assert calls == [
+        (
+            "GET",
+            "/api/agents/v1/session-stores/sessions/sessions",
+            {
+                "query": {
+                    "filter": 'actor_id = "alice \\"demo\\""',
+                    "order_by": "last_activity_time desc",
+                    "page_size": 50,
+                }
+            },
+        )
+    ]
+
+
+def test_chat_session_items_exclude_non_message_items():
+    result = ui._chat_session_items(
+        {
+            "session_items": [
+                {"item_id": "1", "data": {"role": "user", "content": "hello"}},
+                {"item_id": "2", "data": {"type": "ai", "content": "hi"}},
+                {"item_id": "3", "data": {"event_type": "checkpoint"}},
+                {"item_id": "5", "data": {"content": "missing role"}},
+            ],
+            "next_page_token": "next",
+        }
+    )
+
+    assert result == {
+        "session_items": [
+            {"item_id": "1", "data": {"role": "user", "content": "hello"}},
+            {"item_id": "2", "data": {"type": "ai", "content": "hi"}},
+        ],
+        "next_page_token": "next",
+    }
+
+
+@pytest.mark.asyncio
+async def test_local_history_reads_messages_from_in_process_session(monkeypatch):
+    import databricks_mason.openai.sessions as ss
+
+    class _FakeSession:
+        async def get_items(self, limit=None):
+            return [
+                {"id": "m1", "role": "user", "content": "saved message"},
+                {"role": "assistant", "content": "saved reply"},
+            ]
+
+    monkeypatch.setattr(ss, "session_store", lambda session_id: _FakeSession())
+    result = await ui._local_history("saved-session")
+
+    assert result == {
+        "session_id": "saved-session",
+        "session_items": [
+            {"item_id": "m1", "data": {"id": "m1", "role": "user", "content": "saved message"}},
+            {"item_id": "1", "data": {"role": "assistant", "content": "saved reply"}},
+        ],
+        "interrupts": [],
+    }
+
+
+def test_managed_memory_and_session_routes(monkeypatch):
+    client = _client(monkeypatch, configured=True, session_id="s1")
+
+    config = client.get("/api/demo/config").json()
+    assert config["memory"] == {
+        "enabled": True,
+        "store": "memory-stores/store",
+        "actor": "alice",
+    }
+    assert config["session"]["store"] == "sessions"
+    assert config["session"]["actor"] == "alice"
+    assert config["session"]["history"] is True
+
+    created = client.post(
+        "/api/demo/memory/entries",
+        json={"path": "/profile.md", "content": "I work at Databricks"},
+    )
+    assert created.status_code == 200
+    assert created.json()["path"] == "/profile.md"
+    assert created.json()["session_id"] == "s1"
+    assert client.get("/api/demo/memory/entries", params={"path_prefix": "/"}).status_code == 200
+    search = client.post("/api/demo/memory/search", json={"query": "Databricks"})
+    assert search.json()["managed_memory_entries"][0]["content"] == "Databricks"
+
+    assert (
+        client.post("/api/demo/sessions", json={"session_id": "ignored"}).json()["session_id"]
+        == "s1"
+    )
+    listed = client.get("/api/demo/sessions").json()
+    assert [session["session_id"] for session in listed["sessions"]] == ["s1", "s2"]
+    assert listed["current_session_id"] == "s1"
+    assert listed["managed"] is True
+    assert client.get("/api/demo/session").json()["session_id"] == "s1"
+    appended = client.post(
+        "/api/demo/session/items",
+        json={"items": [{"role": "user", "content": "hello"}]},
+    )
+    assert appended.json()["session_items"][0]["data"]["content"] == "hello"
+    assert (
+        client.get("/api/demo/session/items").json()["session_items"][0]["data"]["content"] == "s1"
+    )
+    assert [
+        item["data"]["content"]
+        for item in client.get("/api/demo/session/items").json()["session_items"]
+    ] == ["s1", "saved reply"]
+
+    opened = client.post("/api/demo/sessions/s2/open")
+    assert opened.json() == {
+        "session_id": "s2",
+        "previous_session_id": "s1",
+        "managed": True,
+    }
+    assert client.get("/api/demo/config").json()["session_id"] == "s2"
+    assert (
+        client.get("/api/demo/session/items").json()["session_items"][0]["data"]["content"] == "s2"
+    )
+
+
+def test_open_session_rejects_another_actor(monkeypatch):
+    client = _client(monkeypatch, configured=True, session_id="s1")
+
+    class _ForeignActorClient(_FakeStateClient):
+        def get_session(self, session_id):
+            return {"session_id": session_id, "actor_id": "bob"}
+
+    monkeypatch.setattr(ui, "_state_client", lambda: _ForeignActorClient())
+
+    response = client.post("/api/demo/sessions/s2/open")
+    assert response.status_code == 403
+    assert response.json()["detail"] == "Session belongs to another actor."

--- a/integrations/mason/templates/ui/agent-openai/ui/app.js
+++ b/integrations/mason/templates/ui/agent-openai/ui/app.js
@@ -10,22 +10,17 @@ const elements = {
   copySession: document.querySelector("#copy-session"),
   emptyState: document.querySelector("#empty-state"),
   eventLog: document.querySelector("#event-log"),
-  memoryFact: document.querySelector("#memory-fact"),
   memoryHelp: document.querySelector("#memory-help"),
   memoryMode: document.querySelector("#memory-mode-value"),
-  memoryPath: document.querySelector("#memory-path"),
-  memoryQuery: document.querySelector("#memory-query"),
   memoryResults: document.querySelector("#memory-results"),
   memoryStatus: document.querySelector("#memory-status"),
+  refreshMemory: document.querySelector("#refresh-memory"),
   newSession: document.querySelector("#new-session"),
   promptInput: document.querySelector("#prompt-input"),
-  askMemory: document.querySelector("#ask-memory"),
-  searchMemory: document.querySelector("#search-memory"),
   refreshConfig: document.querySelector("#refresh-config"),
   refreshSession: document.querySelector("#refresh-session"),
   rejectAction: document.querySelector("#reject-action"),
   rejectSession: document.querySelector("#reject-session"),
-  rememberButton: document.querySelector("#remember-button"),
   resumeSession: document.querySelector("#resume-session"),
   runStatus: document.querySelector("#run-status"),
   sendButton: document.querySelector("#send-button"),
@@ -79,9 +74,7 @@ function setBusy(busy, label = "Working") {
   elements.promptInput.disabled = busy;
   elements.approveAction.disabled = busy;
   elements.rejectAction.disabled = busy;
-  elements.rememberButton.disabled = busy || !state.config?.memory.enabled;
-  elements.searchMemory.disabled = busy || !state.config?.memory.enabled;
-  elements.askMemory.disabled = busy || !state.config?.memory.enabled;
+  elements.refreshMemory.disabled = busy || !state.config?.memory.enabled;
   elements.newSession.disabled = busy;
   elements.refreshSession.disabled = busy || !state.config?.session.history;
   elements.resumeSession.disabled = busy || !state.config?.session.durable;
@@ -501,52 +494,6 @@ async function listMemoryEntries() {
   }
 }
 
-async function saveMemoryEntry() {
-  const path = elements.memoryPath.value.trim();
-  const content = elements.memoryFact.value.trim();
-  if (!path || !content) {
-    (path ? elements.memoryFact : elements.memoryPath).focus();
-    return;
-  }
-  stateMessage(elements.memoryResults, "Saving memory entry…", "loading");
-  try {
-    const response = await fetch("/api/demo/memory/entries", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ path, content }),
-    });
-    const result = await jsonResponse(response);
-    addEvent("memory.entry.create", result);
-    elements.memoryHelp.textContent = `Saved ${path} for actor ${state.config.memory.actor}.`;
-    await listMemoryEntries();
-  } catch (error) {
-    stateMessage(elements.memoryResults, error instanceof Error ? error.message : String(error), "error");
-    addEvent("memory.error", { message: String(error) });
-  }
-}
-
-async function searchMemoryEntries() {
-  const query = elements.memoryQuery.value.trim();
-  if (!query) {
-    elements.memoryQuery.focus();
-    return;
-  }
-  stateMessage(elements.memoryResults, "Searching memory…", "loading");
-  try {
-    const response = await fetch("/api/demo/memory/search", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ query, limit: 10 }),
-    });
-    const result = await jsonResponse(response);
-    renderMemoryEntries(memoryEntries(result));
-    addEvent("memory.entries.search", result);
-  } catch (error) {
-    stateMessage(elements.memoryResults, error instanceof Error ? error.message : String(error), "error");
-    addEvent("memory.error", { message: String(error) });
-  }
-}
-
 async function invokeSync(payload) {
   const response = await fetch("/invocations", {
     method: "POST",
@@ -782,9 +729,7 @@ async function loadConfig() {
       config.session.managed ? true : config.session.history ? "degraded" : false,
     );
     setCapability(elements.memoryStatus, config.memory.enabled);
-    elements.rememberButton.disabled = state.busy || !config.memory.enabled;
-    elements.searchMemory.disabled = state.busy || !config.memory.enabled;
-    elements.askMemory.disabled = state.busy || !config.memory.enabled;
+    elements.refreshMemory.disabled = state.busy || !config.memory.enabled;
     elements.newSession.disabled = state.busy;
     elements.refreshSession.disabled = state.busy || !config.session.history;
     elements.resumeSession.disabled = state.busy || !config.session.durable;
@@ -865,13 +810,7 @@ elements.rejectAction.addEventListener("click", () => resume("reject"));
 elements.resumeSession.addEventListener("click", () => resume("approve"));
 elements.rejectSession.addEventListener("click", () => resume("reject"));
 
-elements.rememberButton.addEventListener("click", saveMemoryEntry);
-elements.searchMemory.addEventListener("click", searchMemoryEntries);
-elements.askMemory.addEventListener("click", async () => {
-  const query = elements.memoryQuery.value.trim() || "my saved profile and preferences";
-  clearChat();
-  await sendText(`Use the recall tool to find what you remember about ${query}.`, "sync").catch(() => {});
-});
+elements.refreshMemory.addEventListener("click", listMemoryEntries);
 
 loadConfig().catch((error) => {
   appendError(error);

--- a/integrations/mason/templates/ui/agent-openai/ui/app.js
+++ b/integrations/mason/templates/ui/agent-openai/ui/app.js
@@ -736,7 +736,7 @@ async function loadConfig() {
     elements.rejectSession.disabled = state.busy || !config.session.durable;
     elements.memoryHelp.textContent = config.memory.enabled
       ? `${config.memory.store} · actor ${config.memory.actor}`
-      : "Deploy with --with-memory-store to expose managed entries and agent memory tools.";
+      : "Deploy with --memory to expose managed entries and agent memory tools.";
     elements.sessionStoreLabel.textContent = config.session.managed
       ? `${config.session.store} · actor ${config.session.actor} · the Apps routing cookie keys the session transcript.`
       : config.session.history

--- a/integrations/mason/templates/ui/agent-openai/ui/app.js
+++ b/integrations/mason/templates/ui/agent-openai/ui/app.js
@@ -1,0 +1,877 @@
+const elements = {
+  approvalPanel: document.querySelector("#approval-panel"),
+  approvalSummary: document.querySelector("#approval-summary"),
+  approveAction: document.querySelector("#approve-action"),
+  backgroundMode: document.querySelector("#background-mode-value"),
+  backgroundStatus: document.querySelector("#background-status"),
+  chatLog: document.querySelector("#chat-log"),
+  clearEvents: document.querySelector("#clear-events"),
+  composer: document.querySelector("#composer"),
+  copySession: document.querySelector("#copy-session"),
+  emptyState: document.querySelector("#empty-state"),
+  environmentBadge: document.querySelector("#environment-badge"),
+  eventLog: document.querySelector("#event-log"),
+  memoryFact: document.querySelector("#memory-fact"),
+  memoryHelp: document.querySelector("#memory-help"),
+  memoryMode: document.querySelector("#memory-mode-value"),
+  memoryPath: document.querySelector("#memory-path"),
+  memoryQuery: document.querySelector("#memory-query"),
+  memoryResults: document.querySelector("#memory-results"),
+  memoryStatus: document.querySelector("#memory-status"),
+  newSession: document.querySelector("#new-session"),
+  promptInput: document.querySelector("#prompt-input"),
+  askMemory: document.querySelector("#ask-memory"),
+  searchMemory: document.querySelector("#search-memory"),
+  refreshConfig: document.querySelector("#refresh-config"),
+  refreshSession: document.querySelector("#refresh-session"),
+  rejectAction: document.querySelector("#reject-action"),
+  rejectSession: document.querySelector("#reject-session"),
+  rememberButton: document.querySelector("#remember-button"),
+  resumeSession: document.querySelector("#resume-session"),
+  runStatus: document.querySelector("#run-status"),
+  sendButton: document.querySelector("#send-button"),
+  sessionId: document.querySelector("#session-id"),
+  sessionItems: document.querySelector("#session-items"),
+  sessionList: document.querySelector("#session-list"),
+  sessionMode: document.querySelector("#session-mode-value"),
+  sessionStatus: document.querySelector("#session-status"),
+  sessionStoreLabel: document.querySelector("#session-store-label"),
+  streamingMode: document.querySelector("#streaming-mode-value"),
+  streamingStatus: document.querySelector("#streaming-status"),
+  viewerValue: document.querySelector("#viewer-value"),
+};
+
+const state = {
+  busy: false,
+  config: null,
+  draft: null,
+  draftText: "",
+  events: [],
+  instanceId: null,
+  lastAssistantText: "",
+  managedSessionId: "",
+  mode: "streaming",
+  pendingInterrupt: null,
+  sessionId: "",
+};
+
+function ensureSessionId() {
+  if (!state.sessionId) throw new Error("The routing session is not initialized yet.");
+  return state.sessionId;
+}
+
+function setSessionId(value) {
+  const nextSessionId = String(value || "");
+  if (!nextSessionId) return;
+  if (state.sessionId !== nextSessionId) state.managedSessionId = "";
+  state.sessionId = nextSessionId;
+  elements.sessionId.textContent = state.sessionId;
+}
+
+function setStatus(label, type = "ready") {
+  elements.runStatus.textContent = label;
+  elements.runStatus.className = `run-status ${type === "ready" ? "" : type}`.trim();
+}
+
+function setBusy(busy, label = "Working") {
+  state.busy = busy;
+  elements.chatLog.setAttribute("aria-busy", String(busy));
+  elements.sendButton.disabled = busy;
+  elements.promptInput.disabled = busy;
+  elements.approveAction.disabled = busy;
+  elements.rejectAction.disabled = busy;
+  elements.rememberButton.disabled = busy || !state.config?.memory.enabled;
+  elements.searchMemory.disabled = busy || !state.config?.memory.enabled;
+  elements.askMemory.disabled = busy || !state.config?.memory.enabled;
+  elements.newSession.disabled = busy;
+  elements.refreshSession.disabled = busy || !state.config?.session.history;
+  elements.resumeSession.disabled = busy || !state.config?.session.durable;
+  elements.rejectSession.disabled = busy || !state.config?.session.durable;
+  document.querySelectorAll(".session-open-button").forEach((button) => {
+    button.disabled = busy;
+  });
+  if (busy) setStatus(label, "busy");
+  else if (!elements.runStatus.classList.contains("error")) setStatus("Ready");
+}
+
+function setCapability(element, enabled) {
+  element.classList.toggle("enabled", Boolean(enabled));
+  element.classList.toggle("disabled", !enabled);
+}
+
+function formatJson(value) {
+  try {
+    return JSON.stringify(value, null, 2);
+  } catch {
+    return String(value);
+  }
+}
+
+function addEvent(type, payload) {
+  state.events.unshift({ type, payload, at: new Date() });
+  state.events = state.events.slice(0, 60);
+  elements.eventLog.replaceChildren();
+  for (const event of state.events) {
+    const entry = document.createElement("div");
+    entry.className = "event-entry";
+    const header = document.createElement("div");
+    header.className = "event-entry-header";
+    const name = document.createElement("span");
+    name.textContent = event.type;
+    const time = document.createElement("span");
+    time.textContent = event.at.toLocaleTimeString();
+    const body = document.createElement("pre");
+    body.textContent = formatJson(event.payload);
+    header.append(name, time);
+    entry.append(header, body);
+    elements.eventLog.append(entry);
+  }
+}
+
+function normalizeRole(message) {
+  const value = String(message?.role || message?.type || "assistant").toLowerCase();
+  if (["human", "user"].includes(value)) return "user";
+  if (["tool", "function"].includes(value)) return "tool";
+  if (["system", "developer"].includes(value)) return "system";
+  return "assistant";
+}
+
+function extractText(content) {
+  if (content == null) return "";
+  if (typeof content === "string") return content;
+  if (Array.isArray(content)) {
+    return content
+      .map((part) => {
+        if (typeof part === "string") return part;
+        if (typeof part?.text === "string") return part.text;
+        if (typeof part?.content === "string") return part.content;
+        return "";
+      })
+      .filter(Boolean)
+      .join("\n");
+  }
+  return typeof content === "object" ? formatJson(content) : String(content);
+}
+
+function hideEmptyState() {
+  elements.emptyState.hidden = true;
+}
+
+function appendMessage(role, content, label) {
+  hideEmptyState();
+  const wrapper = document.createElement("article");
+  wrapper.className = `message ${role}`;
+  const avatar = document.createElement("div");
+  avatar.className = "message-avatar";
+  avatar.textContent = role === "user" ? "YOU" : role === "assistant" ? "AI" : role === "tool" ? "TOOL" : "!";
+  const body = document.createElement("div");
+  body.className = "message-body";
+  const meta = document.createElement("div");
+  meta.className = "message-meta";
+  meta.textContent = label || (role === "user" ? "You" : role === "assistant" ? "Agent" : role);
+  const text = document.createElement("div");
+  text.className = "message-content";
+  text.textContent = content;
+  body.append(meta, text);
+  wrapper.append(avatar, body);
+  elements.chatLog.append(wrapper);
+  elements.chatLog.scrollTop = elements.chatLog.scrollHeight;
+  return { wrapper, text };
+}
+
+function appendError(error) {
+  const message = error instanceof Error ? error.message : String(error);
+  appendMessage("error", message, "Request failed");
+  setStatus("Error", "error");
+  addEvent("error", { message });
+}
+
+function startDraft() {
+  if (state.draft) return state.draft;
+  const draft = appendMessage("assistant", "", "Agent · streaming");
+  draft.wrapper.classList.add("streaming");
+  state.draft = draft;
+  state.draftText = "";
+  return draft;
+}
+
+function appendDelta(content) {
+  const text = extractText(content);
+  if (!text) return;
+  const draft = startDraft();
+  state.draftText += text;
+  state.lastAssistantText = state.draftText;
+  draft.text.textContent = state.draftText;
+  elements.chatLog.scrollTop = elements.chatLog.scrollHeight;
+}
+
+function finishDraft(finalText = "") {
+  if (!state.draft) return false;
+  if (finalText) {
+    state.draftText = finalText;
+    state.lastAssistantText = finalText;
+    state.draft.text.textContent = finalText;
+  }
+  state.draft.wrapper.classList.remove("streaming");
+  state.draft.wrapper.querySelector(".message-meta").textContent = "Agent";
+  state.draft = null;
+  return true;
+}
+
+function toolSummary(message) {
+  if (message?.name) return `${message.name}\n${extractText(message.content)}`.trim();
+  if (Array.isArray(message?.tool_calls) && message.tool_calls.length) {
+    return message.tool_calls.map((call) => `${call.name || "tool"}(${formatJson(call.args || {})})`).join("\n");
+  }
+  return extractText(message?.content) || formatJson(message);
+}
+
+function handleAgentMessage(message) {
+  const role = normalizeRole(message);
+  if (role === "user") return;
+  if (role === "assistant") {
+    const text = extractText(message?.content);
+    if (finishDraft(text)) return;
+    if (text) {
+      state.lastAssistantText = text;
+      appendMessage("assistant", text, "Agent");
+    }
+    if (message?.tool_calls?.length) appendMessage("tool", toolSummary(message), "Tool request");
+    return;
+  }
+  appendMessage(role, toolSummary(message), role === "tool" ? "Tool result" : "System");
+}
+
+function interruptSummary(interrupt) {
+  const requests = interrupt?.value?.action_requests || [];
+  if (!requests.length) return "The agent paused and needs a decision.";
+  return requests
+    .map((request) => `${request.name || "tool"} ${formatJson(request.args || {})}`)
+    .join(" · ");
+}
+
+function handleInterrupt(interrupt) {
+  finishDraft();
+  state.pendingInterrupt = interrupt;
+  elements.approvalSummary.textContent = interruptSummary(interrupt);
+  elements.approvalPanel.hidden = false;
+  appendMessage("system", interruptSummary(interrupt), "Approval required");
+}
+
+function handleEvent(event) {
+  addEvent(event?.type || "event", event);
+  if (event?.type === "delta") appendDelta(event.content);
+  if (event?.type === "message") handleAgentMessage(event.message);
+  if (event?.type === "interrupt") handleInterrupt(event);
+  if (event?.error) throw new Error(event.error);
+}
+
+function handleOutput(output) {
+  for (const item of output || []) {
+    if (item?.type === "interrupt") handleInterrupt(item);
+    else handleAgentMessage(item);
+  }
+}
+
+function invocationHeaders() {
+  return {
+    "Content-Type": "application/json",
+  };
+}
+
+function invocationPayload(payload) {
+  return { ...payload };
+}
+
+async function jsonResponse(response) {
+  const body = await response.json().catch(() => ({}));
+  if (!response.ok) throw new Error(body.detail || body.error || `Request failed with ${response.status}`);
+  return body;
+}
+
+function stateMessage(container, message, kind = "empty") {
+  container.replaceChildren();
+  const item = document.createElement("div");
+  item.className = `state-${kind}`;
+  item.textContent = message;
+  container.append(item);
+}
+
+function renderStateItems(container, items, emptyMessage, renderItem) {
+  container.replaceChildren();
+  if (!items.length) {
+    stateMessage(container, emptyMessage);
+    return;
+  }
+  for (const value of items) {
+    const item = document.createElement("article");
+    item.className = "state-item";
+    const rendered = renderItem(value);
+    const title = document.createElement("strong");
+    title.textContent = rendered.title;
+    const content = document.createElement("p");
+    content.textContent = rendered.content || "No content returned.";
+    const meta = document.createElement("small");
+    meta.textContent = rendered.meta || "";
+    item.append(title, content, meta);
+    container.append(item);
+  }
+}
+
+function memoryEntries(payload) {
+  return payload?.managed_memory_entries || [];
+}
+
+function sessionItems(payload) {
+  return payload?.session_items || [];
+}
+
+function sessions(payload) {
+  return payload?.sessions || [];
+}
+
+function renderMemoryEntries(entries, emptyMessage = "No matching memory entries.") {
+  renderStateItems(elements.memoryResults, entries, emptyMessage, (entry) => ({
+    title: entry.path || entry.name || "Memory entry",
+    content: extractText(entry.content) || entry.description || "Content is omitted from list responses.",
+    meta: [entry.actor_id, entry.session_id, entry.update_time].filter(Boolean).join(" · "),
+  }));
+}
+
+function renderSessionItems(items) {
+  renderStateItems(elements.sessionItems, items, "No transcript items yet.", (item) => {
+    const data = item?.data || {};
+    return {
+      title: String(data.role || data.type || "item"),
+      content: extractText(data.content ?? data),
+      meta: [item.item_id, item.create_time, data.transport].filter(Boolean).join(" · "),
+    };
+  });
+}
+
+function renderSessions(items) {
+  elements.sessionList.replaceChildren();
+  if (!items.length) {
+    stateMessage(elements.sessionList, "No sessions yet.");
+    return;
+  }
+  for (const session of items) {
+    const current = session.session_id === state.sessionId;
+    const item = document.createElement("article");
+    item.className = `state-item session-item${current ? " current" : ""}`;
+    const heading = document.createElement("div");
+    heading.className = "session-item-heading";
+    const title = document.createElement("strong");
+    title.textContent = current ? "Current session" : "Session";
+    heading.append(title);
+    if (!current && state.config?.session.managed) {
+      const open = document.createElement("button");
+      open.className = "text-button session-open-button";
+      open.type = "button";
+      open.textContent = "Open";
+      open.disabled = state.busy;
+      open.addEventListener("click", () => openSession(session.session_id));
+      heading.append(open);
+    }
+    const content = document.createElement("p");
+    content.textContent = session.session_id || "Unknown session";
+    const meta = document.createElement("small");
+    meta.textContent = [
+      session.actor_id,
+      session.last_activity_time || session.create_time,
+      current ? "active routing cookie" : "",
+    ].filter(Boolean).join(" · ");
+    item.append(heading, content, meta);
+    elements.sessionList.append(item);
+  }
+}
+
+function renderSessionTranscript(items) {
+  state.draft = null;
+  state.draftText = "";
+  state.lastAssistantText = "";
+  elements.chatLog.replaceChildren(elements.emptyState);
+  elements.emptyState.hidden = false;
+
+  for (const item of items) {
+    const data = item?.data || {};
+    const storedRole = String(data.role || data.type || "").toLowerCase();
+    const content = extractText(data.content ?? data);
+    if (!content) continue;
+    if (storedRole === "human_decision") {
+      appendMessage("system", content, "Human decision");
+      continue;
+    }
+    const role = normalizeRole(data);
+    if (role === "assistant") state.lastAssistantText = content;
+    appendMessage(
+      role,
+      role === "tool" ? toolSummary(data) : content,
+      role === "user" ? "You" : role === "assistant" ? "Agent" : role === "tool" ? "Tool result" : "System",
+    );
+  }
+}
+
+async function ensureManagedSession() {
+  if (!state.config?.session.managed) return null;
+  const sessionId = ensureSessionId();
+  if (state.managedSessionId === sessionId) return sessionId;
+  stateMessage(elements.sessionItems, "Connecting managed session…", "loading");
+  const response = await fetch("/api/demo/sessions", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: "{}",
+  });
+  const result = await jsonResponse(response);
+  state.managedSessionId = sessionId;
+  addEvent("session.managed", result);
+  return sessionId;
+}
+
+async function refreshSession({ hydrateChat = false } = {}) {
+  if (!state.config?.session.history) {
+    stateMessage(elements.sessionItems, "Session history is not available.");
+    return;
+  }
+  try {
+    const sessionId = state.config.session.managed ? await ensureManagedSession() : ensureSessionId();
+    const response = await fetch("/api/demo/session/items", { cache: "no-store" });
+    const result = await jsonResponse(response);
+    const items = sessionItems(result);
+    renderSessionItems(items);
+    if (hydrateChat) {
+      renderSessionTranscript(items);
+      for (const interrupt of result.interrupts || []) handleInterrupt(interrupt);
+    }
+    addEvent("session.items.list", result);
+  } catch (error) {
+    stateMessage(elements.sessionItems, error instanceof Error ? error.message : String(error), "error");
+    addEvent("session.error", { message: String(error) });
+  }
+}
+
+async function refreshSessions() {
+  stateMessage(elements.sessionList, "Loading sessions…", "loading");
+  try {
+    const response = await fetch("/api/demo/sessions", { cache: "no-store" });
+    const result = await jsonResponse(response);
+    renderSessions(sessions(result));
+    addEvent("sessions.list", result);
+  } catch (error) {
+    stateMessage(elements.sessionList, error instanceof Error ? error.message : String(error), "error");
+    addEvent("session.error", { message: String(error) });
+  }
+}
+
+async function refreshSessionView({ hydrateChat = false } = {}) {
+  await refreshSession({ hydrateChat });
+  await refreshSessions();
+}
+
+async function recordSessionItems(items) {
+  if (!state.config?.session.managed || !items.length) return;
+  try {
+    const sessionId = await ensureManagedSession();
+    const response = await fetch("/api/demo/session/items", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ items }),
+    });
+    const result = await jsonResponse(response);
+    addEvent("session.items.append", result);
+    await refreshSessionView();
+  } catch (error) {
+    stateMessage(elements.sessionItems, error instanceof Error ? error.message : String(error), "error");
+    addEvent("session.error", { message: String(error) });
+  }
+}
+
+async function listMemoryEntries() {
+  if (!state.config?.memory.enabled) return;
+  stateMessage(elements.memoryResults, "Loading memory entries…", "loading");
+  try {
+    const response = await fetch("/api/demo/memory/entries", { cache: "no-store" });
+    const result = await jsonResponse(response);
+    renderMemoryEntries(memoryEntries(result), "No memory entries for this actor yet.");
+    addEvent("memory.entries.list", result);
+  } catch (error) {
+    stateMessage(elements.memoryResults, error instanceof Error ? error.message : String(error), "error");
+    addEvent("memory.error", { message: String(error) });
+  }
+}
+
+async function saveMemoryEntry() {
+  const path = elements.memoryPath.value.trim();
+  const content = elements.memoryFact.value.trim();
+  if (!path || !content) {
+    (path ? elements.memoryFact : elements.memoryPath).focus();
+    return;
+  }
+  stateMessage(elements.memoryResults, "Saving memory entry…", "loading");
+  try {
+    const response = await fetch("/api/demo/memory/entries", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ path, content }),
+    });
+    const result = await jsonResponse(response);
+    addEvent("memory.entry.create", result);
+    elements.memoryHelp.textContent = `Saved ${path} for actor ${state.config.memory.actor}.`;
+    await listMemoryEntries();
+  } catch (error) {
+    stateMessage(elements.memoryResults, error instanceof Error ? error.message : String(error), "error");
+    addEvent("memory.error", { message: String(error) });
+  }
+}
+
+async function searchMemoryEntries() {
+  const query = elements.memoryQuery.value.trim();
+  if (!query) {
+    elements.memoryQuery.focus();
+    return;
+  }
+  stateMessage(elements.memoryResults, "Searching memory…", "loading");
+  try {
+    const response = await fetch("/api/demo/memory/search", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ query, limit: 10 }),
+    });
+    const result = await jsonResponse(response);
+    renderMemoryEntries(memoryEntries(result));
+    addEvent("memory.entries.search", result);
+  } catch (error) {
+    stateMessage(elements.memoryResults, error instanceof Error ? error.message : String(error), "error");
+    addEvent("memory.error", { message: String(error) });
+  }
+}
+
+async function invokeSync(payload) {
+  const response = await fetch("/invocations", {
+    method: "POST",
+    credentials: "same-origin",
+    headers: invocationHeaders(),
+    body: JSON.stringify(invocationPayload(payload)),
+  });
+  const result = await jsonResponse(response);
+  addEvent("response", result);
+  if (result.session_id) setSessionId(result.session_id);
+  handleOutput(result.output);
+  return result;
+}
+
+function parseSseFrame(frame) {
+  const data = frame
+    .split("\n")
+    .filter((line) => line.startsWith("data:"))
+    .map((line) => line.slice(5).trimStart())
+    .join("\n");
+  if (!data || data === "[DONE]") return null;
+  return JSON.parse(data);
+}
+
+async function invokeStreaming(payload) {
+  const response = await fetch("/invocations", {
+    method: "POST",
+    credentials: "same-origin",
+    headers: invocationHeaders(),
+    body: JSON.stringify(invocationPayload({ ...payload, stream: true })),
+  });
+  if (!response.ok || !response.body) await jsonResponse(response);
+  const reader = response.body.getReader();
+  const decoder = new TextDecoder();
+  let buffer = "";
+  while (true) {
+    const { value, done } = await reader.read();
+    buffer += decoder.decode(value || new Uint8Array(), { stream: !done });
+    const frames = buffer.split("\n\n");
+    buffer = frames.pop() || "";
+    for (const frame of frames) {
+      const event = parseSseFrame(frame);
+      if (event) handleEvent(event);
+    }
+    if (done) break;
+  }
+  if (buffer.trim()) {
+    const event = parseSseFrame(buffer);
+    if (event) handleEvent(event);
+  }
+  finishDraft();
+  return { status: state.pendingInterrupt ? "interrupted" : "completed" };
+}
+
+async function pollBackground(invocationId) {
+  const deadline = Date.now() + 180000;
+  while (Date.now() < deadline) {
+    await new Promise((resolve) => setTimeout(resolve, 850));
+    const response = await fetch(`/invocations/${encodeURIComponent(invocationId)}`, {
+      cache: "no-store",
+      credentials: "same-origin",
+    });
+    const result = await jsonResponse(response);
+    addEvent("background.poll", result);
+    if (result.status === "completed") {
+      if (result.session_id) setSessionId(result.session_id);
+      handleOutput(result.output);
+      return result;
+    }
+    if (result.status === "failed") throw new Error(result.error || "Background invocation failed");
+    setStatus(`Background · ${result.status}`, "busy");
+  }
+  throw new Error("Background invocation did not finish within three minutes.");
+}
+
+async function invokeBackground(payload) {
+  const response = await fetch("/invocations", {
+    method: "POST",
+    credentials: "same-origin",
+    headers: invocationHeaders(),
+    body: JSON.stringify(invocationPayload({ ...payload, background: true })),
+  });
+  const started = await jsonResponse(response);
+  addEvent("background.started", started);
+  setStatus(`Background · ${started.id}`, "busy");
+  return pollBackground(started.id);
+}
+
+async function dispatch(payload, mode = state.mode) {
+  state.lastAssistantText = "";
+  state.pendingInterrupt = null;
+  elements.approvalPanel.hidden = true;
+  if (mode === "streaming") return invokeStreaming(payload);
+  if (mode === "background") return invokeBackground(payload);
+  return invokeSync(payload);
+}
+
+async function sendText(text, mode = state.mode) {
+  const content = text.trim();
+  if (!content || state.busy) return "";
+  appendMessage("user", content, "You");
+  setBusy(true, mode === "background" ? "Starting background run" : mode === "streaming" ? "Streaming" : "Running");
+  try {
+    await dispatch({ input: [{ role: "user", content }] }, mode);
+    const items = [{ role: "user", content, transport: mode, instance_id: state.instanceId }];
+    if (state.lastAssistantText) {
+      items.push({
+        role: "assistant",
+        content: state.lastAssistantText,
+        transport: mode,
+        instance_id: state.instanceId,
+      });
+    }
+    await recordSessionItems(items);
+    return state.lastAssistantText;
+  } catch (error) {
+    finishDraft();
+    appendError(error);
+    throw error;
+  } finally {
+    setBusy(false);
+  }
+}
+
+async function resume(decision) {
+  if (state.busy) return;
+  if (!state.pendingInterrupt && !state.config?.session.durable) {
+    appendError(new Error("No paused run is loaded for the current routing session."));
+    return;
+  }
+  const payload =
+    decision === "approve"
+      ? { resume: { decisions: [{ type: "approve" }] } }
+      : { resume: { decisions: [{ type: "reject", message: "Rejected from the Mason demo UI." }] } };
+  appendMessage("system", decision === "approve" ? "Approved pending tool call." : "Rejected pending tool call.", "Human decision");
+  setBusy(true, "Resuming");
+  try {
+    await dispatch(payload, "streaming");
+    const items = [
+      { role: "human_decision", content: decision, instance_id: state.instanceId },
+    ];
+    if (state.lastAssistantText) {
+      items.push({
+        role: "assistant",
+        content: state.lastAssistantText,
+        transport: "streaming",
+        instance_id: state.instanceId,
+      });
+    }
+    await recordSessionItems(items);
+  } catch (error) {
+    appendError(error);
+  } finally {
+    setBusy(false);
+  }
+}
+
+function clearChat({ recordEvent = true } = {}) {
+  state.pendingInterrupt = null;
+  state.draft = null;
+  state.draftText = "";
+  state.lastAssistantText = "";
+  elements.approvalPanel.hidden = true;
+  elements.chatLog.replaceChildren(elements.emptyState);
+  elements.emptyState.hidden = false;
+  elements.promptInput.focus();
+  if (recordEvent) addEvent("chat.cleared", { session_id: state.sessionId });
+}
+
+function resetSessionState() {
+  clearChat({ recordEvent: false });
+  stateMessage(elements.sessionList, "Loading sessions…", "loading");
+  stateMessage(elements.sessionItems, "Loading transcript…", "loading");
+}
+
+async function createNewSession() {
+  if (state.busy) return;
+  setBusy(true, "Creating session");
+  try {
+    const response = await fetch("/api/session/new", {
+      method: "POST",
+      credentials: "same-origin",
+    });
+    const result = await jsonResponse(response);
+    setSessionId(result.session_id);
+    resetSessionState();
+    addEvent("session.new", result);
+    if (state.config?.session.managed) await ensureManagedSession();
+    await refreshSessionView({ hydrateChat: true });
+  } catch (error) {
+    appendError(error);
+  } finally {
+    setBusy(false);
+  }
+}
+
+async function openSession(sessionId) {
+  if (state.busy || !sessionId || sessionId === state.sessionId) return;
+  setBusy(true, "Opening session");
+  try {
+    const response = await fetch(`/api/demo/sessions/${encodeURIComponent(sessionId)}/open`, {
+      method: "POST",
+      credentials: "same-origin",
+    });
+    const result = await jsonResponse(response);
+    setSessionId(result.session_id);
+    resetSessionState();
+    addEvent("session.open", result);
+    await refreshSessionView({ hydrateChat: true });
+  } catch (error) {
+    appendError(error);
+  } finally {
+    setBusy(false);
+  }
+}
+
+async function loadConfig() {
+  try {
+    const response = await fetch("/api/demo/config", { cache: "no-store" });
+    const config = await jsonResponse(response);
+    state.config = config;
+    state.instanceId = config.instance_id;
+    setSessionId(config.session_id);
+    elements.environmentBadge.textContent = config.deployed ? "Databricks App" : "Local runtime";
+    elements.viewerValue.textContent = config.viewer;
+    elements.streamingMode.textContent = config.streaming.transport;
+    elements.backgroundMode.textContent = config.background.durable ? "Durable run store" : "In-process run store";
+    elements.sessionMode.textContent = config.session.mode;
+    elements.memoryMode.textContent = config.memory.enabled ? `Managed · actor ${config.memory.actor}` : "Not connected";
+    setCapability(elements.streamingStatus, config.streaming.enabled);
+    setCapability(elements.backgroundStatus, config.background.enabled);
+    setCapability(elements.sessionStatus, config.session.history);
+    setCapability(elements.memoryStatus, config.memory.enabled);
+    elements.rememberButton.disabled = state.busy || !config.memory.enabled;
+    elements.searchMemory.disabled = state.busy || !config.memory.enabled;
+    elements.askMemory.disabled = state.busy || !config.memory.enabled;
+    elements.newSession.disabled = state.busy;
+    elements.refreshSession.disabled = state.busy || !config.session.history;
+    elements.resumeSession.disabled = state.busy || !config.session.durable;
+    elements.rejectSession.disabled = state.busy || !config.session.durable;
+    elements.memoryHelp.textContent = config.memory.enabled
+      ? `${config.memory.store} · actor ${config.memory.actor}`
+      : "Deploy with --with-memory-store to expose managed entries and agent memory tools.";
+    elements.sessionStoreLabel.textContent = config.session.managed
+      ? `${config.session.store} · actor ${config.session.actor} · the Apps routing cookie keys the session transcript.`
+      : config.session.history
+        ? "Messages load from the in-process session for the current routing cookie."
+        : "Session history is unavailable.";
+    addEvent("runtime.config", config);
+    void refreshSessionView({ hydrateChat: true });
+    if (config.memory.enabled) void listMemoryEntries();
+    else stateMessage(elements.memoryResults, "Connect a Memory Store to manage entries.");
+    return config;
+  } catch (error) {
+    elements.environmentBadge.textContent = "Runtime unavailable";
+    throw error;
+  }
+}
+elements.composer.addEventListener("submit", async (event) => {
+  event.preventDefault();
+  const text = elements.promptInput.value;
+  if (!text.trim()) return;
+  elements.promptInput.value = "";
+  elements.promptInput.style.height = "auto";
+  try {
+    await sendText(text);
+  } catch {
+    elements.promptInput.value = text;
+  }
+});
+
+elements.promptInput.addEventListener("input", () => {
+  elements.promptInput.style.height = "auto";
+  elements.promptInput.style.height = `${Math.min(elements.promptInput.scrollHeight, 180)}px`;
+});
+
+elements.promptInput.addEventListener("keydown", (event) => {
+  if (event.key === "Enter" && !event.shiftKey) {
+    event.preventDefault();
+    elements.composer.requestSubmit();
+  }
+});
+
+document.querySelectorAll(".mode-button").forEach((button) => {
+  button.addEventListener("click", () => {
+    state.mode = button.dataset.mode;
+    document.querySelectorAll(".mode-button").forEach((item) => item.classList.toggle("active", item === button));
+  });
+});
+
+document.querySelectorAll("[data-prompt]").forEach((button) => {
+  button.addEventListener("click", () => {
+    elements.promptInput.value = button.dataset.prompt;
+    elements.promptInput.dispatchEvent(new Event("input"));
+    elements.promptInput.focus();
+  });
+});
+
+elements.copySession.addEventListener("click", async () => {
+  await navigator.clipboard.writeText(ensureSessionId());
+  const label = elements.copySession.querySelector("span");
+  label.textContent = "Copied";
+  setTimeout(() => { label.textContent = "Copy"; }, 1200);
+});
+
+elements.refreshConfig.addEventListener("click", () => loadConfig().catch(appendError));
+elements.newSession.addEventListener("click", createNewSession);
+elements.refreshSession.addEventListener("click", () => refreshSessionView({ hydrateChat: true }));
+elements.clearEvents.addEventListener("click", () => {
+  state.events = [];
+  elements.eventLog.innerHTML = '<div class="event-empty">Invocation events appear here.</div>';
+});
+elements.approveAction.addEventListener("click", () => resume("approve"));
+elements.rejectAction.addEventListener("click", () => resume("reject"));
+elements.resumeSession.addEventListener("click", () => resume("approve"));
+elements.rejectSession.addEventListener("click", () => resume("reject"));
+
+elements.rememberButton.addEventListener("click", saveMemoryEntry);
+elements.searchMemory.addEventListener("click", searchMemoryEntries);
+elements.askMemory.addEventListener("click", async () => {
+  const query = elements.memoryQuery.value.trim() || "my saved profile and preferences";
+  clearChat();
+  await sendText(`Use the recall tool to find what you remember about ${query}.`, "sync").catch(() => {});
+});
+
+loadConfig().catch((error) => {
+  appendError(error);
+  elements.memoryHelp.textContent = "Runtime configuration is unavailable.";
+});

--- a/integrations/mason/templates/ui/agent-openai/ui/app.js
+++ b/integrations/mason/templates/ui/agent-openai/ui/app.js
@@ -462,24 +462,6 @@ async function refreshSessionView({ hydrateChat = false } = {}) {
   await refreshSessions();
 }
 
-async function recordSessionItems(items) {
-  if (!state.config?.session.managed || !items.length) return;
-  try {
-    const sessionId = await ensureManagedSession();
-    const response = await fetch("/api/demo/session/items", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ items }),
-    });
-    const result = await jsonResponse(response);
-    addEvent("session.items.append", result);
-    await refreshSessionView();
-  } catch (error) {
-    stateMessage(elements.sessionItems, error instanceof Error ? error.message : String(error), "error");
-    addEvent("session.error", { message: String(error) });
-  }
-}
-
 async function listMemoryEntries() {
   if (!state.config?.memory.enabled) return;
   stateMessage(elements.memoryResults, "Loading memory entries…", "loading");
@@ -598,16 +580,8 @@ async function sendText(text, mode = state.mode) {
   setBusy(true, mode === "background" ? "Starting background run" : mode === "streaming" ? "Streaming" : "Running");
   try {
     await dispatch({ input: [{ role: "user", content }] }, mode);
-    const items = [{ role: "user", content, transport: mode, instance_id: state.instanceId }];
-    if (state.lastAssistantText) {
-      items.push({
-        role: "assistant",
-        content: state.lastAssistantText,
-        transport: mode,
-        instance_id: state.instanceId,
-      });
-    }
-    await recordSessionItems(items);
+    // The agent persists the turn to its own Session; refresh the panel to show it (no client write).
+    await refreshSessionView();
     return state.lastAssistantText;
   } catch (error) {
     finishDraft();
@@ -632,18 +606,8 @@ async function resume(decision) {
   setBusy(true, "Resuming");
   try {
     await dispatch(payload, "streaming");
-    const items = [
-      { role: "human_decision", content: decision, instance_id: state.instanceId },
-    ];
-    if (state.lastAssistantText) {
-      items.push({
-        role: "assistant",
-        content: state.lastAssistantText,
-        transport: "streaming",
-        instance_id: state.instanceId,
-      });
-    }
-    await recordSessionItems(items);
+    // The agent persists the resumed turn to its own Session; refresh the panel (no client write).
+    await refreshSessionView();
   } catch (error) {
     appendError(error);
   } finally {

--- a/integrations/mason/templates/ui/agent-openai/ui/app.js
+++ b/integrations/mason/templates/ui/agent-openai/ui/app.js
@@ -9,7 +9,6 @@ const elements = {
   composer: document.querySelector("#composer"),
   copySession: document.querySelector("#copy-session"),
   emptyState: document.querySelector("#empty-state"),
-  environmentBadge: document.querySelector("#environment-badge"),
   eventLog: document.querySelector("#event-log"),
   memoryFact: document.querySelector("#memory-fact"),
   memoryHelp: document.querySelector("#memory-help"),
@@ -94,9 +93,11 @@ function setBusy(busy, label = "Working") {
   else if (!elements.runStatus.classList.contains("error")) setStatus("Ready");
 }
 
-function setCapability(element, enabled) {
-  element.classList.toggle("enabled", Boolean(enabled));
-  element.classList.toggle("disabled", !enabled);
+function setCapability(element, state) {
+  const degraded = state === "degraded";
+  element.classList.toggle("enabled", state === true);
+  element.classList.toggle("degraded", degraded);
+  element.classList.toggle("disabled", !state);
 }
 
 function formatJson(value) {
@@ -769,7 +770,6 @@ async function loadConfig() {
     state.config = config;
     state.instanceId = config.instance_id;
     setSessionId(config.session_id);
-    elements.environmentBadge.textContent = config.deployed ? "Databricks App" : "Local runtime";
     elements.viewerValue.textContent = config.viewer;
     elements.streamingMode.textContent = config.streaming.transport;
     elements.backgroundMode.textContent = config.background.durable ? "Durable run store" : "In-process run store";
@@ -777,7 +777,10 @@ async function loadConfig() {
     elements.memoryMode.textContent = config.memory.enabled ? `Managed · actor ${config.memory.actor}` : "Not connected";
     setCapability(elements.streamingStatus, config.streaming.enabled);
     setCapability(elements.backgroundStatus, config.background.enabled);
-    setCapability(elements.sessionStatus, config.session.history);
+    setCapability(
+      elements.sessionStatus,
+      config.session.managed ? true : config.session.history ? "degraded" : false,
+    );
     setCapability(elements.memoryStatus, config.memory.enabled);
     elements.rememberButton.disabled = state.busy || !config.memory.enabled;
     elements.searchMemory.disabled = state.busy || !config.memory.enabled;
@@ -800,7 +803,6 @@ async function loadConfig() {
     else stateMessage(elements.memoryResults, "Connect a Memory Store to manage entries.");
     return config;
   } catch (error) {
-    elements.environmentBadge.textContent = "Runtime unavailable";
     throw error;
   }
 }

--- a/integrations/mason/templates/ui/agent-openai/ui/index.html
+++ b/integrations/mason/templates/ui/agent-openai/ui/index.html
@@ -151,17 +151,7 @@
           <section class="control-card">
             <div class="control-card-heading">
               <div><p class="eyebrow">Cross-session</p><h2>Long-term memory</h2></div>
-            </div>
-            <label for="memory-path">Entry path</label>
-            <input id="memory-path" value="/profile.md" />
-            <label for="memory-fact">Content</label>
-            <textarea id="memory-fact" rows="2" placeholder="I prefer concise answers with examples."></textarea>
-            <label for="memory-query">Search query</label>
-            <input id="memory-query" value="profile preferences" />
-            <div class="button-row wrap">
-              <button id="remember-button" class="button button-primary" type="button">Save entry</button>
-              <button id="search-memory" class="button button-secondary" type="button">Search</button>
-              <button id="ask-memory" class="button button-secondary" type="button">Ask agent</button>
+              <button id="refresh-memory" class="icon-button" type="button" aria-label="Refresh memory entries">↻</button>
             </div>
             <p id="memory-help" class="supporting-text">Connect a Memory Store to manage entries.</p>
             <div id="memory-results" class="state-list" aria-live="polite">

--- a/integrations/mason/templates/ui/agent-openai/ui/index.html
+++ b/integrations/mason/templates/ui/agent-openai/ui/index.html
@@ -19,9 +19,6 @@
             <h1>Agent Lab</h1>
           </div>
         </div>
-        <div class="topbar-status" aria-live="polite">
-          <span id="environment-badge" class="badge badge-neutral">Loading runtime</span>
-        </div>
       </header>
 
       <div class="trust-strip">

--- a/integrations/mason/templates/ui/agent-openai/ui/index.html
+++ b/integrations/mason/templates/ui/agent-openai/ui/index.html
@@ -1,0 +1,189 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="color-scheme" content="light dark" />
+    <title>Mason Agent Lab</title>
+    <link rel="stylesheet" href="/ui-assets/styles.css" />
+  </head>
+  <body>
+    <div class="app-shell">
+      <header class="topbar">
+        <div class="brand-lockup">
+          <div class="brand-mark" aria-hidden="true">
+            <span></span><span></span><span></span>
+          </div>
+          <div>
+            <p class="eyebrow">Mason CLI</p>
+            <h1>Agent Lab</h1>
+          </div>
+        </div>
+        <div class="topbar-status" aria-live="polite">
+          <span id="environment-badge" class="badge badge-neutral">Loading runtime</span>
+        </div>
+      </header>
+
+      <div class="trust-strip">
+        <span>AI-generated responses can be wrong. Verify important output.</span>
+      </div>
+
+      <main class="workspace">
+        <aside class="left-rail" aria-label="Runtime configuration">
+          <section class="rail-section">
+            <div class="section-heading">
+              <div>
+                <p class="eyebrow">Runtime</p>
+                <h2>Capabilities</h2>
+              </div>
+              <button id="refresh-config" class="icon-button" type="button" aria-label="Refresh runtime configuration">↻</button>
+            </div>
+            <div class="capability-list">
+              <div class="capability-row">
+                <span class="capability-icon">↯</span>
+                <span><strong>Streaming</strong><small id="streaming-mode-value">Checking…</small></span>
+                <span id="streaming-status" class="status-orb"></span>
+              </div>
+              <div class="capability-row">
+                <span class="capability-icon">◷</span>
+                <span><strong>Background</strong><small id="background-mode-value">Checking…</small></span>
+                <span id="background-status" class="status-orb"></span>
+              </div>
+              <div class="capability-row">
+                <span class="capability-icon">◎</span>
+                <span><strong>Session</strong><small id="session-mode-value">Checking…</small></span>
+                <span id="session-status" class="status-orb"></span>
+              </div>
+              <div class="capability-row">
+                <span class="capability-icon">◇</span>
+                <span><strong>Memory</strong><small id="memory-mode-value">Checking…</small></span>
+                <span id="memory-status" class="status-orb"></span>
+              </div>
+            </div>
+          </section>
+
+          <section class="rail-section session-card">
+            <div class="section-heading compact">
+              <div>
+                <p class="eyebrow">Conversation history</p>
+                <h2>Sessions</h2>
+              </div>
+              <div class="button-row compact-actions">
+                <button id="new-session" class="text-button" type="button">New session</button>
+                <button id="refresh-session" class="text-button" type="button">Refresh</button>
+              </div>
+            </div>
+            <button id="copy-session" class="session-key" type="button" title="Copy session ID">
+              <code id="session-id">Loading…</code>
+              <span>Copy</span>
+            </button>
+            <div class="button-row wrap">
+              <button id="resume-session" class="button button-primary" type="button">Approve paused HITL</button>
+              <button id="reject-session" class="button button-secondary" type="button">Reject paused HITL</button>
+            </div>
+            <p id="session-store-label" class="supporting-text">The Databricks Apps routing cookie is also the application session ID.</p>
+            <label>Recent sessions</label>
+            <div id="session-list" class="state-list compact-list" aria-live="polite">
+              <div class="state-empty">Loading sessions…</div>
+            </div>
+            <label>Current transcript</label>
+            <div id="session-items" class="state-list compact-list" aria-live="polite">
+              <div class="state-empty">Connect a Session Store to mirror transcript items.</div>
+            </div>
+          </section>
+
+          <section class="rail-section identity-card">
+            <p class="eyebrow">Signed in as</p>
+            <h2>Viewer</h2>
+            <p id="viewer-value" class="identity-primary">Loading viewer…</p>
+          </section>
+        </aside>
+
+        <section class="chat-panel" aria-label="Agent chat">
+          <div class="chat-header">
+            <div>
+              <p class="eyebrow">Interactive client</p>
+              <h2>OpenAI agent</h2>
+            </div>
+            <span id="run-status" class="run-status">Ready</span>
+          </div>
+
+          <div id="chat-log" class="chat-log" role="log" aria-live="polite" aria-busy="false">
+            <div id="empty-state" class="empty-state">
+              <div class="empty-orbit" aria-hidden="true"><span></span></div>
+              <p class="eyebrow">One backend, three transports</p>
+              <h2>Start a conversation</h2>
+              <p>Switch between streaming, background, and synchronous calls while keeping the same session.</p>
+              <div class="prompt-grid">
+                <button type="button" data-prompt="Use the get_current_time tool and explain what you did.">Use a tool</button>
+                <button type="button" data-prompt="Remember in this conversation that my launch color is indigo. Do not use long-term memory.">Test session</button>
+                <button type="button" data-prompt="Send a message to demo@databricks.com saying the Mason demo is ready. Use the send_message tool.">Trigger approval</button>
+              </div>
+            </div>
+          </div>
+
+          <div id="approval-panel" class="approval-panel" hidden>
+            <div>
+              <p class="eyebrow">Human approval required</p>
+              <p id="approval-summary">A tool is waiting for a decision.</p>
+            </div>
+            <div class="approval-actions">
+              <button id="reject-action" class="button button-secondary" type="button">Reject</button>
+              <button id="approve-action" class="button button-primary" type="button">Approve</button>
+            </div>
+          </div>
+
+          <form id="composer" class="composer">
+            <label class="sr-only" for="prompt-input">Message the agent</label>
+            <textarea id="prompt-input" rows="1" placeholder="Ask the agent, use a tool, or test memory…"></textarea>
+            <div class="composer-footer">
+              <div class="mode-switcher" aria-label="Invocation mode">
+                <button class="mode-button active" data-mode="streaming" type="button">Streaming</button>
+                <button class="mode-button" data-mode="background" type="button">Background</button>
+                <button class="mode-button" data-mode="sync" type="button">Sync</button>
+              </div>
+              <button id="send-button" class="send-button" type="submit">
+                <span>Send</span>
+                <span aria-hidden="true">↑</span>
+              </button>
+            </div>
+          </form>
+        </section>
+
+        <aside class="right-rail" aria-label="Demo controls">
+          <section class="control-card">
+            <div class="control-card-heading">
+              <div><p class="eyebrow">Cross-session</p><h2>Long-term memory</h2></div>
+            </div>
+            <label for="memory-path">Entry path</label>
+            <input id="memory-path" value="/profile.md" />
+            <label for="memory-fact">Content</label>
+            <textarea id="memory-fact" rows="2" placeholder="I prefer concise answers with examples."></textarea>
+            <label for="memory-query">Search query</label>
+            <input id="memory-query" value="profile preferences" />
+            <div class="button-row wrap">
+              <button id="remember-button" class="button button-primary" type="button">Save entry</button>
+              <button id="search-memory" class="button button-secondary" type="button">Search</button>
+              <button id="ask-memory" class="button button-secondary" type="button">Ask agent</button>
+            </div>
+            <p id="memory-help" class="supporting-text">Connect a Memory Store to manage entries.</p>
+            <div id="memory-results" class="state-list" aria-live="polite">
+              <div class="state-empty">Memory entries appear here.</div>
+            </div>
+          </section>
+
+          <section class="control-card event-card">
+            <div class="section-heading compact">
+              <div><p class="eyebrow">Native contract</p><h2>Event feed</h2></div>
+              <button id="clear-events" class="text-button" type="button">Clear</button>
+            </div>
+            <div id="event-log" class="event-log" role="log">
+              <div class="event-empty">Invocation events appear here.</div>
+            </div>
+          </section>
+        </aside>
+      </main>
+    </div>
+    <script src="/ui-assets/app.js" defer></script>
+  </body>
+</html>

--- a/integrations/mason/templates/ui/agent-openai/ui/styles.css
+++ b/integrations/mason/templates/ui/agent-openai/ui/styles.css
@@ -81,7 +81,6 @@ code {
 }
 
 .brand-lockup,
-.topbar-status,
 .section-heading,
 .control-card-heading,
 .button-row,
@@ -144,28 +143,11 @@ h2 {
   line-height: 1.25;
 }
 
-.topbar-status {
-  gap: 10px;
-}
-
-.badge,
 .run-status {
   display: inline-flex;
   align-items: center;
   border-radius: 999px;
   white-space: nowrap;
-}
-
-.badge {
-  min-height: 28px;
-  padding: 4px 10px;
-  font-size: 0.74rem;
-  font-weight: 700;
-}
-
-.badge-neutral {
-  background: var(--surface-muted);
-  color: var(--ink-soft);
 }
 
 .status-orb {
@@ -178,6 +160,11 @@ h2 {
 .status-orb.enabled {
   background: var(--success);
   box-shadow: 0 0 0 4px var(--success-soft);
+}
+
+.status-orb.degraded {
+  background: var(--warning);
+  box-shadow: 0 0 0 4px var(--warning-soft);
 }
 
 .status-orb.disabled {
@@ -981,7 +968,6 @@ h2 {
     padding: 13px 16px;
   }
 
-  .badge-neutral,
   .trust-strip span:last-child {
     display: none;
   }
@@ -1016,10 +1002,6 @@ h2 {
 }
 
 @media (max-width: 560px) {
-  .topbar-status {
-    gap: 4px;
-  }
-
   .left-rail {
     display: flex;
   }

--- a/integrations/mason/templates/ui/agent-openai/ui/styles.css
+++ b/integrations/mason/templates/ui/agent-openai/ui/styles.css
@@ -1,0 +1,1050 @@
+:root {
+  --page: #f4f3ef;
+  --surface: #fffefa;
+  --surface-raised: #ffffff;
+  --surface-muted: #eeede8;
+  --ink: #171715;
+  --ink-soft: #66645f;
+  --line: #dad8d1;
+  --line-strong: #b9b6ad;
+  --accent: #ff4f32;
+  --accent-deep: #d93820;
+  --accent-soft: #ffe4dd;
+  --success: #16794b;
+  --success-soft: #dff4e9;
+  --warning: #9a5b00;
+  --warning-soft: #fff0cb;
+  --danger: #b3261e;
+  --danger-soft: #ffe4e1;
+  --focus: #3759c7;
+  --shadow: 0 16px 45px rgba(34, 31, 24, 0.08);
+  --radius-large: 22px;
+  --radius-medium: 15px;
+  --radius-small: 10px;
+  color-scheme: light;
+  font-family: Inter, ui-sans-serif, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-width: 320px;
+  min-height: 100vh;
+  background:
+    radial-gradient(circle at 15% 0%, rgba(255, 79, 50, 0.1), transparent 24rem),
+    var(--page);
+  color: var(--ink);
+}
+
+button,
+input,
+textarea {
+  font: inherit;
+}
+
+button {
+  color: inherit;
+}
+
+button:focus-visible,
+input:focus-visible,
+textarea:focus-visible {
+  outline: 3px solid color-mix(in srgb, var(--focus) 34%, transparent);
+  outline-offset: 2px;
+}
+
+code {
+  font-family: "SFMono-Regular", Consolas, "Liberation Mono", monospace;
+  font-size: 0.9em;
+}
+
+.app-shell {
+  min-height: 100vh;
+}
+
+.topbar {
+  height: 76px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 24px;
+  padding: 0 28px;
+  border-bottom: 1px solid var(--line);
+  background: color-mix(in srgb, var(--surface) 92%, transparent);
+  backdrop-filter: blur(18px);
+  position: sticky;
+  top: 0;
+  z-index: 20;
+}
+
+.brand-lockup,
+.topbar-status,
+.section-heading,
+.control-card-heading,
+.button-row,
+.composer-footer,
+.approval-actions {
+  display: flex;
+  align-items: center;
+}
+
+.brand-lockup {
+  gap: 13px;
+}
+
+.brand-mark {
+  width: 38px;
+  height: 38px;
+  position: relative;
+  display: grid;
+  place-items: center;
+  transform: rotate(-8deg);
+}
+
+.brand-mark span {
+  position: absolute;
+  width: 32px;
+  height: 9px;
+  border: 2px solid var(--accent);
+  border-radius: 2px;
+  transform: skewY(-17deg);
+}
+
+.brand-mark span:nth-child(1) { top: 4px; }
+.brand-mark span:nth-child(2) { top: 14px; }
+.brand-mark span:nth-child(3) { top: 24px; }
+
+.eyebrow {
+  margin: 0 0 4px;
+  color: var(--ink-soft);
+  font-size: 0.68rem;
+  font-weight: 750;
+  letter-spacing: 0.11em;
+  text-transform: uppercase;
+}
+
+h1,
+h2,
+p {
+  margin-top: 0;
+}
+
+h1 {
+  margin-bottom: 0;
+  font-size: 1.04rem;
+  line-height: 1;
+}
+
+h2 {
+  margin-bottom: 0;
+  font-size: 0.98rem;
+  line-height: 1.25;
+}
+
+.topbar-status {
+  gap: 10px;
+}
+
+.badge,
+.run-status {
+  display: inline-flex;
+  align-items: center;
+  border-radius: 999px;
+  white-space: nowrap;
+}
+
+.badge {
+  min-height: 28px;
+  padding: 4px 10px;
+  font-size: 0.74rem;
+  font-weight: 700;
+}
+
+.badge-neutral {
+  background: var(--surface-muted);
+  color: var(--ink-soft);
+}
+
+.status-orb {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--line-strong);
+}
+
+.status-orb.enabled {
+  background: var(--success);
+  box-shadow: 0 0 0 4px var(--success-soft);
+}
+
+.status-orb.disabled {
+  background: var(--danger);
+  box-shadow: 0 0 0 4px var(--danger-soft);
+}
+
+.trust-strip {
+  min-height: 34px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 7px 28px;
+  border-bottom: 1px solid var(--line);
+  background: var(--surface-muted);
+  color: var(--ink-soft);
+  font-size: 0.72rem;
+}
+
+.workspace {
+  display: grid;
+  grid-template-columns: minmax(220px, 0.76fr) minmax(440px, 1.75fr) minmax(260px, 0.95fr);
+  gap: 18px;
+  width: min(1600px, 100%);
+  min-height: calc(100vh - 110px);
+  margin: 0 auto;
+  padding: 18px;
+}
+
+.left-rail,
+.right-rail {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.rail-section,
+.control-card,
+.chat-panel {
+  border: 1px solid var(--line);
+  background: var(--surface);
+  box-shadow: var(--shadow);
+}
+
+.rail-section,
+.control-card {
+  border-radius: var(--radius-medium);
+  padding: 18px;
+}
+
+.section-heading {
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 16px;
+}
+
+.section-heading.compact {
+  margin-bottom: 13px;
+}
+
+.icon-button,
+.text-button {
+  border: 0;
+  background: transparent;
+  cursor: pointer;
+}
+
+.icon-button {
+  width: 30px;
+  height: 30px;
+  border-radius: 50%;
+  font-size: 1.15rem;
+}
+
+.icon-button:hover,
+.text-button:hover {
+  background: var(--surface-muted);
+}
+
+.text-button {
+  padding: 5px 8px;
+  border-radius: 7px;
+  color: var(--accent-deep);
+  font-size: 0.75rem;
+  font-weight: 750;
+  white-space: nowrap;
+}
+
+.capability-list {
+  display: grid;
+  gap: 6px;
+}
+
+.capability-row {
+  display: grid;
+  grid-template-columns: 34px minmax(0, 1fr) 10px;
+  align-items: center;
+  gap: 9px;
+  min-height: 52px;
+  padding: 8px 6px;
+  border-bottom: 1px solid var(--line);
+}
+
+.capability-row:last-child {
+  border-bottom: 0;
+}
+
+.capability-icon {
+  width: 32px;
+  height: 32px;
+  display: grid;
+  place-items: center;
+  border-radius: 9px;
+  background: var(--surface-muted);
+  color: var(--accent-deep);
+  font-weight: 800;
+}
+
+.capability-row strong,
+.capability-row small {
+  display: block;
+}
+
+.capability-row strong {
+  margin-bottom: 3px;
+  font-size: 0.81rem;
+}
+
+.capability-row small {
+  overflow: hidden;
+  color: var(--ink-soft);
+  font-size: 0.69rem;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.session-key {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  padding: 11px 12px;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-small);
+  background: var(--surface-raised);
+  cursor: pointer;
+}
+
+.session-key code {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.session-key span {
+  color: var(--accent-deep);
+  font-size: 0.7rem;
+  font-weight: 750;
+}
+
+.session-card label {
+  display: block;
+  margin: 12px 0 5px;
+  color: var(--ink-soft);
+  font-size: 0.68rem;
+  font-weight: 750;
+}
+
+.session-open-row {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 7px;
+}
+
+.session-open-row input {
+  min-width: 0;
+  padding: 8px 9px;
+  border: 1px solid var(--line);
+  border-radius: 9px;
+  background: var(--surface-raised);
+  color: var(--ink);
+  font-family: "SFMono-Regular", Consolas, monospace;
+  font-size: 0.68rem;
+}
+
+.supporting-text {
+  margin: 10px 0 0;
+  color: var(--ink-soft);
+  font-size: 0.72rem;
+  line-height: 1.5;
+}
+
+.identity-primary {
+  margin: 13px 0 4px;
+  font-size: 0.83rem;
+  font-weight: 700;
+  overflow-wrap: anywhere;
+}
+
+.chat-panel {
+  min-height: 700px;
+  display: grid;
+  grid-template-rows: auto minmax(0, 1fr) auto auto;
+  border-radius: var(--radius-large);
+  overflow: hidden;
+}
+
+.chat-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 18px 22px;
+  border-bottom: 1px solid var(--line);
+}
+
+.run-status {
+  min-height: 26px;
+  padding: 4px 10px;
+  background: var(--success-soft);
+  color: var(--success);
+  font-size: 0.7rem;
+  font-weight: 750;
+}
+
+.run-status.busy {
+  background: var(--warning-soft);
+  color: var(--warning);
+}
+
+.run-status.error {
+  background: var(--danger-soft);
+  color: var(--danger);
+}
+
+.chat-log {
+  min-height: 0;
+  overflow-y: auto;
+  padding: 24px;
+  scroll-behavior: smooth;
+}
+
+.empty-state {
+  width: min(520px, 100%);
+  min-height: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  margin: auto;
+  padding: 56px 20px;
+  text-align: center;
+}
+
+.empty-state[hidden] {
+  display: none;
+}
+
+.empty-orbit {
+  width: 70px;
+  height: 70px;
+  display: grid;
+  place-items: center;
+  margin-bottom: 22px;
+  border: 1px solid var(--line-strong);
+  border-radius: 50%;
+  position: relative;
+}
+
+.empty-orbit::before,
+.empty-orbit::after {
+  content: "";
+  position: absolute;
+  inset: 11px;
+  border: 1px solid var(--accent);
+  border-radius: 50%;
+  transform: rotate(45deg) scaleY(0.45);
+}
+
+.empty-orbit::after {
+  transform: rotate(-45deg) scaleY(0.45);
+}
+
+.empty-orbit span {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  background: var(--accent);
+}
+
+.empty-state h2 {
+  margin-bottom: 9px;
+  font-size: 1.38rem;
+}
+
+.empty-state > p:not(.eyebrow) {
+  max-width: 430px;
+  color: var(--ink-soft);
+  font-size: 0.86rem;
+  line-height: 1.55;
+}
+
+.prompt-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 8px;
+  width: 100%;
+  margin-top: 14px;
+}
+
+.prompt-grid button {
+  min-height: 54px;
+  padding: 9px 10px;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-small);
+  background: var(--surface-raised);
+  cursor: pointer;
+  font-size: 0.72rem;
+  font-weight: 700;
+}
+
+.prompt-grid button:hover {
+  border-color: var(--accent);
+  color: var(--accent-deep);
+}
+
+.message {
+  display: grid;
+  grid-template-columns: 30px minmax(0, 1fr);
+  gap: 11px;
+  margin-bottom: 20px;
+}
+
+.message.user {
+  grid-template-columns: minmax(0, 1fr) 30px;
+}
+
+.message-avatar {
+  width: 30px;
+  height: 30px;
+  display: grid;
+  place-items: center;
+  border-radius: 9px;
+  background: var(--ink);
+  color: var(--surface);
+  font-size: 0.66rem;
+  font-weight: 800;
+}
+
+.message.user .message-avatar {
+  grid-column: 2;
+  background: var(--accent);
+}
+
+.message-body {
+  min-width: 0;
+}
+
+.message.user .message-body {
+  grid-column: 1;
+  grid-row: 1;
+  justify-self: end;
+}
+
+.message-meta {
+  margin-bottom: 5px;
+  color: var(--ink-soft);
+  font-size: 0.65rem;
+  font-weight: 700;
+}
+
+.message.user .message-meta {
+  text-align: right;
+}
+
+.message-content {
+  display: inline-block;
+  max-width: min(680px, 100%);
+  padding: 11px 13px;
+  border: 1px solid var(--line);
+  border-radius: 5px 15px 15px 15px;
+  background: var(--surface-raised);
+  font-size: 0.84rem;
+  line-height: 1.6;
+  overflow-wrap: anywhere;
+  white-space: pre-wrap;
+}
+
+.message.user .message-content {
+  border-color: var(--ink);
+  border-radius: 15px 5px 15px 15px;
+  background: var(--ink);
+  color: var(--surface);
+}
+
+.message.tool .message-avatar,
+.message.system .message-avatar {
+  background: var(--surface-muted);
+  color: var(--ink-soft);
+}
+
+.message.tool .message-content,
+.message.system .message-content {
+  background: var(--surface-muted);
+  color: var(--ink-soft);
+  font-family: "SFMono-Regular", Consolas, monospace;
+  font-size: 0.74rem;
+}
+
+.message.error .message-avatar {
+  background: var(--danger);
+}
+
+.message.error .message-content {
+  border-color: color-mix(in srgb, var(--danger) 38%, var(--line));
+  background: var(--danger-soft);
+  color: var(--danger);
+}
+
+.message.streaming .message-content::after {
+  content: "";
+  display: inline-block;
+  width: 7px;
+  height: 14px;
+  margin-left: 4px;
+  background: var(--accent);
+  vertical-align: -2px;
+  animation: blink 0.8s infinite;
+}
+
+.approval-panel {
+  margin: 0 20px 14px;
+  padding: 14px 16px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  border: 1px solid color-mix(in srgb, var(--warning) 35%, var(--line));
+  border-radius: var(--radius-medium);
+  background: var(--warning-soft);
+}
+
+.approval-panel[hidden] {
+  display: none;
+}
+
+.approval-panel p:last-child {
+  margin-bottom: 0;
+  font-size: 0.79rem;
+}
+
+.approval-actions,
+.button-row {
+  gap: 8px;
+}
+
+.button-row.wrap {
+  flex-wrap: wrap;
+}
+
+.compact-actions {
+  margin-top: 0;
+}
+
+.composer {
+  margin: 0 18px 18px;
+  padding: 11px;
+  border: 1px solid var(--line-strong);
+  border-radius: var(--radius-medium);
+  background: var(--surface-raised);
+  box-shadow: 0 7px 28px rgba(34, 31, 24, 0.07);
+}
+
+.composer:focus-within {
+  border-color: var(--focus);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--focus) 15%, transparent);
+}
+
+.composer textarea {
+  width: 100%;
+  max-height: 180px;
+  resize: none;
+  padding: 5px 6px 11px;
+  border: 0;
+  outline: 0;
+  background: transparent;
+  color: var(--ink);
+  line-height: 1.5;
+}
+
+.composer-footer {
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.mode-switcher {
+  display: inline-flex;
+  padding: 3px;
+  border-radius: 9px;
+  background: var(--surface-muted);
+}
+
+.mode-button {
+  padding: 6px 9px;
+  border: 0;
+  border-radius: 7px;
+  background: transparent;
+  color: var(--ink-soft);
+  cursor: pointer;
+  font-size: 0.68rem;
+  font-weight: 750;
+}
+
+.mode-button.active {
+  background: var(--surface-raised);
+  color: var(--ink);
+  box-shadow: 0 2px 7px rgba(34, 31, 24, 0.1);
+}
+
+.send-button {
+  min-width: 86px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  padding: 8px 12px;
+  border: 0;
+  border-radius: 9px;
+  background: var(--accent);
+  color: #ffffff;
+  cursor: pointer;
+  font-size: 0.75rem;
+  font-weight: 800;
+}
+
+.send-button:hover {
+  background: var(--accent-deep);
+}
+
+.send-button:disabled,
+.button:disabled {
+  cursor: not-allowed;
+  opacity: 0.45;
+}
+
+.control-card-heading {
+  gap: 11px;
+  margin-bottom: 15px;
+}
+
+.control-card label {
+  display: block;
+  margin: 11px 0 5px;
+  color: var(--ink-soft);
+  font-size: 0.68rem;
+  font-weight: 750;
+}
+
+.control-card input,
+.control-card textarea {
+  width: 100%;
+  padding: 9px 10px;
+  border: 1px solid var(--line);
+  border-radius: 9px;
+  background: var(--surface-raised);
+  color: var(--ink);
+  font-size: 0.76rem;
+  resize: vertical;
+}
+
+.button-row {
+  margin-top: 11px;
+  align-items: stretch;
+}
+
+.button {
+  min-height: 36px;
+  padding: 8px 11px;
+  border-radius: 9px;
+  cursor: pointer;
+  font-size: 0.7rem;
+  font-weight: 800;
+}
+
+.button-primary {
+  border: 1px solid var(--ink);
+  background: var(--ink);
+  color: var(--surface);
+}
+
+.button-secondary {
+  border: 1px solid var(--line-strong);
+  background: var(--surface-raised);
+}
+
+.state-list {
+  max-height: 230px;
+  margin-top: 12px;
+  overflow: auto;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-small);
+  background: var(--surface-raised);
+}
+
+.compact-list {
+  max-height: 190px;
+}
+
+.state-empty,
+.state-loading,
+.state-error {
+  padding: 13px;
+  color: var(--ink-soft);
+  font-size: 0.7rem;
+  line-height: 1.45;
+}
+
+.state-loading {
+  color: var(--warning);
+}
+
+.state-error {
+  color: var(--danger);
+  background: var(--danger-soft);
+}
+
+.state-item {
+  padding: 10px 11px;
+  border-bottom: 1px solid var(--line);
+}
+
+.state-item:last-child {
+  border-bottom: 0;
+}
+
+.state-item strong,
+.state-item p,
+.state-item small {
+  display: block;
+  overflow-wrap: anywhere;
+}
+
+.state-item strong {
+  color: var(--ink);
+  font-size: 0.7rem;
+}
+
+.session-item.current {
+  background: var(--success-soft);
+}
+
+.session-item-heading {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.session-item-heading .text-button {
+  flex: 0 0 auto;
+  padding: 2px 6px;
+}
+
+.state-item p {
+  margin: 5px 0;
+  color: var(--ink-soft);
+  font-size: 0.7rem;
+  line-height: 1.42;
+  white-space: pre-wrap;
+}
+
+.state-item small {
+  color: var(--line-strong);
+  font-size: 0.61rem;
+}
+
+.event-card {
+  min-height: 260px;
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+}
+
+.event-log {
+  min-height: 150px;
+  max-height: 350px;
+  overflow: auto;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-small);
+  background: #1d1e1c;
+  color: #e8e8e2;
+}
+
+.event-empty {
+  padding: 20px 14px;
+  color: #9d9f98;
+  font-size: 0.72rem;
+  text-align: center;
+}
+
+.event-entry {
+  padding: 9px 10px;
+  border-bottom: 1px solid #343630;
+}
+
+.event-entry:last-child {
+  border-bottom: 0;
+}
+
+.event-entry-header {
+  display: flex;
+  justify-content: space-between;
+  gap: 8px;
+  margin-bottom: 5px;
+  color: #b7b9b2;
+  font-size: 0.61rem;
+  font-weight: 750;
+  text-transform: uppercase;
+}
+
+.event-entry pre {
+  margin: 0;
+  color: #f4f4ee;
+  font-family: "SFMono-Regular", Consolas, monospace;
+  font-size: 0.63rem;
+  line-height: 1.45;
+  overflow-wrap: anywhere;
+  white-space: pre-wrap;
+}
+
+.sr-only {
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+  position: absolute;
+}
+
+@keyframes pulse {
+  0%, 100% { opacity: 0.45; }
+  50% { opacity: 1; }
+}
+
+@keyframes blink {
+  0%, 45% { opacity: 1; }
+  46%, 100% { opacity: 0; }
+}
+
+@media (min-width: 1181px) {
+  html,
+  body,
+  .app-shell {
+    height: 100%;
+    overflow: hidden;
+  }
+
+  .workspace {
+    height: calc(100vh - 110px);
+    min-height: 0;
+  }
+
+  .left-rail,
+  .right-rail {
+    min-height: 0;
+    overflow-y: auto;
+    overscroll-behavior: contain;
+    scrollbar-gutter: stable;
+  }
+
+  .chat-panel {
+    height: 100%;
+    min-height: 0;
+  }
+}
+
+@media (max-width: 1180px) {
+  .workspace {
+    grid-template-columns: 220px minmax(440px, 1fr);
+  }
+
+  .right-rail {
+    grid-column: 1 / -1;
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+  }
+
+  .event-card {
+    min-height: 0;
+  }
+}
+
+@media (max-width: 820px) {
+  .topbar {
+    height: auto;
+    padding: 13px 16px;
+  }
+
+  .badge-neutral,
+  .trust-strip span:last-child {
+    display: none;
+  }
+
+  .trust-strip {
+    padding-inline: 16px;
+  }
+
+  .workspace {
+    display: flex;
+    flex-direction: column;
+    padding: 10px;
+  }
+
+  .left-rail {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+  }
+
+  .left-rail .rail-section:first-child {
+    grid-column: 1 / -1;
+  }
+
+  .right-rail {
+    display: flex;
+  }
+
+  .chat-panel {
+    min-height: 680px;
+    order: -1;
+  }
+}
+
+@media (max-width: 560px) {
+  .topbar-status {
+    gap: 4px;
+  }
+
+  .left-rail {
+    display: flex;
+  }
+
+  .chat-log {
+    padding: 18px 14px;
+  }
+
+  .prompt-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .approval-panel,
+  .composer-footer {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .approval-actions .button,
+  .send-button {
+    flex: 1;
+  }
+
+  .mode-switcher {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+  }
+}

--- a/integrations/mason/tests/unit_tests/init_test.py
+++ b/integrations/mason/tests/unit_tests/init_test.py
@@ -30,7 +30,7 @@ def test_framework_specs_have_repo_ref_path():
     for fw in ("openai", "langgraph"):
         spec = init_mod._TEMPLATES[fw]
         assert spec["repo"] and spec["ref"] and spec["path"]
-    assert init_mod._TEMPLATES["openai"]["path"] == "agent-openai-basic"
+    assert init_mod._TEMPLATES["openai"]["path"] == "integrations/mason/templates/agent-openai"
     assert (
         init_mod._TEMPLATES["langgraph"]["path"] == "integrations/mason/templates/agent-langgraph"
     )
@@ -38,14 +38,14 @@ def test_framework_specs_have_repo_ref_path():
         init_mod._CHAT_APP_TEMPLATES["langgraph"]
         == "integrations/mason/templates/ui/agent-langgraph"
     )
+    assert init_mod._CHAT_APP_TEMPLATES["openai"] == "integrations/mason/templates/ui/agent-openai"
 
 
 def test_template_ref_pins_versioned_template_to_release_tag(monkeypatch: pytest.MonkeyPatch):
     monkeypatch.setattr(init_mod, "_installed_version", lambda _: "0.3.0")
-    # A released CLI fetches the template tagged for its own version.
+    # A released CLI fetches each versioned template tagged for its own version.
     assert init_mod._template_ref("langgraph") == "databricks-mason-v0.3.0"
-    # An unversioned framework (different repo, not tagged in lockstep) keeps its default ref.
-    assert init_mod._template_ref("openai") == "main"
+    assert init_mod._template_ref("openai") == "databricks-mason-v0.3.0"
 
 
 @pytest.mark.parametrize("installed", ["0.1.0.dev0", "0.2.0+local"])
@@ -66,7 +66,7 @@ def test_template_ref_falls_back_when_package_not_installed(monkeypatch: pytest.
 
 
 def test_init_scaffolds_default_directory(tmp_path: pathlib.Path):
-    dest = tmp_path / "agent-openai-basic"
+    dest = tmp_path / "agent-openai"
 
     def fake_fetch(repo, ref, template_path, target, overlay_dirs=()):
         target.mkdir(parents=True)
@@ -78,9 +78,9 @@ def test_init_scaffolds_default_directory(tmp_path: pathlib.Path):
     fetched.assert_called_once()
     # framework's repo + path passed through to the fetch
     assert fetched.call_args.args[0] == init_mod._TEMPLATES["openai"]["repo"]
-    assert fetched.call_args.args[2] == "agent-openai-basic"
+    assert fetched.call_args.args[2] == "integrations/mason/templates/agent-openai"
     assert (dest / "app.yaml").exists()
-    assert "agent-openai-basic" in result.output
+    assert "agent-openai" in result.output
 
 
 def test_init_defaults_to_langgraph_framework(tmp_path: pathlib.Path):
@@ -245,15 +245,28 @@ def test_init_enable_chat_app_flag_is_accepted_no_op(tmp_path: pathlib.Path):
     assert f.call_args.args[4] == ("integrations/mason/templates/ui/agent-langgraph",)
 
 
-def test_init_openai_has_no_chat_app(tmp_path: pathlib.Path):
+def test_init_openai_includes_chat_app_by_default(tmp_path: pathlib.Path):
     dest = tmp_path / "proj"
     with mock.patch.object(init_mod, "_fetch_template", side_effect=lambda *a: a[3].mkdir()) as f:
         result = CliRunner().invoke(
             init_mod.init, ["--framework", "openai", str(dest)], obj=_Ctx(output="json")
         )
     assert result.exit_code == 0, result.output
-    assert f.call_args.args[4] == ()  # openai framework has no chat-app overlay
-    assert json.loads(result.output)["chat_app_enabled"] is False
+    assert f.call_args.args[4] == ("integrations/mason/templates/ui/agent-openai",)
+    assert json.loads(result.output)["chat_app_enabled"] is True
+
+
+def test_init_disable_chat_app_omits_openai_overlay(tmp_path: pathlib.Path):
+    dest = tmp_path / "api-only"
+    with mock.patch.object(init_mod, "_fetch_template", side_effect=lambda *a: a[3].mkdir()) as f:
+        result = CliRunner().invoke(
+            init_mod.init,
+            ["--framework", "openai", "--disable-chat-app", str(dest)],
+            obj=_Ctx(),
+        )
+    assert result.exit_code == 0, result.output
+    assert f.call_args.args[4] == ()  # no chat-app overlay
+    assert "Chat app" not in result.output
 
 
 def test_init_json_output(tmp_path: pathlib.Path):

--- a/integrations/mason/tests/unit_tests/tools_test.py
+++ b/integrations/mason/tests/unit_tests/tools_test.py
@@ -104,15 +104,30 @@ def test_add_mcp_and_uc_function_write_typed_manifest_records(tmp_path: pathlib.
         ["add", "sandbox", "--scope", "table:samples.nyctaxi.trips"],
         ["add", "mcp", "system.ai.web_search"],
         ["add", "uc-function", "main.tools.lookup_ticket"],
-        ["add", "python", "lookup-ticket"],
     ],
 )
-def test_add_rejects_framework_without_runtime_adapter(tmp_path: pathlib.Path, command: list[str]):
+def test_add_manifest_tool_works_for_any_framework(tmp_path: pathlib.Path, command: list[str]):
+    # mcp / uc_function / sandbox are framework-neutral agent.toml entries; adding them must succeed
+    # regardless of framework (every runtime adapter reads them from the manifest).
     project = _project(tmp_path, framework="openai")
 
     result = CliRunner().invoke(
         tools,
         [*command, "--source", str(project)],
+        obj=_Ctx(),
+    )
+
+    assert result.exit_code == 0, result.output
+    assert AgentProject.load(project).tools, "expected the tool to be written to the manifest"
+
+
+def test_add_python_rejects_non_langgraph_framework(tmp_path: pathlib.Path):
+    # `add python` scaffolds a framework-native tool file; only langgraph is supported so far.
+    project = _project(tmp_path, framework="openai")
+
+    result = CliRunner().invoke(
+        tools,
+        ["add", "python", "lookup-ticket", "--source", str(project)],
         obj=_Ctx(),
     )
 


### PR DESCRIPTION
Adds a second basic framework — `mason init --framework openai` — built on the OpenAI Agents SDK, mirroring the agent-langgraph template file-for-file:

- databricks_mason.openai adapter (sessions/mcp/memory/tracing) alongside the langgraph one, behind a new `runtime-openai` extra.
- templates/agent-openai + the templates/ui/agent-openai chat overlay. The agent translates Agents SDK stream events into the same {delta,message,interrupt} envelope, so the SDK-agnostic runtime and the browser UI are reused unchanged.
- init.py points the openai framework at this repo (versioned in lockstep with the CLI, chat app on by default).

HITL is in-process only: an Agents SDK Session persists the transcript, not paused RunState, so a paused run does not survive restarts/replicas even with a Session Store. Durable HITL is left for a follow-up, as is de-duping the copied chat UI.