### PR TITLE
mason: expose app instance count and sticky routing

### DIFF
--- a/integrations/mason/src/databricks_mason/deploy.py
+++ b/integrations/mason/src/databricks_mason/deploy.py
@@ -101,6 +101,18 @@ def _validate_deployment_name(name: str) -> str:
     return name
 
 
+def _instance_args(instances: Optional[int]) -> list[str]:
+    """Build runtime instance arguments from Mason's fixed-count option."""
+    if instances is None:
+        return []
+    return [
+        "--compute-min-instances",
+        str(instances),
+        "--compute-max-instances",
+        str(instances),
+    ]
+
+
 def _prefixed_name(name: str) -> str:
     """Mason deployments carry a `mason-` prefix so `deployments list` can find only its own apps."""
     return name if name.startswith(_DEPLOYMENT_PREFIX) else f"{_DEPLOYMENT_PREFIX}{name}"
@@ -351,6 +363,12 @@ def _grant_store_access(
     default=None,
     help="Workspace destination for the synced source (defaults to a per-user path).",
 )
+@click.option(
+    "--instances",
+    type=click.IntRange(min=1, max=5),
+    default=None,
+    help="Number of deployment instances.",
+)
 @click.pass_obj
 def deploy(
     obj,
@@ -360,14 +378,23 @@ def deploy(
     traces_experiment,
     pip_index_url,
     workspace_path,
+    instances,
 ) -> None:
     """Deploy an agent: validate its bound stores, wire in tracing, and roll out the deployment.
 
     The app is named `mason-<name>` (Mason adds the prefix if absent); use that full name with the
     other `mason deployments` verbs. `deployments list` shows only apps carrying this prefix.
+
+    Horizontally scaled deployments use best-effort sticky routing (session affinity). Browsers
+    preserve the routing cookie automatically.
+
+    \b
+    API clients must reuse a stable UUID in this cookie on every request:
+      __Host-databricks-app-router=<uuid>
     """
     name = _prefixed_name(name)
     _validate_deployment_name(name)
+    instance_args = _instance_args(instances)
     source_dir = pathlib.Path(source)
     client = obj.client()
 
@@ -395,6 +422,8 @@ def deploy(
         for env in _PIP_INDEX_ENVS:
             env_updates[env] = pip_index_url
         provisioned["Package index"] = pip_index_url
+    if instances is not None:
+        provisioned["Instances"] = str(instances)
 
     # 2. Patch the app.yaml manifest with any trace/index env (stores are read from agent.toml).
     scaffolded = False
@@ -404,7 +433,7 @@ def deploy(
     # 3. Roll out the deployment (Databricks Apps runtime).
     if not _deployment_exists(name, obj.profile):
         result = _databricks(
-            ["apps", "create", name],
+            ["apps", "create", name, *instance_args],
             obj.profile,
             capture=True,
             action=f"Could not create deployment '{name}'.",
@@ -415,6 +444,22 @@ def deploy(
         # RUNNING — so wait for it, or the first deploy races and fails ("not in RUNNING state").
         with render.status("Waiting for app compute to start (this can take a few minutes)…"):
             _wait_for_running(name, obj.profile)
+    elif instance_args:
+        update = {
+            "app": {
+                "compute_min_instances": instances,
+                "compute_max_instances": instances,
+            },
+            "update_mask": "compute_min_instances,compute_max_instances",
+        }
+        result = _databricks(
+            ["apps", "create-update", name, "--json", json.dumps(update)],
+            obj.profile,
+            capture=True,
+            action=f"Could not update deployment '{name}'.",
+        )
+        old, new = _AGENT_COMPUTE_OUTPUT
+        click.echo((result.stdout or "").replace(old, new), nl=False)
     ws_path = workspace_path or f"/Workspace/Users/{client.current_user}/mason_deployments/{name}"
     # Don't ship uv.lock: it pins exact package URLs from whatever index the developer's machine
     # resolved against (often an internal proxy). The Apps build must resolve against its own

--- a/integrations/mason/src/databricks_mason/help.py
+++ b/integrations/mason/src/databricks_mason/help.py
@@ -183,7 +183,10 @@ _EXAMPLES: dict[CommandPath, tuple[Example, ...]] = {
     ("tracing", "instrument"): (
         ("mason tracing instrument --destination main.agent_traces", "print instrumentation code"),
     ),
-    ("deploy",): (("mason deploy my-agent", "deploy the agent to Databricks Apps"),),
+    ("deploy",): (
+        ("mason deploy my-agent", "deploy the agent"),
+        ("mason deploy my-agent --instances 2", "deploy with two instances"),
+    ),
     ("deployments",): (("mason deployments list", "list agent deployments"),),
     ("deployments", "list"): (("mason deployments list", "list agent deployments"),),
     ("deployments", "get"): (("mason deployments get mason-my-agent", "show one deployment"),),

--- a/integrations/mason/tests/unit_tests/deploy_test.py
+++ b/integrations/mason/tests/unit_tests/deploy_test.py
@@ -132,6 +132,103 @@ def test_deploy_drives_sync_and_apps_deploy(tmp_path: pathlib.Path, monkeypatch)
     assert "AGENT_MEMORY_STORE" not in env
 
 
+def test_deploy_creates_with_instance_count(tmp_path: pathlib.Path, monkeypatch):
+    src = tmp_path / "app"
+    src.mkdir()
+    (src / "app.yaml").write_text(yaml.safe_dump({"command": ["x"]}))
+
+    calls: list[tuple[list[str], dict]] = []
+    monkeypatch.setattr(deploy_mod, "_deployment_exists", lambda a, p: False)
+    monkeypatch.setattr(deploy_mod, "_wait_for_running", lambda name, profile: None)
+    monkeypatch.setattr(
+        deploy_mod,
+        "_databricks",
+        lambda args, profile, **kwargs: calls.append((args, kwargs))
+        or types.SimpleNamespace(returncode=0, stdout="", stderr=""),
+    )
+
+    result = CliRunner().invoke(
+        deploy_mod.deploy,
+        ["myapp", "--source", str(src), "--instances", "2"],
+        obj=_FakeCtx(),
+    )
+
+    assert result.exit_code == 0, result.output
+    assert (
+        [
+            "apps",
+            "create",
+            "mason-myapp",
+            "--compute-min-instances",
+            "2",
+            "--compute-max-instances",
+            "2",
+        ],
+        {
+            "capture": True,
+            "action": "Could not create deployment 'mason-myapp'.",
+        },
+    ) in calls
+
+
+def test_deploy_updates_existing_instance_count(tmp_path: pathlib.Path, monkeypatch):
+    src = tmp_path / "app"
+    src.mkdir()
+    (src / "app.yaml").write_text(yaml.safe_dump({"command": ["x"]}))
+
+    calls: list[tuple[list[str], dict]] = []
+    monkeypatch.setattr(deploy_mod, "_deployment_exists", lambda a, p: True)
+    monkeypatch.setattr(
+        deploy_mod,
+        "_databricks",
+        lambda args, profile, **kwargs: calls.append((args, kwargs))
+        or types.SimpleNamespace(returncode=0, stdout="", stderr=""),
+    )
+
+    result = CliRunner().invoke(
+        deploy_mod.deploy,
+        ["myapp", "--source", str(src), "--instances", "2"],
+        obj=_FakeCtx(),
+    )
+
+    assert result.exit_code == 0, result.output
+    update_args, update_kwargs = next(
+        call for call in calls if call[0][:3] == ["apps", "create-update", "mason-myapp"]
+    )
+    assert update_kwargs == {
+        "capture": True,
+        "action": "Could not update deployment 'mason-myapp'.",
+    }
+    payload = json.loads(update_args[update_args.index("--json") + 1])
+    assert payload == {
+        "app": {"compute_min_instances": 2, "compute_max_instances": 2},
+        "update_mask": "compute_min_instances,compute_max_instances",
+    }
+
+
+def test_deploy_rejects_instance_count_above_platform_limit():
+    result = CliRunner().invoke(
+        deploy_mod.deploy,
+        ["myapp", "--instances", "6"],
+        obj=_FakeCtx(),
+    )
+
+    assert result.exit_code != 0
+    assert "6 is not in the range 1<=x<=5" in result.output
+
+
+def test_deploy_help_exposes_instances_and_sticky_routing():
+    result = CliRunner().invoke(deploy_mod.deploy, ["--help"])
+
+    assert result.exit_code == 0, result.output
+    assert "--instances" in result.output
+    assert "--min-instances" not in result.output
+    assert "--max-instances" not in result.output
+    assert "sticky routing" in result.output
+    assert "__Host-databricks-app-router" in result.output
+    assert "Databricks Apps instances" not in result.output
+
+
 def test_deploy_renames_underlying_app_compute_output(tmp_path: pathlib.Path, monkeypatch):
     src = tmp_path / "app"
     src.mkdir()


### PR DESCRIPTION
## Summary

- add optional `--instances` to `mason deploy` for a fixed instance count
- map it to equal `compute_min_instances` and `compute_max_instances` values required by the Apps API
- support both new deployments and updates to existing deployments
- document sticky routing and `__Host-databricks-app-router` in `mason deploy --help`
- keep the default README deployment flow unchanged and simple

## Demo

```bash
export PROFILE=<profile>
export BRIDGE=/home/shivam.mittal/databricks-ai-bridge-worktrees/mason-routing-autoscaling

rm -rf ~/horizontal-scaling
uv tool install --force --with 'mlflow[databricks]>=3.10.1' \
  --editable "$BRIDGE/integrations/mason"
mason login -p "$PROFILE"

mason init ~/horizontal-scaling
cd ~/horizontal-scaling
mason dev
```

Stop the local server, then create one instance and update the same deployment to two:

```bash
mason deploy horizontal-scaling --instances 1
mason deploy horizontal-scaling --instances 2
```

For the sticky-routing API demo, use a workspace-scoped OAuth profile:

```bash
export APP_AUTH_PROFILE=<workspace-oauth-profile>
export APP_URL=$(databricks apps get mason-horizontal-scaling -p "$PROFILE" -o json | jq -r .url)
export TOKEN=$(databricks auth token "$APP_AUTH_PROFILE" | jq -r .access_token)
export ROUTING_KEY=$(uuidgen)

for i in 1 2 3 4 5; do
  curl -fsS "$APP_URL/api/demo/config" \
    -H "Authorization: Bearer $TOKEN" \
    -b "__Host-databricks-app-router=$ROUTING_KEY" |
    jq '{session_id, instance_id}'
done
```

The same routing key should return the same session and process instance on every request.

## Testing

- `uv run pytest -q` — 306 passed
- `uv run ruff check`
- `uv run ruff format --check`
- `uv run ty check`
- fresh generated LangGraph project — 26 passed, 1 skipped
- local cookie test — repeated requests returned the same non-null `session_id` and `instance_id`
- live `e2-dogfood` test on September 4, 2026:
  - deployed with `--instances 1`
  - updated the same deployment with `--instances 2`
  - verified both API bounds were `2`, `active_instances=2`, `compute_status=ACTIVE`, and `app_status=RUNNING`
  - cleaned up the temporary app and workspace source
- the existing `e2-dogfood` account-routed OAuth token returned HTTP 401 for the App API; use a workspace-scoped OAuth profile for the curl demo above
