### PR TITLE
mason: annotate CLI help examples and fix their alignment

### DIFF
--- a/integrations/mason/src/databricks_mason/help.py
+++ b/integrations/mason/src/databricks_mason/help.py
@@ -8,119 +8,216 @@ import click
 
 CommandPath = tuple[str, ...]
 
-_EXAMPLES: dict[CommandPath, tuple[str, ...]] = {
+# Each example is either a bare command, or a (command, comment) pair. The comment is a short gloss
+# rendered beside/above the command so a first-time reader can tell what each example does without
+# running it. See `_example_epilog` for how comments are laid out.
+Example = str | tuple[str, str]
+
+_EXAMPLES: dict[CommandPath, tuple[Example, ...]] = {
     (): (
-        "mason login --profile <profile>",
-        "mason init my-agent",
-        "cd my-agent",
-        "mason dev",
-        "mason deploy my-agent",
+        ("mason login --profile <profile>", "authenticate and save a default profile"),
+        ("mason init my-agent", "scaffold a new agent project"),
+        ("cd my-agent", "enter the project directory"),
+        ("mason dev", "run the agent locally with a chat UI"),
+        ("mason deploy my-agent", "deploy the agent to Databricks Apps"),
     ),
-    ("login",): ("mason login --profile <profile>",),
-    ("logout",): ("mason logout",),
-    ("init",): ("mason init my-agent",),
-    ("dev",): ("mason dev",),
+    ("login",): (("mason login --profile <profile>", "save a profile as your default"),),
+    ("logout",): (("mason logout", "forget the saved default profile"),),
+    ("init",): (("mason init my-agent", "scaffold a new agent project"),),
+    ("dev",): (("mason dev", "run the agent locally with a chat UI"),),
     ("memory",): (
-        "mason memory stores create --display-name agent-memory",
-        "mason deploy <agent> --memory agent-memory",
+        ("mason memory stores create --display-name agent-memory", "create a memory store"),
+        ("mason deploy <agent> --memory agent-memory", "wire it into a deployment"),
     ),
-    ("memory", "stores"): ("mason memory stores list",),
-    ("memory", "stores", "create"): ("mason memory stores create --display-name agent-memory",),
-    ("memory", "stores", "list"): ("mason memory stores list",),
-    ("memory", "stores", "get"): ("mason memory stores get <store>",),
+    ("memory", "stores"): (("mason memory stores list", "list managed memory stores"),),
+    ("memory", "stores", "create"): (
+        ("mason memory stores create --display-name agent-memory", "create a memory store"),
+    ),
+    ("memory", "stores", "list"): (("mason memory stores list", "list managed memory stores"),),
+    ("memory", "stores", "get"): (("mason memory stores get <store>", "show one store's details"),),
     ("memory", "stores", "update"): (
-        'mason memory stores update <store> --description "Agent memory"',
+        ('mason memory stores update <store> --description "Agent memory"', "edit a store"),
     ),
-    ("memory", "stores", "delete"): ("mason memory stores delete <store>",),
-    ("memory", "entries"): ("mason memory entries list --store <store> --actor-id alice",),
+    ("memory", "stores", "delete"): (("mason memory stores delete <store>", "delete a store"),),
+    ("memory", "entries"): (
+        ("mason memory entries list --store <store> --actor-id alice", "list an actor's entries"),
+    ),
     ("memory", "entries", "create"): (
-        "mason memory entries create --store <store> --actor-id alice "
-        '--path /preferences/style.md --content "Terse, code first."',
+        (
+            "mason memory entries create --store <store> --actor-id alice "
+            '--path /preferences/style.md --content "Terse, code first."',
+            "add a memory entry for an actor",
+        ),
     ),
-    ("memory", "entries", "get"): ("mason memory entries get --store <store> <entry>",),
-    ("memory", "entries", "list"): ("mason memory entries list --store <store> --actor-id alice",),
+    ("memory", "entries", "get"): (
+        ("mason memory entries get --store <store> <entry>", "show one entry"),
+    ),
+    ("memory", "entries", "list"): (
+        ("mason memory entries list --store <store> --actor-id alice", "list an actor's entries"),
+    ),
     ("memory", "entries", "search"): (
-        'mason memory entries search --store <store> --actor-id alice --query "style"',
+        (
+            'mason memory entries search --store <store> --actor-id alice --query "style"',
+            "search an actor's entries",
+        ),
     ),
     ("memory", "entries", "update"): (
-        'mason memory entries update --store <store> <entry> --content "Concise"',
+        (
+            'mason memory entries update --store <store> <entry> --content "Concise"',
+            "edit an entry",
+        ),
     ),
-    ("memory", "entries", "delete"): ("mason memory entries delete --store <store> <entry>",),
-    ("mcp",): ("mason mcp list", "mason mcp list --schema main.tools"),
-    ("mcp", "list"): ("mason mcp list", "mason mcp list --schema main.tools"),
-    ("sessions",): ("mason sessions stores list", "mason sessions list --help"),
-    ("sessions", "stores"): ("mason sessions stores list",),
-    ("sessions", "stores", "create"): ("mason sessions stores create --name agent-sessions",),
-    ("sessions", "stores", "list"): ("mason sessions stores list",),
-    ("sessions", "stores", "get"): ("mason sessions stores get agent-sessions",),
+    ("memory", "entries", "delete"): (
+        ("mason memory entries delete --store <store> <entry>", "delete an entry"),
+    ),
+    ("mcp",): (
+        ("mason mcp list", "list workspace MCP services"),
+        ("mason mcp list --schema main.tools", "scope the list to one UC schema"),
+    ),
+    ("mcp", "list"): (
+        ("mason mcp list", "list workspace MCP services"),
+        ("mason mcp list --schema main.tools", "scope the list to one UC schema"),
+    ),
+    ("sessions",): (
+        ("mason sessions stores list", "list managed session stores"),
+        ("mason sessions list --help", "see how to list sessions"),
+    ),
+    ("sessions", "stores"): (("mason sessions stores list", "list managed session stores"),),
+    ("sessions", "stores", "create"): (
+        ("mason sessions stores create --name agent-sessions", "create a session store"),
+    ),
+    ("sessions", "stores", "list"): (
+        ("mason sessions stores list", "list managed session stores"),
+    ),
+    ("sessions", "stores", "get"): (
+        ("mason sessions stores get agent-sessions", "show one store's details"),
+    ),
     ("sessions", "stores", "update"): (
-        'mason sessions stores update agent-sessions --description "Agent sessions"',
+        (
+            'mason sessions stores update agent-sessions --description "Agent sessions"',
+            "edit a store",
+        ),
     ),
-    ("sessions", "stores", "delete"): ("mason sessions stores delete agent-sessions",),
+    ("sessions", "stores", "delete"): (
+        ("mason sessions stores delete agent-sessions", "delete a store"),
+    ),
     ("sessions", "items"): (
-        "mason sessions items list --store agent-sessions --session-id <session-id>",
+        (
+            "mason sessions items list --store agent-sessions --session-id <session-id>",
+            "list a session's items",
+        ),
     ),
     ("sessions", "items", "list"): (
-        "mason sessions items list --store agent-sessions --session-id <session-id>",
+        (
+            "mason sessions items list --store agent-sessions --session-id <session-id>",
+            "list a session's items",
+        ),
     ),
     ("sessions", "items", "append"): (
-        "mason sessions items append --store agent-sessions --session-id <session-id> "
-        '--data \'{"role":"user","content":"Hello"}\'',
+        (
+            "mason sessions items append --store agent-sessions --session-id <session-id> "
+            '--data \'{"role":"user","content":"Hello"}\'',
+            "append an item to a session",
+        ),
     ),
     ("sessions", "items", "pop"): (
-        "mason sessions items pop --store agent-sessions --session-id <session-id>",
+        (
+            "mason sessions items pop --store agent-sessions --session-id <session-id>",
+            "remove the last item",
+        ),
     ),
     ("sessions", "items", "clear"): (
-        "mason sessions items clear --store agent-sessions --session-id <session-id>",
+        (
+            "mason sessions items clear --store agent-sessions --session-id <session-id>",
+            "remove all items",
+        ),
     ),
-    ("sessions", "create"): ("mason sessions create --store agent-sessions --actor-id alice",),
-    ("sessions", "list"): ("mason sessions list --store agent-sessions",),
-    ("sessions", "get"): ("mason sessions get <session-id> --store agent-sessions",),
+    ("sessions", "create"): (
+        ("mason sessions create --store agent-sessions --actor-id alice", "start a new session"),
+    ),
+    ("sessions", "list"): (
+        ("mason sessions list --store agent-sessions", "list sessions in a store"),
+    ),
+    ("sessions", "get"): (
+        ("mason sessions get <session-id> --store agent-sessions", "show one session"),
+    ),
     ("sessions", "update"): (
-        "mason sessions update <session-id> --store agent-sessions "
-        '--metadata \'{"status":"reviewed"}\'',
+        (
+            "mason sessions update <session-id> --store agent-sessions "
+            '--metadata \'{"status":"reviewed"}\'',
+            "edit a session's metadata",
+        ),
     ),
-    ("sessions", "delete"): ("mason sessions delete <session-id> --store agent-sessions",),
+    ("sessions", "delete"): (
+        ("mason sessions delete <session-id> --store agent-sessions", "delete a session"),
+    ),
     ("sessions", "fork"): (
-        "mason sessions fork --store agent-sessions --source-session-id <session-id> "
-        "--actor-id alice",
+        (
+            "mason sessions fork --store agent-sessions --source-session-id <session-id> "
+            "--actor-id alice",
+            "copy a session into a new one",
+        ),
     ),
-    ("tracing",): ("mason tracing setup --catalog main --schema agent_traces",),
-    ("tracing", "setup"): ("mason tracing setup --catalog main --schema agent_traces",),
-    ("tracing", "list"): ("mason tracing list --experiment /Users/me/mason-traces/my-agent",),
-    ("tracing", "get"): ("mason tracing get <trace-id>",),
-    ("tracing", "instrument"): ("mason tracing instrument --destination main.agent_traces",),
-    ("deploy",): ("mason deploy my-agent",),
-    ("deployments",): ("mason deployments list",),
-    ("deployments", "list"): ("mason deployments list",),
-    ("deployments", "get"): ("mason deployments get mason-my-agent",),
-    ("deployments", "logs"): ("mason deployments logs mason-my-agent",),
-    ("deployments", "start"): ("mason deployments start mason-my-agent",),
-    ("deployments", "stop"): ("mason deployments stop mason-my-agent",),
-    ("deployments", "delete"): ("mason deployments delete mason-my-agent",),
+    ("tracing",): (
+        ("mason tracing setup --catalog main --schema agent_traces", "link a UC trace destination"),
+    ),
+    ("tracing", "setup"): (
+        ("mason tracing setup --catalog main --schema agent_traces", "link a UC trace destination"),
+    ),
+    ("tracing", "list"): (
+        ("mason tracing list --experiment /Users/me/mason-traces/my-agent", "list recent traces"),
+    ),
+    ("tracing", "get"): (("mason tracing get <trace-id>", "show one trace"),),
+    ("tracing", "instrument"): (
+        ("mason tracing instrument --destination main.agent_traces", "print instrumentation code"),
+    ),
+    ("deploy",): (("mason deploy my-agent", "deploy the agent to Databricks Apps"),),
+    ("deployments",): (("mason deployments list", "list agent deployments"),),
+    ("deployments", "list"): (("mason deployments list", "list agent deployments"),),
+    ("deployments", "get"): (("mason deployments get mason-my-agent", "show one deployment"),),
+    ("deployments", "logs"): (
+        ("mason deployments logs mason-my-agent", "stream a deployment's logs"),
+    ),
+    ("deployments", "start"): (("mason deployments start mason-my-agent", "start a deployment"),),
+    ("deployments", "stop"): (("mason deployments stop mason-my-agent", "stop a deployment"),),
+    ("deployments", "delete"): (
+        ("mason deployments delete mason-my-agent", "delete a deployment"),
+    ),
     ("tools",): (
-        "mason tools add --help",
-        "mason tools add sandbox --scope table:samples.nyctaxi.trips",
-        "mason tools add mcp system.ai.web_search",
-        "mason tools remove mcp system.ai.web_search",
-        "mason tools list",
+        ("mason tools add --help", "see all tool types you can add"),
+        ("mason tools add sandbox --scope table:samples.nyctaxi.trips", "add a data sandbox tool"),
+        ("mason tools add mcp system.ai.web_search", "add a managed MCP tool"),
+        ("mason tools remove mcp system.ai.web_search", "remove a tool binding"),
+        ("mason tools list", "list configured tools"),
     ),
     ("tools", "add"): (
-        "mason tools add sandbox --scope table:samples.nyctaxi.trips",
-        "mason tools add mcp system.ai.web_search",
-        "mason tools add uc-function catalog.schema.lookup_ticket",
-        "mason tools add python lookup-ticket",
+        ("mason tools add sandbox --scope table:samples.nyctaxi.trips", "add a data sandbox tool"),
+        ("mason tools add mcp system.ai.web_search", "add a managed MCP tool"),
+        ("mason tools add uc-function catalog.schema.lookup_ticket", "add a UC function tool"),
+        ("mason tools add python lookup-ticket", "scaffold a local Python tool"),
     ),
-    ("tools", "add", "sandbox"): ("mason tools add sandbox --scope table:samples.nyctaxi.trips",),
-    ("tools", "add", "mcp"): ("mason tools add mcp system.ai.web_search",),
-    ("tools", "add", "uc-function"): ("mason tools add uc-function catalog.schema.lookup_ticket",),
-    ("tools", "add", "python"): ("mason tools add python lookup-ticket",),
+    ("tools", "add", "sandbox"): (
+        ("mason tools add sandbox --scope table:samples.nyctaxi.trips", "add a data sandbox tool"),
+    ),
+    ("tools", "add", "mcp"): (
+        ("mason tools add mcp system.ai.web_search", "add a managed MCP tool"),
+    ),
+    ("tools", "add", "uc-function"): (
+        ("mason tools add uc-function catalog.schema.lookup_ticket", "add a UC function tool"),
+    ),
+    ("tools", "add", "python"): (
+        ("mason tools add python lookup-ticket", "scaffold a local Python tool"),
+    ),
     ("tools", "remove"): (
-        "mason tools remove mcp system.ai.web_search",
-        "mason tools remove web_search",
+        ("mason tools remove mcp system.ai.web_search", "remove an MCP tool by service"),
+        ("mason tools remove web_search", "remove a tool by id"),
     ),
-    ("tools", "list"): ("mason tools list",),
+    ("tools", "list"): (("mason tools list", "list configured tools"),),
 }
+
+# Longest command we align an inline `# comment` after. Past this, a group's comments would be
+# pushed so far right they wrap or scroll off, so we stack the comment on the line above instead.
+_INLINE_COMMENT_MAX = 46
 
 
 def _walk(
@@ -134,8 +231,34 @@ def _walk(
         yield from _walk(child, path)
 
 
-def _example_epilog(examples: tuple[str, ...]) -> str:
-    return "\n".join(("\b", "Examples:", *(f"  {example}" for example in examples)))
+def _split(example: Example) -> tuple[str, str | None]:
+    """Normalize an example into (command, comment-or-None)."""
+    if isinstance(example, tuple):
+        return example[0], example[1]
+    return example, None
+
+
+def _example_epilog(examples: tuple[Example, ...]) -> str:
+    """Render the Examples block, keeping commands left-aligned and comments legible.
+
+    Commands sit flush at a two-space indent so the block scans as a clean column. The whole group
+    uses one comment layout for consistency: if every command is short enough, comments go inline
+    (`cmd  # what it does`) aligned across the group; if any command is long, all comments stack on
+    the line above their command so nothing wraps.
+    """
+    pairs = [_split(example) for example in examples]
+    stack = any(comment and len(cmd) > _INLINE_COMMENT_MAX for cmd, comment in pairs)
+    inline_width = max((len(cmd) for cmd, comment in pairs if comment), default=0)
+    lines = ["\b", "Examples:"]
+    for cmd, comment in pairs:
+        if not comment:
+            lines.append(f"  {cmd}")
+        elif stack:
+            lines.append(f"  # {comment}")
+            lines.append(f"  {cmd}")
+        else:
+            lines.append(f"  {cmd.ljust(inline_width)}  # {comment}")
+    return "\n".join(lines)
 
 
 def configure_help(root: click.Group) -> None:

--- a/integrations/mason/tests/unit_tests/cli_test.py
+++ b/integrations/mason/tests/unit_tests/cli_test.py
@@ -6,6 +6,7 @@ import click
 from click.testing import CliRunner
 
 from databricks_mason import cli
+from databricks_mason import help as help_mod
 
 
 def _command_paths(group: click.Group, prefix: tuple[str, ...] = ()):
@@ -123,3 +124,48 @@ def test_every_command_has_an_example_in_option_help():
         result = runner.invoke(cli.mason, [*path, "--help"])
         assert result.exit_code == 0, (path, result.output)
         assert "Examples:" in result.output, path
+
+
+def test_root_examples_render_inline_comments():
+    # Short commands carry an aligned inline comment so first-time readers know what each does.
+    result = CliRunner().invoke(cli.mason, ["--help"])
+
+    assert result.exit_code == 0, result.output
+    assert "mason init my-agent" in result.output
+    assert "# scaffold a new agent project" in result.output
+    # inline: command and its comment on the same line
+    line = next(ln for ln in result.output.splitlines() if "mason init my-agent" in ln)
+    assert "# scaffold a new agent project" in line
+
+
+def test_inline_comments_are_column_aligned():
+    # Every inline comment in a group starts at the same column (the `#` lines up).
+    result = CliRunner().invoke(cli.mason, ["mcp", "--help"])
+
+    assert result.exit_code == 0, result.output
+    hash_columns = {ln.index("#") for ln in result.output.splitlines() if "  # " in ln}
+    assert len(hash_columns) == 1, result.output
+
+
+def test_long_commands_stack_the_comment_above():
+    # A command too long to inline puts its comment on the preceding line so nothing wraps.
+    epilog = help_mod._example_epilog(
+        (("mason x " + "y" * help_mod._INLINE_COMMENT_MAX, "does a long thing"),)
+    )
+    lines = epilog.splitlines()
+    comment_i = next(i for i, ln in enumerate(lines) if "# does a long thing" in ln)
+    # comment sits on its own line, immediately above the command
+    assert lines[comment_i].strip() == "# does a long thing"
+    assert lines[comment_i + 1].strip().startswith("mason x")
+
+
+def test_group_comment_layout_is_uniform():
+    # If any command in a group must stack, the whole group stacks (no mixed inline/stacked).
+    epilog = help_mod._example_epilog(
+        (
+            ("mason short", "inline-able"),
+            ("mason " + "z" * help_mod._INLINE_COMMENT_MAX, "forces stacking"),
+        )
+    )
+    # no command line carries a trailing inline comment
+    assert not any(ln.strip().startswith("mason") and " # " in ln for ln in epilog.splitlines())


### PR DESCRIPTION
Each example now carries a short comment explaining what it does, so first-time users can scan `--help` without running commands. Commands stay flush-left in a clean column; a group renders its comments inline when every command is short enough (aligned across the group), and stacks them on the line above otherwise — uniformly per group so the layout never mixes inline and stacked.

Addresses the "poor command readability" bug-bash feedback (inconsistent indent, no explanation of what examples do).