### PR TITLE
[mason] deploy/dev: rename store flags and create stores by default

### DIFF
--- a/integrations/mason/README.md
+++ b/integrations/mason/README.md
@@ -78,7 +78,7 @@ mason [-p <profile>] [-o text|json]
   init         [--framework openai|langgraph] [--disable-chat-app]
                [--profile P] [--repo URL] [--ref REF] [directory]
   dev          [--source PATH] [--prepare-environment] [--app-port PORT]
-               [--memory N] [--session-store N]
+               [--memory/-m N] [--session/-s N]
                [--with-traces C.S] [--no-create-stores]
   memory
     stores     create | list | get | update | delete
@@ -97,8 +97,8 @@ mason [-p <profile>] [-o text|json]
     add uc-function  FUNCTION [--name NAME] [--source PATH]
     add python       NAME [--source PATH]
     list             [--source PATH]
-  deploy       <name> --source PATH [--memory N]
-               [--session-store N] [--actor-id ID]
+  deploy       <name> --source PATH [--memory/-m N]
+               [--session/-s N] [--actor-id ID]
                [--with-traces C.S] [--no-create-stores]
   deployments  list | get | logs | start | stop | delete
 ```
@@ -184,7 +184,7 @@ For the full deployed demo, connect both managed stores:
 
 ```sh
 mason --profile <profile> deploy mason-agent-demo --source . \
-  --session-store mason-demo-sessions \
+  --session mason-demo-sessions \
   --memory mason-demo-memory \
   --actor-id alice
 ```

--- a/integrations/mason/README.md
+++ b/integrations/mason/README.md
@@ -78,8 +78,8 @@ mason [-p <profile>] [-o text|json]
   init         [--framework openai|langgraph] [--disable-chat-app]
                [--profile P] [--repo URL] [--ref REF] [directory]
   dev          [--source PATH] [--prepare-environment] [--app-port PORT]
-               [--with-memory-store N] [--with-session-store N]
-               [--with-traces C.S] [--create-stores]
+               [--memory N] [--session-store N]
+               [--with-traces C.S] [--no-create-stores]
   memory
     stores     create | list | get | update | delete
     entries    create | get | list | search | update | delete
@@ -97,9 +97,9 @@ mason [-p <profile>] [-o text|json]
     add uc-function  FUNCTION [--name NAME] [--source PATH]
     add python       NAME [--source PATH]
     list             [--source PATH]
-  deploy       <name> --source PATH [--with-memory-store N]
-               [--with-session-store N] [--actor-id ID]
-               [--with-traces C.S] [--create-stores]
+  deploy       <name> --source PATH [--memory N]
+               [--session-store N] [--actor-id ID]
+               [--with-traces C.S] [--no-create-stores]
   deployments  list | get | logs | start | stop | delete
 ```
 
@@ -184,11 +184,12 @@ For the full deployed demo, connect both managed stores:
 
 ```sh
 mason --profile <profile> deploy mason-agent-demo --source . \
-  --with-session-store mason-demo-sessions \
-  --with-memory-store mason-demo-memory \
-  --actor-id alice \
-  --create-stores
+  --session-store mason-demo-sessions \
+  --memory mason-demo-memory \
+  --actor-id alice
 ```
+
+(Missing stores are created automatically; pass `--no-create-stores` to require they already exist.)
 
 The Databricks Apps `__Host-databricks-app-router` cookie is both the sticky routing key and the
 application session id. The browser sends it automatically; API clients must reuse it as a cookie.

