### PR TITLE
mason: surface the deployed app URL from `mason deploy`

### DIFF
--- a/integrations/mason/src/databricks_mason/deploy.py
+++ b/integrations/mason/src/databricks_mason/deploy.py
@@ -56,6 +56,17 @@ def _app_service_principal(name: str, profile: Optional[str]) -> Optional[str]:
         return None
 
 
+def _app_url(name: str, profile: Optional[str]) -> Optional[str]:
+    """The deployed app's browsable URL, or None if it can't be read."""
+    result = _databricks(["apps", "get", name, "-o", "json"], profile, capture=True, check=False)
+    if result.returncode != 0:
+        return None
+    try:
+        return json.loads(result.stdout).get("url") or None
+    except json.JSONDecodeError:
+        return None
+
+
 def _app_compute_state(name: str, profile: Optional[str]) -> Optional[str]:
     """The app's compute state (e.g. RUNNING), or None if it can't be read."""
     result = _databricks(["apps", "get", name, "-o", "json"], profile, capture=True, check=False)
@@ -428,10 +439,13 @@ def deploy(
                 name, sp, client.current_user, session_store, memory_database, obj.profile
             )
 
+    app_url = _app_url(name, obj.profile)
+
     if obj.output == "json":
         render.emit_json(
             {
                 "deployment": name,
+                "url": app_url,
                 "workspace_path": ws_path,
                 "env": env_updates,
                 "store_grant": "skipped"
@@ -443,6 +457,8 @@ def deploy(
         return
 
     steps = [f"mason deployments logs {name}", f"mason deployments get {name}"]
+    if app_url:
+        steps.insert(0, f"open {app_url}")
     if scaffolded:
         steps.insert(
             0, f"Set a real `command:` in {source_dir / 'app.yaml'} (a placeholder was written)"
@@ -456,9 +472,11 @@ def deploy(
         )
     if grants_stores and grant_error is None:
         provisioned["Store access"] = "granted to app service principal"
+    fields = {"URL": app_url} if app_url else {}
+    fields.update({"Workspace path": ws_path, **provisioned})
     render.success(
         f"Deployed agent '{name}'",
-        fields={"Workspace path": ws_path, **provisioned},
+        fields=fields,
         next_steps=steps,
     )
 

--- a/integrations/mason/tests/unit_tests/deploy_test.py
+++ b/integrations/mason/tests/unit_tests/deploy_test.py
@@ -115,6 +115,32 @@ def test_deploy_drives_sync_and_apps_deploy(tmp_path: pathlib.Path, monkeypatch)
     assert env["AGENT_MEMORY_STORE"] == "mem-id-123"
 
 
+def test_deploy_reports_app_url(tmp_path: pathlib.Path, monkeypatch):
+    src = tmp_path / "app"
+    src.mkdir()
+    (src / "app.yaml").write_text(yaml.safe_dump({"command": ["x"]}))
+
+    monkeypatch.setattr(deploy_mod, "_deployment_exists", lambda a, p: True)
+    monkeypatch.setattr(
+        deploy_mod,
+        "_databricks",
+        lambda args, profile, **kw: types.SimpleNamespace(returncode=0, stdout="", stderr=""),
+    )
+    monkeypatch.setattr(
+        deploy_mod, "_app_url", lambda name, p: "https://myapp-123.databricksapps.com"
+    )
+    captured: dict = {}
+    monkeypatch.setattr(deploy_mod.render, "emit_json", lambda data: captured.update(data))
+
+    class _JsonCtx(_FakeCtx):
+        output = "json"
+
+    result = CliRunner().invoke(deploy_mod.deploy, ["myapp", "--source", str(src)], obj=_JsonCtx())
+
+    assert result.exit_code == 0, result.output
+    assert captured["url"] == "https://myapp-123.databricksapps.com"
+
+
 def test_deploy_sync_keeps_directly_edited_agent_manifest(tmp_path: pathlib.Path, monkeypatch):
     src = tmp_path / "app"
     src.mkdir()


### PR DESCRIPTION
## What

`mason deploy` didn't report the deployed Databricks App's URL, so there was no direct link to open the app after a successful deploy. This adds it.

The URL is already available from `databricks apps get -o json` (and is used by `mason deployments get`). After rollout, `deploy` now fetches it and surfaces it in both output modes:

- **text**: a top `URL` field in the success panel plus an `open <url>` next step
- **json**: a `"url"` key alongside the existing fields

It degrades gracefully — if the URL can't be read, it's simply omitted (no failure).

## Testing

- New unit test `test_deploy_reports_app_url` asserts the URL is included in the JSON output.
- `uv run pytest tests/unit_tests/deploy_test.py` — 22 passed.
- `uv run ruff format` / `ruff check` — clean.

Before
<img width="1204" height="186" alt="Screenshot 2026-09-02 at 5 41 44 PM" src="https://github.com/user-attachments/assets/d5e9b689-31a7-49a5-bf3f-4fa929daeb7b" />

After
<img width="943" height="241" alt="Screenshot 2026-09-02 at 5 41 19 PM" src="https://github.com/user-attachments/assets/49591281-7b56-4a6b-9279-0c9413689c31" />
