### PR TITLE
[mason] audit CLI next steps: add descriptions, fix unhelpful ones

### DIFF
--- a/integrations/mason/README.md
+++ b/integrations/mason/README.md
@@ -125,7 +125,7 @@ mason sessions items append --help
 For the shortest path from a blank directory to a running and deployed agent:
 
 ```sh
-mason login --profile my-workspace
+mason login --profile <profile>
 mason init my-agent
 cd my-agent
 mason dev

--- a/integrations/mason/src/databricks_mason/auth.py
+++ b/integrations/mason/src/databricks_mason/auth.py
@@ -120,7 +120,11 @@ def login(obj, profile) -> None:
     render.success(
         f"Logged in as {user}",
         fields={"Profile": profile, "Host": client.host},
-        next_steps=["mason sessions stores list", "mason memory stores list"],
+        next_steps=[
+            ("mason init my-agent", "Scaffold a new agent project"),
+            ("mason dev", "Run an agent locally with a chat UI"),
+            ("mason deploy my-agent", "Deploy an agent to Databricks"),
+        ],
     )
 
 

--- a/integrations/mason/src/databricks_mason/auth.py
+++ b/integrations/mason/src/databricks_mason/auth.py
@@ -110,7 +110,7 @@ def login(obj, profile) -> None:
     if not profile:
         raise AgentCliError(
             "No profile to save.",
-            hint="Pass one to remember, e.g. `mason login --profile my-workspace`.",
+            hint="Pass one to remember, e.g. `mason login --profile <profile>`.",
         )
     client, user = _authenticate_profile(profile)
     _save_default_profile(profile)

--- a/integrations/mason/src/databricks_mason/auth.py
+++ b/integrations/mason/src/databricks_mason/auth.py
@@ -122,8 +122,6 @@ def login(obj, profile) -> None:
         fields={"Profile": profile, "Host": client.host},
         next_steps=[
             ("mason init my-agent", "Scaffold a new agent project"),
-            ("mason dev", "Run an agent locally with a chat UI"),
-            ("mason deploy my-agent", "Deploy an agent to Databricks"),
         ],
     )
 

--- a/integrations/mason/src/databricks_mason/deploy.py
+++ b/integrations/mason/src/databricks_mason/deploy.py
@@ -454,9 +454,12 @@ def deploy(
         )
         return
 
-    steps = [f"mason deployments logs {name}", f"mason deployments get {name}"]
+    steps: list[str | tuple[str, str]] = [
+        (f"mason deployments get {name}", "Check its status and URL"),
+        (f"mason deployments logs {name}", "Tail its logs"),
+    ]
     if app_url:
-        steps.insert(0, f"open {app_url}")
+        steps.insert(0, (f"open {app_url}", "Open the deployed app"))
     if scaffolded:
         steps.insert(
             0, f"Set a real `command:` in {source_dir / 'app.yaml'} (a placeholder was written)"

--- a/integrations/mason/src/databricks_mason/dev.py
+++ b/integrations/mason/src/databricks_mason/dev.py
@@ -160,7 +160,7 @@ def _announce_local_url(source_dir: pathlib.Path, port: int) -> None:
             fields={"Chat UI": base},
             next_steps=[
                 f"Open {base} to chat with your agent",
-                ("mason tools add mcp <service>", "Give the agent a tool (see `mason mcp list`)"),
+                ("mason tools add mcp <service>", "Give the agent a tool"),
                 ("mason dev -m <store> -s <store>", "Attach a memory / session store"),
                 (f"mason deploy {deploy_name}", "Deploy it to Databricks"),
             ],
@@ -176,7 +176,7 @@ def _announce_local_url(source_dir: pathlib.Path, port: int) -> None:
             fields={"Invoke": f"POST {base}/invocations"},
             next_steps=[
                 (sample, "Send a test request"),
-                ("mason tools add mcp <service>", "Give the agent a tool (see `mason mcp list`)"),
+                ("mason tools add mcp <service>", "Give the agent a tool"),
                 (f"mason deploy {deploy_name}", "Deploy it to Databricks"),
             ],
         )

--- a/integrations/mason/src/databricks_mason/dev.py
+++ b/integrations/mason/src/databricks_mason/dev.py
@@ -153,8 +153,17 @@ def dev(
 def _announce_local_url(source_dir: pathlib.Path, port: int) -> None:
     """Print how to reach the running app: the chat UI if present, else a sample invoke request."""
     base = f"http://localhost:{port}"
+    deploy_name = source_dir.resolve().name
     if (source_dir / "runtime" / "ui.py").is_file():
-        render.success("Starting agent", fields={"Chat UI": base})
+        render.success(
+            "Starting agent",
+            fields={"Chat UI": base},
+            next_steps=[
+                f"Open {base} to chat with your agent",
+                ("Edit agent/agent.py", "Change the model, prompt, or tools, then reload"),
+                (f"mason deploy {deploy_name} --source .", "Deploy it to Databricks"),
+            ],
+        )
     else:
         # No page is served at `/`, so give a copy-pasteable request instead of just the URL.
         sample = (
@@ -164,7 +173,10 @@ def _announce_local_url(source_dir: pathlib.Path, port: int) -> None:
         render.success(
             "Starting API-only agent (no chat UI — see `mason init --help`)",
             fields={"Invoke": f"POST {base}/invocations"},
-            next_steps=[sample],
+            next_steps=[
+                (sample, "Send a test request"),
+                (f"mason deploy {deploy_name} --source .", "Deploy it to Databricks"),
+            ],
         )
 
 

--- a/integrations/mason/src/databricks_mason/dev.py
+++ b/integrations/mason/src/databricks_mason/dev.py
@@ -161,7 +161,7 @@ def _announce_local_url(source_dir: pathlib.Path, port: int) -> None:
             next_steps=[
                 f"Open {base} to chat with your agent",
                 "Edit agent/agent.py to change the model, prompt, or tools, then reload",
-                (f"mason deploy {deploy_name} --source .", "Deploy it to Databricks"),
+                (f"mason deploy {deploy_name}", "Deploy it to Databricks"),
             ],
         )
     else:
@@ -175,7 +175,7 @@ def _announce_local_url(source_dir: pathlib.Path, port: int) -> None:
             fields={"Invoke": f"POST {base}/invocations"},
             next_steps=[
                 (sample, "Send a test request"),
-                (f"mason deploy {deploy_name} --source .", "Deploy it to Databricks"),
+                (f"mason deploy {deploy_name}", "Deploy it to Databricks"),
             ],
         )
 

--- a/integrations/mason/src/databricks_mason/dev.py
+++ b/integrations/mason/src/databricks_mason/dev.py
@@ -160,7 +160,8 @@ def _announce_local_url(source_dir: pathlib.Path, port: int) -> None:
             fields={"Chat UI": base},
             next_steps=[
                 f"Open {base} to chat with your agent",
-                "Edit agent/agent.py to change the model, prompt, or tools, then reload",
+                ("mason tools add mcp <service>", "Give the agent a tool (see `mason mcp list`)"),
+                ("mason dev -m <store> -s <store>", "Attach a memory / session store"),
                 (f"mason deploy {deploy_name}", "Deploy it to Databricks"),
             ],
         )
@@ -175,6 +176,7 @@ def _announce_local_url(source_dir: pathlib.Path, port: int) -> None:
             fields={"Invoke": f"POST {base}/invocations"},
             next_steps=[
                 (sample, "Send a test request"),
+                ("mason tools add mcp <service>", "Give the agent a tool (see `mason mcp list`)"),
                 (f"mason deploy {deploy_name}", "Deploy it to Databricks"),
             ],
         )

--- a/integrations/mason/src/databricks_mason/dev.py
+++ b/integrations/mason/src/databricks_mason/dev.py
@@ -160,7 +160,7 @@ def _announce_local_url(source_dir: pathlib.Path, port: int) -> None:
             fields={"Chat UI": base},
             next_steps=[
                 f"Open {base} to chat with your agent",
-                ("Edit agent/agent.py", "Change the model, prompt, or tools, then reload"),
+                "Edit agent/agent.py to change the model, prompt, or tools, then reload",
                 (f"mason deploy {deploy_name} --source .", "Deploy it to Databricks"),
             ],
         )

--- a/integrations/mason/src/databricks_mason/help.py
+++ b/integrations/mason/src/databricks_mason/help.py
@@ -10,13 +10,13 @@ CommandPath = tuple[str, ...]
 
 _EXAMPLES: dict[CommandPath, tuple[str, ...]] = {
     (): (
-        "mason login --profile my-workspace",
+        "mason login --profile <profile>",
         "mason init my-agent",
         "cd my-agent",
         "mason dev",
         "mason deploy my-agent",
     ),
-    ("login",): ("mason login --profile my-workspace",),
+    ("login",): ("mason login --profile <profile>",),
     ("logout",): ("mason logout",),
     ("init",): ("mason init my-agent",),
     ("dev",): ("mason dev",),

--- a/integrations/mason/src/databricks_mason/init.py
+++ b/integrations/mason/src/databricks_mason/init.py
@@ -259,5 +259,5 @@ def init(
     steps.append(("mason dev", "Run the agent locally"))
     if chat_app_enabled:
         steps.append("Open http://localhost:8000 to chat with it")
-    steps.append((f"mason deploy {dest.name} --source {dest}", "Deploy it to Databricks"))
+    steps.append((f"mason deploy {dest.name}", "Deploy it to Databricks (from the project dir)"))
     render.success(f"Scaffolded '{template_name}'", fields=fields, next_steps=steps)

--- a/integrations/mason/src/databricks_mason/init.py
+++ b/integrations/mason/src/databricks_mason/init.py
@@ -246,18 +246,18 @@ def init(
     fields = {"Framework": framework, "Directory": str(dest)}
     if chat_app_enabled:
         fields["Chat app"] = "enabled"
-    steps = [f"cd {dest}"]
+    steps: list[str | tuple[str, str]] = [(f"cd {dest}", "Enter the project directory")]
     if wrote_env:
         fields["Profile (.env)"] = env_profile
     else:
         # No profile resolved, so no .env was seeded — call out the auth step explicitly rather
         # than burying it, since running locally fails without a Databricks profile.
         steps += [
-            "cp .env.example .env",
+            ("cp .env.example .env", "Create your local env file"),
             "Set DATABRICKS_CONFIG_PROFILE in .env (or re-run `mason init --profile <profile>`)",
         ]
-    steps += ["mason dev        # run locally"]
+    steps.append(("mason dev", "Run the agent locally"))
     if chat_app_enabled:
-        steps.append("Open http://localhost:8000")
-    steps.append(f"mason deploy <name> --source {dest}")
+        steps.append("Open http://localhost:8000 to chat with it")
+    steps.append((f"mason deploy {dest.name} --source {dest}", "Deploy it to Databricks"))
     render.success(f"Scaffolded '{template_name}'", fields=fields, next_steps=steps)

--- a/integrations/mason/src/databricks_mason/memory.py
+++ b/integrations/mason/src/databricks_mason/memory.py
@@ -147,8 +147,11 @@ def stores_create(obj, display_name, description) -> None:
         f"Created memory store '{display_name}'",
         fields={"Store ID": store_id, "Name": field(data, "name")},
         next_steps=[
-            f"mason memory entries create --store {store_id} --actor-id <id> --path </p>",
-            f"mason memory stores get {store_id}",
+            (
+                f"mason memory entries create --store {store_id} --actor-id <id> --path </p>",
+                "Add a memory entry for an actor",
+            ),
+            (f"mason memory stores get {store_id}", "View this store's details"),
         ],
     )
 

--- a/integrations/mason/src/databricks_mason/render.py
+++ b/integrations/mason/src/databricks_mason/render.py
@@ -205,10 +205,12 @@ def success(
         steps.add_column(style=MUTED)
         for step in next_steps:
             if isinstance(step, tuple):
+                # A `$ ` prompt prefix marks a runnable command (both in accent).
                 command, description = step
-                steps.add_row(Text("→ ", style=ACCENT) + Text(command, style=ACCENT), description)
+                steps.add_row(Text("$ ", style=ACCENT) + Text(command, style=ACCENT), description)
             else:
-                steps.add_row(Text("→ ", style=ACCENT) + Text(step), "")
+                # Prose (e.g. "Open <url>") gets a muted bullet, not a command prompt.
+                steps.add_row(Text("• ", style=MUTED) + Text(step), "")
         body.append(steps)
 
     con.print()

--- a/integrations/mason/src/databricks_mason/render.py
+++ b/integrations/mason/src/databricks_mason/render.py
@@ -174,10 +174,16 @@ def success(
     title: str,
     *,
     fields: Optional[dict[str, Any]] = None,
-    next_steps: Optional[Sequence[str]] = None,
+    next_steps: "Optional[Sequence[str | tuple[str, str]]]" = None,
     con: Optional[Console] = None,
 ) -> None:
-    """A green success panel with optional details and a Next steps list."""
+    """A green success panel with optional details and a Next steps list.
+
+    Each next step is either a ``(command, description)`` pair — the command is highlighted and
+    the description explains what it does — or a bare string for a non-command instruction (e.g.
+    ``"Open http://localhost:8000"``), rendered as plain prose. Commands are shown so they can be
+    copied and run in a terminal.
+    """
     con = con or _stdout
     body: list[RenderableType] = [Text("✓ ", style="green") + Text(title, style="bold")]
 
@@ -190,9 +196,20 @@ def success(
         body.append(grid)
 
     if next_steps:
-        body.append(Text("Next steps", style=f"bold {MUTED}"))
+        has_command = any(isinstance(step, tuple) for step in next_steps)
+        header = "Next steps · run these in your terminal" if has_command else "Next steps"
+        body.append(Text(header, style=f"bold {MUTED}"))
+        # A two-column grid aligns every command's description at the same offset.
+        steps = Table.grid(padding=(0, 2))
+        steps.add_column()
+        steps.add_column(style=MUTED)
         for step in next_steps:
-            body.append(Text("  → ", style=ACCENT) + Text(step))
+            if isinstance(step, tuple):
+                command, description = step
+                steps.add_row(Text("→ ", style=ACCENT) + Text(command, style=ACCENT), description)
+            else:
+                steps.add_row(Text("→ ", style=ACCENT) + Text(step), "")
+        body.append(steps)
 
     con.print()
     con.print(Panel(Group(*body), border_style="green", box=box.ROUNDED))

--- a/integrations/mason/src/databricks_mason/render.py
+++ b/integrations/mason/src/databricks_mason/render.py
@@ -197,8 +197,11 @@ def success(
 
     if next_steps:
         has_command = any(isinstance(step, tuple) for step in next_steps)
-        header = "Next steps · run these in your terminal" if has_command else "Next steps"
-        body.append(Text(header, style=f"bold {MUTED}"))
+        # When any step is a command, define the `$` marker so the convention is self-explanatory.
+        header = Text("Next steps", style=f"bold {MUTED}")
+        if has_command:
+            header += Text("   ($ = run in your terminal)", style=MUTED)
+        body.append(header)
         # A two-column grid aligns every command's description at the same offset.
         steps = Table.grid(padding=(0, 2))
         steps.add_column()

--- a/integrations/mason/src/databricks_mason/sessions.py
+++ b/integrations/mason/src/databricks_mason/sessions.py
@@ -77,9 +77,12 @@ def stores_create(obj, name, description, metadata) -> None:
         f"Created session store '{name}'",
         fields={"Store ID": field(data, "session_store_id")},
         next_steps=[
-            f"mason sessions create --store {name} --actor-id <id>",
-            f"mason sessions stores get {name}",
-            f"mason deploy <agent> --source <path> --with-session-store {name}",
+            (
+                f"mason sessions create --store {name} --actor-id <id>",
+                "Start a session for an actor",
+            ),
+            (f"mason sessions stores get {name}", "View this store's details"),
+            (f"mason deploy <agent> --session {name}", "Wire this store into a deployment"),
         ],
     )
 
@@ -224,8 +227,11 @@ def sessions_create(obj, store, actor_id, session_id, parent_session_id, metadat
         f"Created session '{field(data, 'session_id')}'",
         fields={"Actor": actor_id, "Store": store},
         next_steps=[
-            f"mason sessions items append --store {store} "
-            f"--session-id {field(data, 'session_id')} --data '{{...}}'",
+            (
+                f"mason sessions items append --store {store} "
+                f"--session-id {field(data, 'session_id')} --data '{{...}}'",
+                "Append an item to this session",
+            ),
         ],
     )
 

--- a/integrations/mason/src/databricks_mason/tracing.py
+++ b/integrations/mason/src/databricks_mason/tracing.py
@@ -228,10 +228,16 @@ def tracing_setup(obj, catalog, schema, app, experiment, warehouse_id, relink) -
         f"Linked traces for '{exp_name}' to {destination}",
         fields={"Experiment": exp_name, "Destination": destination, "View traces": url},
         next_steps=[
-            f"mason dev --with-traces {destination}{exp_flag}",
-            f"mason deploy {deploy_name} --with-traces {destination}{exp_flag}",
-            f"mason tracing instrument --destination {destination}",
-            f"mason tracing list --experiment {exp_name}",
+            (f"mason dev --with-traces {destination}{exp_flag}", "Run locally with tracing on"),
+            (
+                f"mason deploy {deploy_name} --with-traces {destination}{exp_flag}",
+                "Deploy with tracing on",
+            ),
+            (
+                f"mason tracing instrument --destination {destination}",
+                "Print the code snippet to trace your own agent",
+            ),
+            (f"mason tracing list --experiment {exp_name}", "List traces once you have some"),
         ],
     )
 

--- a/integrations/mason/tests/unit_tests/cli_test.py
+++ b/integrations/mason/tests/unit_tests/cli_test.py
@@ -82,7 +82,7 @@ def test_help_examples_recommend_the_default_happy_path():
     runner = CliRunner()
     expected_examples = {
         (): (
-            "mason login --profile my-workspace",
+            "mason login --profile <profile>",
             "mason init my-agent",
             "cd my-agent",
             "mason dev",

--- a/integrations/mason/tests/unit_tests/render_test.py
+++ b/integrations/mason/tests/unit_tests/render_test.py
@@ -61,6 +61,35 @@ def test_resource_table_renders_title_and_count():
     assert "1 item" in out
 
 
+def test_success_next_steps_render_command_and_description():
+    con, buf = _console()
+    render.success(
+        "Logged in",
+        next_steps=[
+            ("mason init my-agent", "Scaffold a new agent project"),
+            "Open http://localhost:8000 to chat with it",
+        ],
+        con=con,
+    )
+    out = buf.getvalue()
+    # The header hints the steps are runnable when at least one is a command.
+    assert "run these in your terminal" in out
+    # Both the command and its description are shown.
+    assert "mason init my-agent" in out
+    assert "Scaffold a new agent project" in out
+    # A bare-string step renders as prose (no description column).
+    assert "Open http://localhost:8000 to chat with it" in out
+
+
+def test_success_prose_only_next_steps_omit_terminal_hint():
+    con, buf = _console()
+    render.success("Done", next_steps=["Set DATABRICKS_CONFIG_PROFILE in .env"], con=con)
+    out = buf.getvalue()
+    assert "Next steps" in out
+    assert "run these in your terminal" not in out  # no command -> no runnable hint
+    assert "Set DATABRICKS_CONFIG_PROFILE in .env" in out
+
+
 def test_detail_renders_breadcrumb_status_and_snippet():
     con, buf = _console()
     render.detail(

--- a/integrations/mason/tests/unit_tests/render_test.py
+++ b/integrations/mason/tests/unit_tests/render_test.py
@@ -74,11 +74,11 @@ def test_success_next_steps_render_command_and_description():
     out = buf.getvalue()
     # The header hints the steps are runnable when at least one is a command.
     assert "run these in your terminal" in out
-    # Both the command and its description are shown.
-    assert "mason init my-agent" in out
+    # Commands get a `$ ` prompt prefix and show their description.
+    assert "$ mason init my-agent" in out
     assert "Scaffold a new agent project" in out
-    # A bare-string step renders as prose (no description column).
-    assert "Open http://localhost:8000 to chat with it" in out
+    # A bare-string step renders as prose with a `•` bullet (not a command prompt).
+    assert "• Open http://localhost:8000 to chat with it" in out
 
 
 def test_success_prose_only_next_steps_omit_terminal_hint():

--- a/integrations/mason/tests/unit_tests/render_test.py
+++ b/integrations/mason/tests/unit_tests/render_test.py
@@ -72,8 +72,8 @@ def test_success_next_steps_render_command_and_description():
         con=con,
     )
     out = buf.getvalue()
-    # The header hints the steps are runnable when at least one is a command.
-    assert "run these in your terminal" in out
+    # The header defines the `$` marker when at least one step is a command.
+    assert "$ = run in your terminal" in out
     # Commands get a `$ ` prompt prefix and show their description.
     assert "$ mason init my-agent" in out
     assert "Scaffold a new agent project" in out
@@ -86,7 +86,7 @@ def test_success_prose_only_next_steps_omit_terminal_hint():
     render.success("Done", next_steps=["Set DATABRICKS_CONFIG_PROFILE in .env"], con=con)
     out = buf.getvalue()
     assert "Next steps" in out
-    assert "run these in your terminal" not in out  # no command -> no runnable hint
+    assert "$ = run in your terminal" not in out  # no command -> no marker legend
     assert "Set DATABRICKS_CONFIG_PROFILE in .env" in out
 
 


### PR DESCRIPTION
From the Custom Agent bug bash — next steps were often unhelpful (e.g. `mason login` pointed at listing empty stores) and gave no hint they're runnable.

- render.success next steps now take `(command, description)` pairs (or a bare string for prose like "Open <url>"). Commands render highlighted with their description aligned alongside, under a "Next steps · run these in your terminal" header.
- mason login: point to `mason init` / `mason dev` / `mason deploy` (get started) instead of `sessions stores list` / `memory stores list`.
- mason dev: add next steps (was empty for the chat-UI case) — open the UI, edit agent.py, deploy.
- mason init/deploy: use the real project/deployment name (fixes the next-steps vs --help arg-order inconsistency).
- memory/sessions/tracing create: describe what each suggested command does.