### PR TITLE
[mason] mason login authenticates you (no separate databricks auth login)

### DIFF
--- a/integrations/mason/README.md
+++ b/integrations/mason/README.md
@@ -29,20 +29,21 @@ pip install 'databricks-mason[tracing]'
 ## Authentication
 
 Mason uses [Databricks authentication](https://docs.databricks.com/aws/en/dev-tools/cli/authentication).
-If you do not already have credentials, authenticate a named profile first. You can
-then ask Mason to validate and remember that profile:
+`mason login` is the only auth command you need: it authenticates the profile — running the
+browser sign-in for you if that profile has no credentials yet — and remembers it as the
+default so later commands can omit `-p`:
 
 ```sh
-databricks auth login --profile <profile>
-mason login --profile <profile>
+mason login --profile <profile> --host https://<workspace>
 mason sessions stores list
 ```
 
-`mason login` does not create credentials; it stores the selected profile in
-`~/.mason/config.json`. `mason logout` forgets that selection without revoking the
-underlying credentials. If Databricks SDK default authentication is already configured,
-you can skip `mason login`. You can also pass `--profile/-p` for an individual command.
-Use `--output json` for scripting.
+Pass `--host` only when first creating a profile; an existing profile already knows its host.
+`mason login` stores the selected profile name in `~/.mason/config.json`, while credentials
+live in `~/.databrickscfg` exactly as the Databricks CLI writes them. `mason logout` forgets
+that selection without revoking the underlying credentials. If Databricks SDK default
+authentication is already configured, you can skip `mason login`; you can also pass
+`--profile/-p` for an individual command. Use `--output json` for scripting.
 
 ## Python SDK
 
@@ -73,7 +74,7 @@ accessors (`store.name`) while remaining plain dicts underneath — so `store["n
 
 ```text
 mason [-p <profile>] [-o text|json]
-  login        [--profile P]
+  login        [--profile P] [--host URL]
   logout
   init         [--framework openai|langgraph] [--disable-chat-app]
                [--profile P] [--repo URL] [--ref REF] [directory]

--- a/integrations/mason/src/databricks_mason/auth.py
+++ b/integrations/mason/src/databricks_mason/auth.py
@@ -68,9 +68,9 @@ def _run_databricks_login(profile: str, host: Optional[str]) -> None:
         ) from exc
     if result.returncode != 0:
         raise AgentCliError(
-            f"Sign-in failed (`{' '.join(cmd)}` exited {result.returncode}).",
-            hint="Re-run `mason login` and complete the browser sign-in, or pass "
-            "--host <workspace-url> if this is a new profile.",
+            "Sign-in didn't complete.",
+            hint="Re-run `mason login` and finish the browser sign-in, or pass "
+            "--host <workspace-url> if this profile is new.",
         )
 
 

--- a/integrations/mason/src/databricks_mason/auth.py
+++ b/integrations/mason/src/databricks_mason/auth.py
@@ -1,10 +1,14 @@
-"""`mason login` / `logout` — remember an optional Databricks profile.
+"""`mason login` / `logout` — authenticate and remember a Databricks profile.
 
-`login` validates a named profile and persists the selection; the root group falls back
-to it whenever `-p` is omitted. Without a saved profile, the Databricks SDK performs its
-normal default authentication resolution. `logout` removes only Mason's saved selection,
-not the underlying credentials. State lives in a small JSON file under `~/.mason`
-(override the directory with `MASON_CONFIG_HOME`, mainly for tests).
+`login` is the only auth command a user needs: it validates the named profile and, if that
+profile has no usable credentials yet, runs the Databricks OAuth sign-in for it (via the
+`databricks` CLI, already required for `dev`/`deploy`) — so there's no separate
+`databricks auth login` step. It then persists the selection; the root group falls back to
+it whenever `-p` is omitted. Without a saved profile, the Databricks SDK performs its normal
+default authentication resolution. `logout` removes only Mason's saved selection, not the
+underlying credentials. Mason's state lives in a small JSON file under `~/.mason` (override
+the directory with `MASON_CONFIG_HOME`, mainly for tests); credentials live in
+`~/.databrickscfg`, exactly as the Databricks CLI writes them.
 """
 
 from __future__ import annotations
@@ -12,6 +16,7 @@ from __future__ import annotations
 import json
 import os
 import pathlib
+import subprocess
 from typing import Optional
 
 import click
@@ -41,6 +46,34 @@ def _save_default_profile(profile: str) -> None:
     path.write_text(json.dumps({"profile": profile}, indent=2) + "\n")
 
 
+def _run_databricks_login(profile: str, host: Optional[str]) -> None:
+    """Run `databricks auth login` for a profile, creating/refreshing its credentials.
+
+    Shelling the Databricks CLI (already required for `dev`/`deploy`) lets `mason login`
+    authenticate a user on its own — the browser sign-in and the saved selection happen from
+    one command. Passing `--profile` writes/updates that profile in `~/.databrickscfg`;
+    `--host` is required only when the profile doesn't exist yet (otherwise the CLI reuses the
+    profile's stored host, or prompts for it).
+    """
+    cmd = ["databricks", "auth", "login", "--profile", profile]
+    if host:
+        cmd += ["--host", host]
+    try:
+        result = subprocess.run(cmd, text=True)
+    except FileNotFoundError as exc:
+        raise AgentCliError(
+            "The Databricks CLI is required to sign in but was not found on PATH.",
+            hint="Install it (https://docs.databricks.com/dev-tools/cli/install.html), "
+            "then re-run `mason login`.",
+        ) from exc
+    if result.returncode != 0:
+        raise AgentCliError(
+            f"Sign-in failed (`{' '.join(cmd)}` exited {result.returncode}).",
+            hint="Re-run `mason login` and complete the browser sign-in, or pass "
+            "--host <workspace-url> if this is a new profile.",
+        )
+
+
 @click.command()
 @click.option(
     "--profile",
@@ -48,17 +81,35 @@ def _save_default_profile(profile: str) -> None:
     default=None,
     help="Profile to authenticate with and remember as the default.",
 )
+@click.option(
+    "--host",
+    default=None,
+    help="Workspace URL (e.g. https://<workspace>.cloud.databricks.com). Only needed when "
+    "first creating the profile; an existing profile already knows its host.",
+)
 @click.pass_obj
-def login(obj, profile) -> None:
-    """Validate a profile's credentials and save it as the default, so later commands can omit -p."""
+def login(obj, profile, host) -> None:
+    """Authenticate a profile and save it as the default, so later commands can omit -p.
+
+    This is the only auth command you need: if the profile has no usable credentials yet, the
+    Databricks OAuth sign-in runs for you (no separate `databricks auth login`). An
+    already-authenticated profile is just validated and remembered.
+    """
     profile = profile or obj.profile
     if not profile:
         raise AgentCliError(
-            "No profile to save.",
-            hint="Pass one to remember, e.g. `mason login --profile my-workspace`.",
+            "No profile to log in.",
+            hint="Pass one, e.g. `mason login --profile my-workspace --host https://<workspace>`.",
         )