--- a/integrations/mason/src/databricks_mason/deploy.py
+++ b/integrations/mason/src/databricks_mason/deploy.py
@@ -210,9 +210,10 @@ def resolve_store_env(
     """Resolve store/trace references to the AGENT_*/MLFLOW_* env vars that wire them in.
 
     Shared by `mason deploy` and `mason dev` so both wire an agent's stores into app.yaml the same
-    way. With `create_stores`, missing stores are created (idempotent); otherwise they must already
-    exist. The memory store resolves to its bare id (the runtime re-adds the `memory-stores/` prefix
-    when building the entries URL); the session store and trace destination are used verbatim.
+    way. With `create_stores` (the default), missing stores are created (idempotent); when it is off
+    they must already exist. The memory store resolves to its bare id (the runtime re-adds the
+    `memory-stores/` prefix when building the entries URL); the session store and trace destination
+    are used verbatim.
     """
     env: dict[str, str] = {}
     if memory_store:
@@ -224,7 +225,8 @@ def resolve_store_env(
             store = _resolve_memory_store(client, memory_store)
             if store is None:
                 raise AgentCliError(
-                    f"Memory store '{memory_store}' does not exist (create it with --create-stores)."
+                    f"Memory store '{memory_store}' does not exist "
+                    "(drop --no-create-stores to create it)."
                 )
         store_name = field(store, "name") or memory_store
         env[_MEMORY_ENV] = store_name.split("/", 1)[-1]
@@ -238,7 +240,7 @@ def resolve_store_env(
             except AgentCliError as exc:
                 raise AgentCliError(
                     f"Session store '{session_store}' does not exist "
-                    "(create it with --create-stores).",
+                    "(drop --no-create-stores to create it).",
                     error_code=exc.error_code,
                 ) from exc
         env[_SESSION_ENV] = session_store
@@ -300,17 +302,19 @@ def _grant_store_access(
     "current directory.",
 )
 @click.option(
-    "--with-memory-store",
+    "--memory",
     "memory_store",
     default=None,
     help="Memory store display name to wire in via AGENT_MEMORY_STORE.",
 )
 @click.option(
-    "--with-session-store",
+    "--session-store",
     "session_store",
     default=None,
     help="Session store name to wire in via AGENT_SESSION_STORE.",
 )
+@click.option("--with-memory-store", "memory_store", default=None, hidden=True)
+@click.option("--with-session-store", "session_store", default=None, hidden=True)
 @click.option(
     "--actor-id",
     default="agent",
@@ -330,9 +334,10 @@ def _grant_store_access(
     help="MLflow experiment path to wire in via MLFLOW_EXPERIMENT_NAME.",
 )
 @click.option(
-    "--create-stores",
-    is_flag=True,
-    help="Create the referenced stores if they don't exist (idempotent).",
+    "--create-stores/--no-create-stores",
+    default=True,
+    help="Create referenced stores if they don't exist (idempotent, default). "
+    "--no-create-stores requires them to already exist.",
 )
 @click.option(
     "--pip-index-url",

--- a/integrations/mason/src/databricks_mason/deploy.py
+++ b/integrations/mason/src/databricks_mason/deploy.py
@@ -334,10 +334,10 @@ def _grant_store_access(
     help="MLflow experiment path to wire in via MLFLOW_EXPERIMENT_NAME.",
 )
 @click.option(
-    "--create-stores/--no-create-stores",
-    default=True,
-    help="Create referenced stores if they don't exist (idempotent, default). "
-    "--no-create-stores requires them to already exist.",
+    "--no-create-stores",
+    is_flag=True,
+    help="Require referenced stores to already exist. By default missing stores are created "
+    "(idempotent).",
 )
 @click.option(
     "--pip-index-url",
@@ -362,7 +362,7 @@ def deploy(
     actor_id,
     traces_destination,
     traces_experiment,
-    create_stores,
+    no_create_stores,
     pip_index_url,
     workspace_path,
 ) -> None:
@@ -379,7 +379,7 @@ def deploy(
         session_store=session_store,
         traces_destination=traces_destination,
         traces_experiment=traces_experiment,
-        create_stores=create_stores,
+        create_stores=not no_create_stores,
     )
     provisioned: dict[str, Any] = {}
     if _MEMORY_ENV in env_updates:

--- a/integrations/mason/src/databricks_mason/deploy.py
+++ b/integrations/mason/src/databricks_mason/deploy.py
@@ -303,18 +303,18 @@ def _grant_store_access(
 )
 @click.option(
     "--memory",
+    "-m",
     "memory_store",
     default=None,
     help="Memory store display name to wire in via AGENT_MEMORY_STORE.",
 )
 @click.option(
-    "--session-store",
+    "--session",
+    "-s",
     "session_store",
     default=None,
     help="Session store name to wire in via AGENT_SESSION_STORE.",
 )
-@click.option("--with-memory-store", "memory_store", default=None, hidden=True)
-@click.option("--with-session-store", "session_store", default=None, hidden=True)
 @click.option(
     "--actor-id",
     default="agent",

--- a/integrations/mason/src/databricks_mason/dev.py
+++ b/integrations/mason/src/databricks_mason/dev.py
@@ -45,17 +45,19 @@ _BUILD_INDEX_ENVS = frozenset({"PIP_INDEX_URL", "UV_INDEX_URL", "UV_DEFAULT_INDE
 )
 @click.option("--app-port", type=int, default=None, help="Port to run the app on (default 8000).")
 @click.option(
-    "--with-memory-store",
+    "--memory",
     "memory_store",
     default=None,
     help="Memory store display name to wire in via AGENT_MEMORY_STORE (same as `mason deploy`).",
 )
 @click.option(
-    "--with-session-store",
+    "--session-store",
     "session_store",
     default=None,
     help="Session store name to wire in via AGENT_SESSION_STORE (same as `mason deploy`).",
 )
+@click.option("--with-memory-store", "memory_store", default=None, hidden=True)
+@click.option("--with-session-store", "session_store", default=None, hidden=True)
 @click.option(
     "--with-traces",
     "traces_destination",
@@ -68,9 +70,10 @@ _BUILD_INDEX_ENVS = frozenset({"PIP_INDEX_URL", "UV_INDEX_URL", "UV_DEFAULT_INDE
     help="MLflow experiment path to wire in via MLFLOW_EXPERIMENT_NAME.",
 )
 @click.option(
-    "--create-stores",
-    is_flag=True,
-    help="Create the referenced stores if they don't exist (idempotent).",
+    "--create-stores/--no-create-stores",
+    default=True,
+    help="Create referenced stores if they don't exist (idempotent, default). "
+    "--no-create-stores requires them to already exist.",
 )
 @click.pass_obj
 def dev(
@@ -91,8 +94,9 @@ def dev(
     ``mason deploy``. The environment is built on first run and reused after; pass
     ``--prepare-environment`` to force a rebuild (e.g. after changing dependencies).
 
-    The ``--with-*`` flags wire an agent's stores/traces into ``app.yaml`` before running, exactly as
-    ``mason deploy`` does — so you can iterate locally against a real store without hand-editing env.
+    The ``--memory`` / ``--session-store`` / ``--with-traces`` flags wire an agent's stores/traces
+    into ``app.yaml`` before running, exactly as ``mason deploy`` does — so you can iterate locally
+    against a real store without hand-editing env.
     Locally the store owner (you) already has access, so no service-principal grant is needed here;
     that grant happens at ``mason deploy`` time.
     """

--- a/integrations/mason/src/databricks_mason/dev.py
+++ b/integrations/mason/src/databricks_mason/dev.py
@@ -70,10 +70,10 @@ _BUILD_INDEX_ENVS = frozenset({"PIP_INDEX_URL", "UV_INDEX_URL", "UV_DEFAULT_INDE
     help="MLflow experiment path to wire in via MLFLOW_EXPERIMENT_NAME.",
 )
 @click.option(
-    "--create-stores/--no-create-stores",
-    default=True,
-    help="Create referenced stores if they don't exist (idempotent, default). "
-    "--no-create-stores requires them to already exist.",
+    "--no-create-stores",
+    is_flag=True,
+    help="Require referenced stores to already exist. By default missing stores are created "
+    "(idempotent).",
 )
 @click.pass_obj
 def dev(
@@ -85,7 +85,7 @@ def dev(
     session_store: Optional[str],
     traces_destination: Optional[str],
     traces_experiment: Optional[str],
-    create_stores: bool,
+    no_create_stores: bool,
 ) -> None:
     """Run a scaffolded agent locally from its app.yaml (wraps `databricks apps run-local`).
 
@@ -119,7 +119,7 @@ def dev(
             session_store=session_store,
             traces_destination=traces_destination,
             traces_experiment=traces_experiment,
-            create_stores=create_stores,
+            create_stores=not no_create_stores,
         )
         if env_updates:
             _upsert_manifest_env(source_dir, env_updates)

--- a/integrations/mason/src/databricks_mason/dev.py
+++ b/integrations/mason/src/databricks_mason/dev.py
@@ -46,18 +46,18 @@ _BUILD_INDEX_ENVS = frozenset({"PIP_INDEX_URL", "UV_INDEX_URL", "UV_DEFAULT_INDE
 @click.option("--app-port", type=int, default=None, help="Port to run the app on (default 8000).")
 @click.option(
     "--memory",
+    "-m",
     "memory_store",
     default=None,
     help="Memory store display name to wire in via AGENT_MEMORY_STORE (same as `mason deploy`).",
 )
 @click.option(
-    "--session-store",
+    "--session",
+    "-s",
     "session_store",
     default=None,
     help="Session store name to wire in via AGENT_SESSION_STORE (same as `mason deploy`).",
 )
-@click.option("--with-memory-store", "memory_store", default=None, hidden=True)
-@click.option("--with-session-store", "session_store", default=None, hidden=True)
 @click.option(
     "--with-traces",
     "traces_destination",
@@ -94,7 +94,7 @@ def dev(
     ``mason deploy``. The environment is built on first run and reused after; pass
     ``--prepare-environment`` to force a rebuild (e.g. after changing dependencies).
 
-    The ``--memory`` / ``--session-store`` / ``--with-traces`` flags wire an agent's stores/traces
+    The ``--memory`` / ``--session`` / ``--with-traces`` flags wire an agent's stores/traces
     into ``app.yaml`` before running, exactly as ``mason deploy`` does — so you can iterate locally
     against a real store without hand-editing env.
     Locally the store owner (you) already has access, so no service-principal grant is needed here;

--- a/integrations/mason/src/databricks_mason/tracing.py
+++ b/integrations/mason/src/databricks_mason/tracing.py
@@ -4,7 +4,7 @@ Parallel to `mason memory` and `mason sessions`: `setup` provisions the trace de
 (links a UC schema to an MLflow experiment, the analog of creating a store), `list`/`get`
 read traces back, and `instrument` prints the wiring snippet (the "Starter code" analog).
 `mason deploy --with-traces` injects the destination into a deployment's app.yaml, exactly as
-`--memory` / `--session-store` inject their stores.
+`--memory` / `--session` inject their stores.
 
 MLflow is an optional dependency: `setup`/`list`/`get` need `mlflow[databricks]>=3.9.0`
 installed and lazily import it; `instrument` (and the deploy wiring) are pure and need nothing.

--- a/integrations/mason/src/databricks_mason/tracing.py
+++ b/integrations/mason/src/databricks_mason/tracing.py
@@ -4,7 +4,7 @@ Parallel to `mason memory` and `mason sessions`: `setup` provisions the trace de
 (links a UC schema to an MLflow experiment, the analog of creating a store), `list`/`get`
 read traces back, and `instrument` prints the wiring snippet (the "Starter code" analog).
 `mason deploy --with-traces` injects the destination into a deployment's app.yaml, exactly as
-`--with-memory-store` / `--with-session-store` inject their stores.
+`--memory` / `--session-store` inject their stores.
 
 MLflow is an optional dependency: `setup`/`list`/`get` need `mlflow[databricks]>=3.9.0`
 installed and lazily import it; `instrument` (and the deploy wiring) are pure and need nothing.

--- a/integrations/mason/templates/agent-langgraph/README.md
+++ b/integrations/mason/templates/agent-langgraph/README.md
@@ -237,7 +237,7 @@ Deploy with the [Mason](../../README.md) CLI:
 mason deploy agent-langgraph --source .
 ```
 
-Add `--memory <name> --session-store <name> --actor-id <actor>` to wire managed state. Mason
+Add `--memory <name> --session <name> --actor-id <actor>` to wire managed state. Mason
 provisions or resolves the stores (creating them if missing), injects the store/actor env vars, and
 deploys the App.
 

--- a/integrations/mason/templates/agent-langgraph/README.md
+++ b/integrations/mason/templates/agent-langgraph/README.md
@@ -237,9 +237,9 @@ Deploy with the [Mason](../../README.md) CLI:
 mason deploy agent-langgraph --source .
 ```
 
-Add `--with-memory-store <name> --with-session-store <name> --actor-id <actor>` to wire managed
-state. Mason provisions or resolves the stores, injects the store/actor env vars, and deploys the
-App.
+Add `--memory <name> --session-store <name> --actor-id <actor>` to wire managed state. Mason
+provisions or resolves the stores (creating them if missing), injects the store/actor env vars, and
+deploys the App.
 
 `app.yaml` carries the app's start command and env. By default the deployed app is the same lean
 backend: in-process session state, tracing off.

--- a/integrations/mason/templates/ui/agent-langgraph/runtime/ui.py
+++ b/integrations/mason/templates/ui/agent-langgraph/runtime/ui.py
@@ -190,7 +190,7 @@ def _require_memory() -> None:
     if not _memory_store():
         raise HTTPException(
             status_code=503,
-            detail=f"Set {_MEMORY_STORE_ENV} by deploying with --with-memory-store.",
+            detail=f"Set {_MEMORY_STORE_ENV} by deploying with --memory.",
         )
 
 
@@ -198,7 +198,7 @@ def _require_session() -> None:
     if not _session_store():
         raise HTTPException(
             status_code=503,
-            detail=f"Set {_SESSION_STORE_ENV} by deploying with --with-session-store.",
+            detail=f"Set {_SESSION_STORE_ENV} by deploying with --session-store.",
         )
 
 

--- a/integrations/mason/templates/ui/agent-langgraph/runtime/ui.py
+++ b/integrations/mason/templates/ui/agent-langgraph/runtime/ui.py
@@ -198,7 +198,7 @@ def _require_session() -> None:
     if not _session_store():
         raise HTTPException(
             status_code=503,
-            detail=f"Set {_SESSION_STORE_ENV} by deploying with --session-store.",
+            detail=f"Set {_SESSION_STORE_ENV} by deploying with --session.",
         )
 
 

--- a/integrations/mason/templates/ui/agent-langgraph/ui/app.js
+++ b/integrations/mason/templates/ui/agent-langgraph/ui/app.js
@@ -788,7 +788,7 @@ async function loadConfig() {
     elements.rejectSession.disabled = state.busy || !config.session.durable;
     elements.memoryHelp.textContent = config.memory.enabled
       ? `${config.memory.store} · actor ${config.memory.actor}`
-      : "Deploy with --with-memory-store to expose managed entries and agent memory tools.";
+      : "Deploy with --memory to expose managed entries and agent memory tools.";
     elements.sessionStoreLabel.textContent = config.session.managed
       ? `${config.session.store} · actor ${config.session.actor} · the Apps routing cookie keys transcript and checkpoint state.`
       : config.session.history

--- a/integrations/mason/tests/unit_tests/deploy_test.py
+++ b/integrations/mason/tests/unit_tests/deploy_test.py
@@ -100,7 +100,7 @@ def test_deploy_drives_sync_and_apps_deploy(tmp_path: pathlib.Path, monkeypatch)
 
     result = CliRunner().invoke(
         deploy_mod.deploy,
-        ["myapp", "--source", str(src), "--with-memory-store", "mem"],
+        ["myapp", "--source", str(src), "--memory", "mem"],
         obj=_FakeCtx(),
     )
 
@@ -211,7 +211,7 @@ def test_deploy_injects_shared_actor_for_managed_stores(tmp_path: pathlib.Path, 
             str(src),
             "--memory",
             "mem",
-            "--session-store",
+            "--session",
             "sessions",
             "--actor-id",
             "alice",
@@ -371,8 +371,8 @@ def test_deploy_creates_missing_stores_by_default(tmp_path: pathlib.Path, monkey
     assert created == ["new-mem"]  # created without any --create-stores flag
 
 
-def test_deploy_accepts_deprecated_with_store_aliases(tmp_path: pathlib.Path, monkeypatch):
-    # The old --with-memory-store / --with-session-store names still work (hidden back-compat).
+def test_deploy_accepts_short_store_flags(tmp_path: pathlib.Path, monkeypatch):
+    # -m / -s are the short forms of --memory / --session.
     src = tmp_path / "app"
     src.mkdir()
     (src / "app.yaml").write_text(yaml.safe_dump({"command": ["x"]}))
@@ -385,7 +385,7 @@ def test_deploy_accepts_deprecated_with_store_aliases(tmp_path: pathlib.Path, mo
     )
     result = CliRunner().invoke(
         deploy_mod.deploy,
-        ["myapp", "--source", str(src), "--with-memory-store", "mem", "--with-session-store", "s"],
+        ["myapp", "--source", str(src), "-m", "mem", "-s", "s"],
         obj=_FakeCtx(),
     )
     assert result.exit_code == 0, result.output

--- a/integrations/mason/tests/unit_tests/deploy_test.py
+++ b/integrations/mason/tests/unit_tests/deploy_test.py
@@ -65,7 +65,14 @@ class _FakeClient:
             "next_page_token": "",
         }
 
+    def create_memory_store(self, display_name):
+        # Create-if-not-exists is the deploy default; return the same id resolution would find.
+        return {"name": "memory-stores/mem-id-123", "display_name": display_name}
+
     def get_session_store(self, name):
+        return {"session_store_name": name}
+
+    def create_session_store(self, name):
         return {"session_store_name": name}
 
 
@@ -202,9 +209,9 @@ def test_deploy_injects_shared_actor_for_managed_stores(tmp_path: pathlib.Path, 
             "myapp",
             "--source",
             str(src),
-            "--with-memory-store",
+            "--memory",
             "mem",
-            "--with-session-store",
+            "--session-store",
             "sessions",
             "--actor-id",
             "alice",
@@ -310,8 +317,10 @@ def test_memory_store_database_resolves_by_display_name():
     assert deploy_mod._memory_store_database(_Client(), "mem") == "memory-uuidx"
 
 
-def test_deploy_without_create_resolves_memory_by_display_name(tmp_path: pathlib.Path, monkeypatch):
-    # Non-create path must resolve by display name (list+match), not get_memory_store (by id).
+def test_deploy_no_create_stores_resolves_memory_by_display_name(
+    tmp_path: pathlib.Path, monkeypatch
+):
+    # --no-create-stores path must resolve by display name (list+match), not get_memory_store (by id).
     src = tmp_path / "app"
     src.mkdir()
     (src / "app.yaml").write_text(yaml.safe_dump({"command": ["x"]}))
@@ -324,12 +333,65 @@ def test_deploy_without_create_resolves_memory_by_display_name(tmp_path: pathlib
     )
     result = CliRunner().invoke(
         deploy_mod.deploy,
-        ["myapp", "--source", str(src), "--with-memory-store", "mem"],
+        ["myapp", "--source", str(src), "--memory", "mem", "--no-create-stores"],
         obj=_FakeCtx(),
     )
     assert result.exit_code == 0, result.output
     env = {e["name"]: e["value"] for e in yaml.safe_load((src / "app.yaml").read_text())["env"]}
     assert env["AGENT_MEMORY_STORE"] == "mem-id-123"  # resolved by display name, bare id
+
+
+def test_deploy_creates_missing_stores_by_default(tmp_path: pathlib.Path, monkeypatch):
+    # Create-if-not-exists is now the default (no flag): a referenced store is created via the API.
+    created: list[str] = []
+    src = tmp_path / "app"
+    src.mkdir()
+    (src / "app.yaml").write_text(yaml.safe_dump({"command": ["x"]}))
+    monkeypatch.setattr(deploy_mod, "_deployment_exists", lambda a, p: True)
+    monkeypatch.setattr(deploy_mod, "_app_service_principal", lambda name, p: None)
+    monkeypatch.setattr(
+        deploy_mod,
+        "_databricks",
+        lambda args, profile, **kw: types.SimpleNamespace(returncode=0, stdout="", stderr=""),
+    )
+
+    class _CreatingClient(_FakeClient):
+        def create_memory_store(self, display_name):
+            created.append(display_name)
+            return {"name": "memory-stores/mem-id-123", "display_name": display_name}
+
+    class _Ctx(_FakeCtx):
+        def client(self):
+            return _CreatingClient()
+
+    result = CliRunner().invoke(
+        deploy_mod.deploy, ["myapp", "--source", str(src), "--memory", "new-mem"], obj=_Ctx()
+    )
+    assert result.exit_code == 0, result.output
+    assert created == ["new-mem"]  # created without any --create-stores flag
+
+
+def test_deploy_accepts_deprecated_with_store_aliases(tmp_path: pathlib.Path, monkeypatch):
+    # The old --with-memory-store / --with-session-store names still work (hidden back-compat).
+    src = tmp_path / "app"
+    src.mkdir()
+    (src / "app.yaml").write_text(yaml.safe_dump({"command": ["x"]}))
+    monkeypatch.setattr(deploy_mod, "_deployment_exists", lambda a, p: True)
+    monkeypatch.setattr(deploy_mod, "_app_service_principal", lambda name, p: None)
+    monkeypatch.setattr(
+        deploy_mod,
+        "_databricks",
+        lambda args, profile, **kw: types.SimpleNamespace(returncode=0, stdout="", stderr=""),
+    )
+    result = CliRunner().invoke(
+        deploy_mod.deploy,
+        ["myapp", "--source", str(src), "--with-memory-store", "mem", "--with-session-store", "s"],
+        obj=_FakeCtx(),
+    )
+    assert result.exit_code == 0, result.output
+    env = {e["name"]: e["value"] for e in yaml.safe_load((src / "app.yaml").read_text())["env"]}
+    assert env["AGENT_MEMORY_STORE"] == "mem-id-123"
+    assert env["AGENT_SESSION_STORE"] == "s"
 
 
 def test_with_traces_defaults_the_experiment_per_app():

--- a/integrations/mason/tests/unit_tests/dev_test.py
+++ b/integrations/mason/tests/unit_tests/dev_test.py
@@ -121,7 +121,7 @@ def test_dev_with_flags_wires_app_yaml_before_running(tmp_path: pathlib.Path):
     ):
         result = CliRunner().invoke(
             dev_mod.dev,
-            ["--source", str(tmp_path), "--with-session-store", "s", "--with-memory-store", "m"],
+            ["--source", str(tmp_path), "--session-store", "s", "--memory", "m"],
             obj=_Ctx(),
         )
     assert result.exit_code == 0, result.output

--- a/integrations/mason/tests/unit_tests/dev_test.py
+++ b/integrations/mason/tests/unit_tests/dev_test.py
@@ -121,7 +121,7 @@ def test_dev_with_flags_wires_app_yaml_before_running(tmp_path: pathlib.Path):
     ):
         result = CliRunner().invoke(
             dev_mod.dev,
-            ["--source", str(tmp_path), "--session-store", "s", "--memory", "m"],
+            ["--source", str(tmp_path), "--session", "s", "--memory", "m"],
             obj=_Ctx(),
         )
     assert result.exit_code == 0, result.output


### PR DESCRIPTION
Addresses CLI-ergonomics review feedback on `mason deploy` / `mason dev`:

- `--with-memory-store` → `--memory`, `--with-session-store` → `--session-store`. The old names stay as hidden, deprecated aliases so existing scripts don't break.
- `--create-stores` is gone as an opt-in flag; create-if-not-exists is now the default. `--no-create-stores` opts back into the fail-if-missing behavior.

Updates the CLI help, the mason README, the langgraph template README, and the chat-app "set it with --…" error messages to the new flags.