### PR TITLE
Make Mason login configure Databricks authentication

### DIFF
--- a/integrations/mason/README.md
+++ b/integrations/mason/README.md
@@ -41,8 +41,9 @@ mason sessions stores list
 `mason login` does not create credentials; it stores the selected profile in
 `~/.mason/config.json`. `mason logout` forgets that selection without revoking the
 underlying credentials. If Databricks SDK default authentication is already configured,
-you can skip `mason login`. You can also pass `--profile/-p` for an individual command.
-Use `--output json` for scripting.
+you can skip `mason login`. You can also pass the global `--profile/-p` option before an
+individual command, for example `mason --profile <profile> mcp list`. Use `--output json`
+for scripting.
 
 ## Python SDK
 

--- a/integrations/mason/README.md
+++ b/integrations/mason/README.md
@@ -29,21 +29,22 @@ pip install 'databricks-mason[tracing]'
 ## Authentication
 
 Mason uses [Databricks authentication](https://docs.databricks.com/aws/en/dev-tools/cli/authentication).
-If you do not already have credentials, authenticate a named profile first. You can
-then ask Mason to validate and remember that profile:
+Ask Mason to authenticate and remember a named profile:
 
 ```sh
-databricks auth login --profile <profile>
 mason login --profile <profile>
 mason sessions stores list
 ```
 
-`mason login` does not create credentials; it stores the selected profile in
-`~/.mason/config.json`. `mason logout` forgets that selection without revoking the
-underlying credentials. If Databricks SDK default authentication is already configured,
-you can skip `mason login`. You can also pass the global `--profile/-p` option before an
-individual command, for example `mason --profile <profile> mcp list`. Use `--output json`
-for scripting.
+`mason login` validates existing credentials first. If validation fails in an interactive
+terminal, Mason runs `databricks auth login --profile <profile>`, revalidates the profile,
+and stores the selection in `~/.mason/config.json`. This browser-based setup requires the
+Databricks CLI. In non-interactive environments, authenticate the profile before running
+Mason. `mason logout` forgets the saved selection without revoking the underlying credentials.
+
+If Databricks SDK default authentication is already configured, you can skip `mason login`.
+You can also pass the global `--profile/-p` option before an individual command, for example
+`mason --profile <profile> mcp list`. Use `--output json` for scripting.
 
 ## Python SDK
 

--- a/integrations/mason/README.md
+++ b/integrations/mason/README.md
@@ -36,10 +36,10 @@ mason login --profile <profile>
 mason sessions stores list
 ```
 
-`mason login` validates existing credentials first. If validation fails in an interactive
-terminal, Mason runs `databricks auth login --profile <profile>`, revalidates the profile,
-and stores the selection in `~/.mason/config.json`. This browser-based setup requires the
-Databricks CLI. In non-interactive environments, authenticate the profile before running
+`mason login` validates existing credentials first. If credentials are missing or rejected in
+an interactive terminal, Mason runs `databricks auth login --profile <profile>`, revalidates the
+profile, and stores the selection in `~/.mason/config.json`. This browser-based setup requires
+the Databricks CLI. In non-interactive environments, authenticate the profile before running
 Mason. `mason logout` forgets the saved selection without revoking the underlying credentials.
 
 If Databricks SDK default authentication is already configured, you can skip `mason login`.

--- a/integrations/mason/src/databricks_mason/auth.py
+++ b/integrations/mason/src/databricks_mason/auth.py
@@ -1,10 +1,11 @@
 """`mason login` / `logout` — remember an optional Databricks profile.
 
-`login` validates a named profile and persists the selection; the root group falls back
-to it whenever `-p` is omitted. Without a saved profile, the Databricks SDK performs its
-normal default authentication resolution. `logout` removes only Mason's saved selection,
-not the underlying credentials. State lives in a small JSON file under `~/.mason`
-(override the directory with `MASON_CONFIG_HOME`, mainly for tests).
+`login` validates a named profile and persists the selection; when validation fails in an
+interactive terminal, it delegates credential setup to `databricks auth login` and retries.
+The root group falls back to the saved profile whenever `-p` is omitted. Without a saved
+profile, the Databricks SDK performs its normal default authentication resolution. `logout`
+removes only Mason's saved selection, not the underlying credentials. State lives in a small
+JSON file under `~/.mason` (override the directory with `MASON_CONFIG_HOME`, mainly for tests).
 """
 
 from __future__ import annotations
@@ -12,6 +13,8 @@ from __future__ import annotations
 import json
 import os
 import pathlib
+import subprocess
+import sys
 from typing import Optional
 
 import click
@@ -41,6 +44,52 @@ def _save_default_profile(profile: str) -> None:
     path.write_text(json.dumps({"profile": profile}, indent=2) + "\n")
 
 
+def _validate_profile(profile: str) -> tuple[MasonClient, str]:
+    client = MasonClient(profile)
+    return client, client.current_user
+
+
+def _is_interactive() -> bool:
+    return sys.stdin.isatty()
+
+
+def _run_databricks_login(profile: str) -> None:
+    command = ["databricks", "auth", "login", "--profile", profile]
+    try:
+        result = subprocess.run(command, text=True, check=False)
+    except FileNotFoundError as exc:
+        raise AgentCliError(
+            "Could not configure Databricks authentication: the `databricks` CLI was not found.",
+            hint=f"Install the Databricks CLI, then retry `mason login --profile {profile}`.",
+        ) from exc
+    if result.returncode != 0:
+        raise AgentCliError(
+            f"`databricks auth login --profile {profile}` failed (exit {result.returncode})."
+        )
+
+
+def _authenticate_profile(profile: str) -> tuple[MasonClient, str]:
+    try:
+        return _validate_profile(profile)
+    except Exception as initial_error:  # noqa: BLE001 - validation may require interactive login
+        if not _is_interactive():
+            raise AgentCliError(
+                f"Could not validate Databricks profile {profile!r}: {initial_error}",
+                hint="Run this command in an interactive terminal so Mason can open "
+                "Databricks login, or authenticate first with "
+                f"`databricks auth login --profile {profile}`.",
+            ) from initial_error
+
+    _run_databricks_login(profile)
+    try:
+        return _validate_profile(profile)
+    except Exception as retry_error:  # noqa: BLE001 - normalize the post-login failure
+        raise AgentCliError(
+            f"Databricks login completed, but profile {profile!r} could not be validated: "
+            f"{retry_error}"
+        ) from retry_error
+
+
 @click.command()
 @click.option(
     "--profile",
@@ -50,15 +99,14 @@ def _save_default_profile(profile: str) -> None:
 )
 @click.pass_obj
 def login(obj, profile) -> None:
-    """Validate a profile's credentials and save it as the default, so later commands can omit -p."""
+    """Authenticate a profile and save it as the default, so later commands can omit -p."""
     profile = profile or obj.profile
     if not profile:
         raise AgentCliError(
             "No profile to save.",
             hint="Pass one to remember, e.g. `mason login --profile my-workspace`.",
         )
-    client = MasonClient(profile)
-    user = client.current_user  # round-trips current_user.me(), so a bad profile fails here
+    client, user = _authenticate_profile(profile)
     _save_default_profile(profile)
     if obj.output == "json":
         render.emit_json({"profile": profile, "user": user, "host": client.host})

--- a/integrations/mason/src/databricks_mason/auth.py
+++ b/integrations/mason/src/databricks_mason/auth.py
@@ -1,11 +1,11 @@
 """`mason login` / `logout` — remember an optional Databricks profile.
 
-`login` validates a named profile and persists the selection; when validation fails in an
-interactive terminal, it delegates credential setup to `databricks auth login` and retries.
-The root group falls back to the saved profile whenever `-p` is omitted. Without a saved
-profile, the Databricks SDK performs its normal default authentication resolution. `logout`
-removes only Mason's saved selection, not the underlying credentials. State lives in a small
-JSON file under `~/.mason` (override the directory with `MASON_CONFIG_HOME`, mainly for tests).
+`login` validates a named profile and persists the selection; when credentials are missing or
+rejected in an interactive terminal, it delegates setup to `databricks auth login` and retries.
+The root group falls back to the saved profile whenever `-p` is omitted. Without a saved profile,
+the Databricks SDK performs its normal default authentication resolution. `logout` removes only
+Mason's saved selection, not the underlying credentials. State lives in a small JSON file under
+`~/.mason` (override the directory with `MASON_CONFIG_HOME`, mainly for tests).
 """
 
 from __future__ import annotations
@@ -18,6 +18,7 @@ import sys
 from typing import Optional
 
 import click
+from databricks.sdk.errors import Unauthenticated
 
 from databricks_mason import render
 from databricks_mason.client import MasonClient
@@ -56,7 +57,8 @@ def _is_interactive() -> bool:
 def _run_databricks_login(profile: str) -> None:
     command = ["databricks", "auth", "login", "--profile", profile]
     try:
-        result = subprocess.run(command, text=True, check=False)
+        # Keep the child process interactive while preserving stdout for Mason's JSON output.
+        result = subprocess.run(command, text=True, check=False, stdout=sys.stderr)
     except FileNotFoundError as exc:
         raise AgentCliError(
             "Could not configure Databricks authentication: the `databricks` CLI was not found.",
@@ -71,7 +73,7 @@ def _run_databricks_login(profile: str) -> None:
 def _authenticate_profile(profile: str) -> tuple[MasonClient, str]:
     try:
         return _validate_profile(profile)
-    except Exception as initial_error:  # noqa: BLE001 - validation may require interactive login
+    except (AgentCliError, Unauthenticated) as initial_error:
         if not _is_interactive():
             raise AgentCliError(
                 f"Could not validate Databricks profile {profile!r}: {initial_error}",
@@ -79,6 +81,10 @@ def _authenticate_profile(profile: str) -> tuple[MasonClient, str]:
                 "Databricks login, or authenticate first with "
                 f"`databricks auth login --profile {profile}`.",
             ) from initial_error
+    except Exception as validation_error:  # noqa: BLE001 - normalize unexpected API failures
+        raise AgentCliError(
+            f"Could not validate Databricks profile {profile!r}: {validation_error}"
+        ) from validation_error
 
     _run_databricks_login(profile)
     try:

--- a/integrations/mason/src/databricks_mason/client.py
+++ b/integrations/mason/src/databricks_mason/client.py
@@ -119,9 +119,8 @@ class MasonClient:
             raise AgentCliError(
                 f"Could not initialize Databricks auth: {exc}",
                 hint="Select an existing profile with `mason --profile <name> <command>` "
-                "(global options must precede subcommands), or save it with "
-                "`mason login --profile <name>`. If the profile has no valid credentials, "
-                "run `databricks auth login --profile <name>` first.",
+                "(global options must precede subcommands), or authenticate and save it with "
+                "`mason login --profile <name>`.",
             ) from exc
 
     @property

--- a/integrations/mason/src/databricks_mason/client.py
+++ b/integrations/mason/src/databricks_mason/client.py
@@ -119,8 +119,7 @@ class MasonClient:
             raise AgentCliError(
                 f"Could not initialize Databricks auth: {exc}",
                 hint="Select an existing profile with `mason --profile <name> <command>` "
-                "(global options must precede subcommands), or authenticate and save it with "
-                "`mason login --profile <name>`.",
+                "or authenticate and save it with `mason login --profile <name>`.",
             ) from exc
 
     @property

--- a/integrations/mason/src/databricks_mason/client.py
+++ b/integrations/mason/src/databricks_mason/client.py
@@ -118,8 +118,10 @@ class MasonClient:
         except Exception as exc:  # noqa: BLE001 - surfaced as a clean CLI error
             raise AgentCliError(
                 f"Could not initialize Databricks auth: {exc}",
-                hint="Check your profile (`databricks auth login --profile <name>`) "
-                "or pass --profile.",
+                hint="Select an existing profile with `mason --profile <name> <command>` "
+                "(global options must precede subcommands), or save it with "
+                "`mason login --profile <name>`. If the profile has no valid credentials, "
+                "run `databricks auth login --profile <name>` first.",
             ) from exc
 
     @property

--- a/integrations/mason/tests/unit_tests/auth_test.py
+++ b/integrations/mason/tests/unit_tests/auth_test.py
@@ -88,8 +88,73 @@ def test_login_configures_invalid_profile_then_revalidates(tmp_path, monkeypatch
     assert auth.load_default_profile() == "prof"
     assert mason_client.call_args_list == [mock.call("prof"), mock.call("prof")]
     databricks_login.assert_called_once_with(
-        ["databricks", "auth", "login", "--profile", "prof"], text=True, check=False
+        ["databricks", "auth", "login", "--profile", "prof"],
+        text=True,
+        check=False,
+        stdout=mock.ANY,
     )
+
+
+def test_login_fallback_keeps_json_stdout_clean(tmp_path, monkeypatch):
+    monkeypatch.setenv("MASON_CONFIG_HOME", str(tmp_path))
+    validated = mock.Mock(current_user="me@example.com", host="https://ws")
+    monkeypatch.setattr(
+        auth,
+        "MasonClient",
+        mock.Mock(side_effect=[auth.AgentCliError("no credentials"), validated]),
+    )
+    monkeypatch.setattr(auth, "_is_interactive", lambda: True)
+
+    def databricks_login(*_args, **kwargs):
+        kwargs["stdout"].write("Databricks browser login output\n")
+        return mock.Mock(returncode=0)
+
+    monkeypatch.setattr(auth.subprocess, "run", databricks_login)
+
+    result = CliRunner().invoke(auth.login, ["--profile", "prof"], obj=_Ctx(output="json"))
+
+    assert result.exit_code == 0, result.output
+    assert json.loads(result.stdout) == {
+        "profile": "prof",
+        "user": "me@example.com",
+        "host": "https://ws",
+    }
+    assert "Databricks browser login output" in result.stderr
+
+
+def test_login_reauthenticates_unauthenticated_api_response(tmp_path, monkeypatch):
+    monkeypatch.setenv("MASON_CONFIG_HOME", str(tmp_path))
+    validated = mock.Mock(current_user="me@example.com", host="https://ws")
+    validate_profile = mock.Mock(
+        side_effect=[auth.Unauthenticated("expired credentials"), (validated, "me@example.com")]
+    )
+    monkeypatch.setattr(auth, "_validate_profile", validate_profile)
+    monkeypatch.setattr(auth, "_is_interactive", lambda: True)
+    databricks_login = mock.Mock(return_value=mock.Mock(returncode=0))
+    monkeypatch.setattr(auth.subprocess, "run", databricks_login)
+
+    result = CliRunner().invoke(auth.login, ["--profile", "prof"], obj=_Ctx())
+
+    assert result.exit_code == 0, result.output
+    assert validate_profile.call_count == 2
+    databricks_login.assert_called_once()
+
+
+def test_login_does_not_reauthenticate_non_auth_validation_error(tmp_path, monkeypatch):
+    monkeypatch.setenv("MASON_CONFIG_HOME", str(tmp_path))
+    monkeypatch.setattr(
+        auth, "_validate_profile", mock.Mock(side_effect=RuntimeError("service unavailable"))
+    )
+    monkeypatch.setattr(auth, "_is_interactive", lambda: True)
+    databricks_login = mock.Mock()
+    monkeypatch.setattr(auth.subprocess, "run", databricks_login)
+
+    result = CliRunner().invoke(auth.login, ["--profile", "prof"], obj=_Ctx())
+
+    assert result.exit_code != 0
+    assert "service unavailable" in result.output
+    assert auth.load_default_profile() is None
+    databricks_login.assert_not_called()
 
 
 def test_login_does_not_launch_browser_when_noninteractive(tmp_path, monkeypatch):

--- a/integrations/mason/tests/unit_tests/auth_test.py
+++ b/integrations/mason/tests/unit_tests/auth_test.py
@@ -7,6 +7,7 @@ is stubbed so login never touches the network.
 from __future__ import annotations
 
 import json
+import sys
 from unittest import mock
 
 from click.testing import CliRunner
@@ -95,31 +96,18 @@ def test_login_configures_invalid_profile_then_revalidates(tmp_path, monkeypatch
     )
 
 
-def test_login_fallback_keeps_json_stdout_clean(tmp_path, monkeypatch):
-    monkeypatch.setenv("MASON_CONFIG_HOME", str(tmp_path))
-    validated = mock.Mock(current_user="me@example.com", host="https://ws")
-    monkeypatch.setattr(
-        auth,
-        "MasonClient",
-        mock.Mock(side_effect=[auth.AgentCliError("no credentials"), validated]),
-    )
-    monkeypatch.setattr(auth, "_is_interactive", lambda: True)
-
-    def databricks_login(*_args, **kwargs):
-        kwargs["stdout"].write("Databricks browser login output\n")
-        return mock.Mock(returncode=0)
-
+def test_databricks_login_routes_child_stdout_to_stderr(monkeypatch):
+    databricks_login = mock.Mock(return_value=mock.Mock(returncode=0))
     monkeypatch.setattr(auth.subprocess, "run", databricks_login)
 
-    result = CliRunner().invoke(auth.login, ["--profile", "prof"], obj=_Ctx(output="json"))
+    auth._run_databricks_login("prof")
 
-    assert result.exit_code == 0, result.output
-    assert json.loads(result.stdout) == {
-        "profile": "prof",
-        "user": "me@example.com",
-        "host": "https://ws",
-    }
-    assert "Databricks browser login output" in result.stderr
+    databricks_login.assert_called_once_with(
+        ["databricks", "auth", "login", "--profile", "prof"],
+        text=True,
+        check=False,
+        stdout=sys.stderr,
+    )
 
 
 def test_login_reauthenticates_unauthenticated_api_response(tmp_path, monkeypatch):

--- a/integrations/mason/tests/unit_tests/auth_test.py
+++ b/integrations/mason/tests/unit_tests/auth_test.py
@@ -37,9 +37,12 @@ def test_load_default_profile_missing_returns_none(tmp_path, monkeypatch):
 def test_login_persists_and_load_round_trips(tmp_path, monkeypatch):
     monkeypatch.setenv("MASON_CONFIG_HOME", str(tmp_path))
     _stub_client(monkeypatch)
+    databricks_login = mock.Mock()
+    monkeypatch.setattr(auth.subprocess, "run", databricks_login)
     result = CliRunner().invoke(auth.login, ["--profile", "my-workspace"], obj=_Ctx())
     assert result.exit_code == 0, result.output
     assert auth.load_default_profile() == "my-workspace"
+    databricks_login.assert_not_called()
 
 
 def test_login_json_output(tmp_path, monkeypatch):
@@ -67,6 +70,58 @@ def test_login_without_any_profile_errors(tmp_path, monkeypatch):
     monkeypatch.setenv("MASON_CONFIG_HOME", str(tmp_path))
     result = CliRunner().invoke(auth.login, [], obj=_Ctx(profile=None))
     assert result.exit_code != 0
+    assert auth.load_default_profile() is None
+
+
+def test_login_configures_invalid_profile_then_revalidates(tmp_path, monkeypatch):
+    monkeypatch.setenv("MASON_CONFIG_HOME", str(tmp_path))
+    validated = mock.Mock(current_user="me@example.com", host="https://ws")
+    mason_client = mock.Mock(side_effect=[auth.AgentCliError("no credentials"), validated])
+    monkeypatch.setattr(auth, "MasonClient", mason_client)
+    monkeypatch.setattr(auth, "_is_interactive", lambda: True)
+    databricks_login = mock.Mock(return_value=mock.Mock(returncode=0))
+    monkeypatch.setattr(auth.subprocess, "run", databricks_login)
+
+    result = CliRunner().invoke(auth.login, ["--profile", "prof"], obj=_Ctx())
+
+    assert result.exit_code == 0, result.output
+    assert auth.load_default_profile() == "prof"
+    assert mason_client.call_args_list == [mock.call("prof"), mock.call("prof")]
+    databricks_login.assert_called_once_with(
+        ["databricks", "auth", "login", "--profile", "prof"], text=True, check=False
+    )
+
+
+def test_login_does_not_launch_browser_when_noninteractive(tmp_path, monkeypatch):
+    monkeypatch.setenv("MASON_CONFIG_HOME", str(tmp_path))
+    monkeypatch.setattr(
+        auth, "MasonClient", mock.Mock(side_effect=auth.AgentCliError("no credentials"))
+    )
+    monkeypatch.setattr(auth, "_is_interactive", lambda: False)
+    databricks_login = mock.Mock()
+    monkeypatch.setattr(auth.subprocess, "run", databricks_login)
+
+    result = CliRunner().invoke(auth.login, ["--profile", "prof"], obj=_Ctx())
+
+    assert result.exit_code != 0
+    assert "interactive terminal" in result.output
+    assert auth.load_default_profile() is None
+    databricks_login.assert_not_called()
+
+
+def test_login_reports_when_databricks_cli_is_missing(tmp_path, monkeypatch):
+    monkeypatch.setenv("MASON_CONFIG_HOME", str(tmp_path))
+    monkeypatch.setattr(
+        auth, "MasonClient", mock.Mock(side_effect=auth.AgentCliError("no credentials"))
+    )
+    monkeypatch.setattr(auth, "_is_interactive", lambda: True)
+    monkeypatch.setattr(auth.subprocess, "run", mock.Mock(side_effect=FileNotFoundError))
+
+    result = CliRunner().invoke(auth.login, ["--profile", "prof"], obj=_Ctx())
+
+    assert result.exit_code != 0
+    assert "Could not configure Databricks authentication" in result.output
+    assert "not found" in result.output
     assert auth.load_default_profile() is None
 
 

--- a/integrations/mason/tests/unit_tests/client_test.py
+++ b/integrations/mason/tests/unit_tests/client_test.py
@@ -149,7 +149,7 @@ def test_auth_error_hint_explains_profile_selection_and_login(_workspace_client)
     assert "`mason --profile <name> <command>`" in hint
     assert "global options must precede subcommands" in hint
     assert "`mason login --profile <name>`" in hint
-    assert "`databricks auth login --profile <name>`" in hint
+    assert "`databricks auth login --profile <name>`" not in hint
 
 
 def test_account_routed_profile_uses_configured_host_and_workspace_header():

--- a/integrations/mason/tests/unit_tests/client_test.py
+++ b/integrations/mason/tests/unit_tests/client_test.py
@@ -139,6 +139,19 @@ def test_preview_error_is_mapped_with_hint(workspace_client):
         assert mapped.hint is not None
 
 
+@mock.patch("databricks_mason.client._workspace_client", side_effect=RuntimeError("no auth"))
+def test_auth_error_hint_explains_profile_selection_and_login(_workspace_client):
+    with pytest.raises(AgentCliError) as exc_info:
+        MasonClient()
+
+    hint = exc_info.value.hint
+    assert hint is not None
+    assert "`mason --profile <name> <command>`" in hint
+    assert "global options must precede subcommands" in hint
+    assert "`mason login --profile <name>`" in hint
+    assert "`databricks auth login --profile <name>`" in hint
+
+
 def test_account_routed_profile_uses_configured_host_and_workspace_header():
     resolved = mock.Mock()
     resolved.config.host = "https://workspace.example.com"

--- a/integrations/mason/tests/unit_tests/client_test.py
+++ b/integrations/mason/tests/unit_tests/client_test.py
@@ -147,7 +147,6 @@ def test_auth_error_hint_explains_profile_selection_and_login(_workspace_client)
     hint = exc_info.value.hint
     assert hint is not None
     assert "`mason --profile <name> <command>`" in hint
-    assert "global options must precede subcommands" in hint
     assert "`mason login --profile <name>`" in hint
     assert "`databricks auth login --profile <name>`" not in hint
 


### PR DESCRIPTION
## Summary

Make `mason login --profile <name>` validate existing credentials and, when credentials are missing or rejected in an interactive terminal, delegate browser authentication to `databricks auth login`, revalidate, and save the profile. Other validation failures return without launching a browser, child login output stays on stderr so Mason JSON remains parseable, and the auth hint points users to Mason commands for either one-off profile selection or saved login.

## Testing

Added regression coverage for valid credentials skipping browser login, credential failures invoking and retrying Databricks login, clean JSON stdout during the fallback, non-auth failures avoiding reauthentication, non-interactive behavior, a missing Databricks CLI, and the profile-selection hint. The complete Mason unit suite passes (230 tests), along with Ruff lint/format checks and focused `ty` checks.

Live E2E against `https://eng-ml-inference.staging.cloud.databricks.com/` used a disposable `eng-ml-inference` profile containing only the host. `mason login --profile eng-ml-inference` invoked Databricks browser authentication, revalidated the profile, and saved it; a subsequent `mason mcp list` succeeded and returned six services. The temporary Databricks and Mason auth files were removed afterward.

Abridged terminal view (user and service rows omitted):

```text
$ mason login --profile eng-ml-inference
[Databricks CLI opens browser authentication]
[profile saved and revalidated]
Logged in as <user>
Profile  eng-ml-inference
Host     https://eng-ml-inference.staging.cloud.databricks.com

$ mason mcp list
MCP Services
Available in system.ai
...
6 items
```