### PR TITLE
[mason] Flag a stray DATABRICKS_TOKEN in the auth-init error

### DIFF
--- a/integrations/mason/src/databricks_mason/_api_client.py
+++ b/integrations/mason/src/databricks_mason/_api_client.py
@@ -124,10 +124,21 @@ class _MasonApiClient:
         try:
             self._w = workspace_client or _workspace_client(profile)
         except Exception as exc:  # noqa: BLE001 - surfaced as a clean CLI error
+            hint = (
+                "Select an existing profile with `mason --profile <name> <command>` "
+                "or authenticate and save it with `mason login --profile <name>`."
+            )
+            # A stray DATABRICKS_TOKEN takes precedence over the profile in the SDK's default
+            # auth resolution, so auth can fail against the wrong host even when the profile is
+            # correct. Surface it — the fix (unset the token) isn't evident from the SDK error.
+            if os.environ.get("DATABRICKS_TOKEN"):
+                hint += (
+                    " DATABRICKS_TOKEN is set in the environment and overrides the profile — "
+                    "unset it if you meant to authenticate with a profile."
+                )
             raise AgentCliError(
                 f"Could not initialize Databricks auth: {exc}",
-                hint="Select an existing profile with `mason --profile <name> <command>` "
-                "or authenticate and save it with `mason login --profile <name>`.",
+                hint=hint,
             ) from exc
 
     @property

--- a/integrations/mason/tests/unit_tests/client_test.py
+++ b/integrations/mason/tests/unit_tests/client_test.py
@@ -259,6 +259,30 @@ def test_auth_error_hint_explains_profile_selection_and_login(_workspace_client)
     assert "`databricks auth login --profile <name>`" not in hint
 
 
+@mock.patch("databricks_mason._api_client._workspace_client", side_effect=RuntimeError("no auth"))
+def test_auth_error_hint_flags_stray_databricks_token(_workspace_client, monkeypatch):
+    monkeypatch.setenv("DATABRICKS_TOKEN", "dapiSTRAY")
+    with pytest.raises(AgentCliError) as exc_info:
+        _MasonApiClient()
+
+    hint = exc_info.value.hint
+    assert hint is not None
+    assert "DATABRICKS_TOKEN" in hint and "unset it" in hint
+    assert "`mason login --profile <name>`" in hint  # base guidance still present
+
+
+@mock.patch("databricks_mason._api_client._workspace_client", side_effect=RuntimeError("no auth"))
+def test_auth_error_hint_omits_token_note_when_unset(_workspace_client, monkeypatch):
+    monkeypatch.delenv("DATABRICKS_TOKEN", raising=False)
+    with pytest.raises(AgentCliError) as exc_info:
+        _MasonApiClient()
+
+    hint = exc_info.value.hint
+    assert hint is not None
+    assert "DATABRICKS_TOKEN" not in hint
+    assert "`mason --profile <name> <command>`" in hint
+
+
 def test_profile_auth_is_forwarded_when_multiple_profiles_share_a_host(
     tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
 ):


### PR DESCRIPTION
## What did you change, and why?

**Context:** From the custom-agent bug bash, the P1 finding *"Auth errors are confusing/looping and suggest the wrong command (`databricks auth login` vs `mason login`)."* Since this PR was opened, most of that has landed on `main` through other PRs:

- the misleading fixed hint (`Check your profile … or pass --profile`) is gone;
- auth-init failures now surface the SDK message verbatim **and** point at the right command — `mason login --profile <name>` (in `_api_client.py`);
- `mason login` configures auth on its own (#520), so a separate `databricks auth login` is no longer needed.

So this PR is **rescoped to the one gap that didn't land**: my own bug-bash finding that a stray `DATABRICKS_TOKEN` silently overrides the selected profile ("had to unset my databricks token … not intuitive from the error messages").

**Change:** when workspace-client initialization fails and `DATABRICKS_TOKEN` is set in the environment, append a note to the auth-error hint explaining that the env token takes precedence over the profile and should be unset. The SDK's default auth resolution prefers the env token, so auth can fail against the wrong host even when the profile is correct — and nothing in the SDK error makes that obvious.

## How do you know it works?

Unit tests in `client_test.py` cover the token-set case (hint flags `DATABRICKS_TOKEN` and says to unset it) and the token-unset case (no note; base guidance intact). Also exercised `_MasonApiClient` directly against both environment states.

This pull request and its description were written by Isaac.
