### PR TITLE
Bump databricks-mason to 0.1.2.dev0

### DIFF
--- a/integrations/mason/pyproject.toml
+++ b/integrations/mason/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "databricks-mason"
-version = "0.1.1.dev0"
+version = "0.1.2.dev0"
 description = "Databricks integration for Mason"
 authors = [
     { name="Databricks", email="agent-feedback@databricks.com" },


### PR DESCRIPTION
Bump databricks-mason version 0.1.1.dev0 → 0.1.2.dev0.