-    client = MasonClient(profile)
-    user = client.current_user  # round-trips current_user.me(), so a bad profile fails here
+    try:
+        client = MasonClient(profile)
+        # Round-trips current_user.me(), so missing/invalid credentials fail here.
+        user = client.current_user
+    except AgentCliError:
+        # No usable credentials for this profile yet — run the sign-in flow, then validate once.
+        _run_databricks_login(profile, host)
+        client = MasonClient(profile)
+        user = client.current_user
     _save_default_profile(profile)
     if obj.output == "json":
         render.emit_json({"profile": profile, "user": user, "host": client.host})

--- a/integrations/mason/tests/unit_tests/auth_test.py
+++ b/integrations/mason/tests/unit_tests/auth_test.py
@@ -12,6 +12,7 @@ from unittest import mock
 from click.testing import CliRunner
 
 from databricks_mason import auth
+from databricks_mason.errors import AgentCliError
 
 
 class _Ctx:
@@ -76,3 +77,42 @@ def test_logout_clears_saved_profile(tmp_path, monkeypatch):
     result = CliRunner().invoke(auth.logout, [], obj=_Ctx())
     assert result.exit_code == 0, result.output
     assert auth.load_default_profile() is None
+
+
+def test_login_runs_signin_when_profile_has_no_credentials(tmp_path, monkeypatch):
+    # A profile with no usable credentials: MasonClient fails until sign-in runs, then succeeds.
+    monkeypatch.setenv("MASON_CONFIG_HOME", str(tmp_path))
+    state = {"signins": 0}
+
+    class _FakeClient:
+        host = "https://ws"
+
+        def __init__(self, profile):
+            if state["signins"] == 0:
+                raise AgentCliError("Could not initialize Databricks auth: no credentials")
+
+        @property
+        def current_user(self):
+            return "me@example.com"
+
+    monkeypatch.setattr(auth, "MasonClient", _FakeClient)
+    monkeypatch.setattr(auth, "_run_databricks_login", lambda p, h: state.__setitem__("signins", 1))
+
+    result = CliRunner().invoke(
+        auth.login, ["--profile", "my-ws", "--host", "https://ws"], obj=_Ctx()
+    )
+    assert result.exit_code == 0, result.output
+    # Sign-in ran exactly once — no separate `databricks auth login` step is required.
+    assert state["signins"] == 1
+    assert auth.load_default_profile() == "my-ws"
+
+
+def test_login_skips_signin_when_already_authenticated(tmp_path, monkeypatch):
+    # A profile that already authenticates should not trigger a browser sign-in.
+    monkeypatch.setenv("MASON_CONFIG_HOME", str(tmp_path))
+    _stub_client(monkeypatch)
+    ran = {"signin": False}
+    monkeypatch.setattr(auth, "_run_databricks_login", lambda p, h: ran.__setitem__("signin", True))
+    result = CliRunner().invoke(auth.login, ["-p", "my-ws"], obj=_Ctx())
+    assert result.exit_code == 0, result.output
+    assert ran["signin"] is False


### PR DESCRIPTION
## What did you change, and why?

**Change:** `mason login` now authenticates a profile on its own. If the profile has no usable credentials yet, it runs the Databricks OAuth sign-in for you (by shelling `databricks auth login`, already a requirement for `dev`/`deploy`), then validates and remembers it. An already-authenticated profile is just validated — no browser opens. Adds `--host` for first-time profile creation.

**Why:** From the custom-agent bug bash, users had to run *two* commands — `databricks auth login` then `mason login` — and error messages that said "run `databricks auth login`" were confusing when the fix that worked was `mason login` (Ann's report). `mason login` is now the only auth command needed.

Behavior:
- Try existing credentials first (cheap, no browser); only sign in if that fails, then retry once.
- Credentials still live in `~/.databrickscfg` exactly as the Databricks CLI writes them; Mason only stores the *selected* profile name in `~/.mason/config.json`.
- README updated to the single-command flow.

Pairs with #522 (clearer auth error messages), whose hints all point at this single `mason login`.

## How do you know it works?

**Testing:** `python -m py_compile` on the changed modules (clean). Added unit tests in `auth_test.py`: `mason login` runs the sign-in exactly once when the profile has no credentials (and persists the selection), and skips the sign-in entirely when the profile already authenticates. Existing `auth_test.py` cases are unchanged. Full suite runs in CI. Draft until CI is green.