### PR TITLE
[mason] Chat app: keep tool-call messages on re-hydrate

### DIFF
--- a/integrations/mason/templates/ui/agent-langgraph/runtime/ui.py
+++ b/integrations/mason/templates/ui/agent-langgraph/runtime/ui.py
@@ -347,7 +347,9 @@ def _chat_session_items(result: dict[str, Any]) -> dict[str, Any]:
         if not isinstance(item, dict):
             continue
         data = item.get("data")
-        if not isinstance(data, dict) or data.get("event_type") or "content" not in data:
+        if not isinstance(data, dict) or data.get("event_type") or (
+            "content" not in data and not data.get("tool_calls")
+        ):
             continue
         role = str(data.get("role") or data.get("type") or "").lower()
         if role in _MESSAGE_ROLES:

--- a/integrations/mason/templates/ui/agent-langgraph/tests/test_demo_ui.py
+++ b/integrations/mason/templates/ui/agent-langgraph/tests/test_demo_ui.py
@@ -263,6 +263,25 @@ def test_chat_session_items_exclude_non_message_items():
     }
 
 
+def test_chat_session_items_keep_assistant_tool_call_without_content():
+    # An assistant tool-call turn carries tool_calls but no content. It must survive the
+    # session-items filter so the transcript keeps its "Tool request" bubble on re-hydrate.
+    result = ui._chat_session_items(
+        {
+            "session_items": [
+                {"item_id": "1", "data": {"role": "assistant", "tool_calls": [{"id": "t1"}]}},
+                {"item_id": "2", "data": {"role": "assistant"}},
+            ],
+        }
+    )
+
+    assert result == {
+        "session_items": [
+            {"item_id": "1", "data": {"role": "assistant", "tool_calls": [{"id": "t1"}]}},
+        ],
+    }
+
+
 def _endpoint(name, task="llm/v1/chat", ready="READY"):
     state = type("State", (), {"ready": type("Ready", (), {"value": ready})()})()
     return type("Endpoint", (), {"name": name, "task": task, "state": state})()

--- a/integrations/mason/templates/ui/agent-langgraph/ui/app.js
+++ b/integrations/mason/templates/ui/agent-langgraph/ui/app.js
@@ -460,17 +460,28 @@ function renderSessionTranscript(items) {
     const data = item?.data || {};
     const storedRole = String(data.role || data.type || "").toLowerCase();
     const content = extractText(data.content ?? data);
-    if (!content) continue;
+    const hasToolCalls = Array.isArray(data.tool_calls) && data.tool_calls.length > 0;
+    // Keep every message on re-hydrate: skip only genuinely empty items, and render an assistant
+    // tool-call as a "Tool request" bubble even when its text is empty (mirrors the streaming path),
+    // so no re-hydrate path (reload, open-session, Refresh) silently drops messages.
+    if (!content && !hasToolCalls) continue;
     if (storedRole === "human_decision") {
       appendMessage("system", content, "Human decision");
       continue;
     }
     const role = normalizeRole(data);
-    if (role === "assistant") state.lastAssistantText = content;
+    if (role === "assistant") {
+      if (content) {
+        state.lastAssistantText = content;
+        appendMessage("assistant", content, "Agent");
+      }
+      if (hasToolCalls) appendMessage("tool", toolSummary(data), "Tool request");
+      continue;
+    }
     appendMessage(
       role,
       role === "tool" ? toolSummary(data) : content,
-      role === "user" ? "You" : role === "assistant" ? "Agent" : role === "tool" ? "Tool result" : "System",
+      role === "user" ? "You" : role === "tool" ? "Tool result" : "System",
     );
   }
 }

--- a/integrations/mason/templates/ui/agent-openai/runtime/ui.py
+++ b/integrations/mason/templates/ui/agent-openai/runtime/ui.py
@@ -341,7 +341,9 @@ def _chat_session_items(result: dict[str, Any]) -> dict[str, Any]:
         if not isinstance(item, dict):
             continue
         data = item.get("data")
-        if not isinstance(data, dict) or data.get("event_type") or "content" not in data:
+        if not isinstance(data, dict) or data.get("event_type") or (
+            "content" not in data and not data.get("tool_calls")
+        ):
             continue
         role = str(data.get("role") or data.get("type") or "").lower()
         if role in _MESSAGE_ROLES:

--- a/integrations/mason/templates/ui/agent-openai/tests/test_demo_ui.py
+++ b/integrations/mason/templates/ui/agent-openai/tests/test_demo_ui.py
@@ -258,6 +258,25 @@ def test_chat_session_items_exclude_non_message_items():
     }
 
 
+def test_chat_session_items_keep_assistant_tool_call_without_content():
+    # An assistant tool-call turn carries tool_calls but no content. It must survive the
+    # session-items filter so the transcript keeps its "Tool request" bubble on re-hydrate.
+    result = ui._chat_session_items(
+        {
+            "session_items": [
+                {"item_id": "1", "data": {"role": "assistant", "tool_calls": [{"id": "t1"}]}},
+                {"item_id": "2", "data": {"role": "assistant"}},
+            ],
+        }
+    )
+
+    assert result == {
+        "session_items": [
+            {"item_id": "1", "data": {"role": "assistant", "tool_calls": [{"id": "t1"}]}},
+        ],
+    }
+
+
 def _endpoint(name, task="llm/v1/chat", ready="READY"):
     state = type("State", (), {"ready": type("Ready", (), {"value": ready})()})()
     return type("Endpoint", (), {"name": name, "task": task, "state": state})()

--- a/integrations/mason/templates/ui/agent-openai/ui/app.js
+++ b/integrations/mason/templates/ui/agent-openai/ui/app.js
@@ -460,17 +460,28 @@ function renderSessionTranscript(items) {
     const data = item?.data || {};
     const storedRole = String(data.role || data.type || "").toLowerCase();
     const content = extractText(data.content ?? data);
-    if (!content) continue;
+    const hasToolCalls = Array.isArray(data.tool_calls) && data.tool_calls.length > 0;
+    // Keep every message on re-hydrate: skip only genuinely empty items, and render an assistant
+    // tool-call as a "Tool request" bubble even when its text is empty (mirrors the streaming path),
+    // so no re-hydrate path (reload, open-session, Refresh) silently drops messages.
+    if (!content && !hasToolCalls) continue;
     if (storedRole === "human_decision") {
       appendMessage("system", content, "Human decision");
       continue;
     }
     const role = normalizeRole(data);
-    if (role === "assistant") state.lastAssistantText = content;
+    if (role === "assistant") {
+      if (content) {
+        state.lastAssistantText = content;
+        appendMessage("assistant", content, "Agent");
+      }
+      if (hasToolCalls) appendMessage("tool", toolSummary(data), "Tool request");
+      continue;
+    }
     appendMessage(
       role,
       role === "tool" ? toolSummary(data) : content,
-      role === "user" ? "You" : role === "assistant" ? "Agent" : role === "tool" ? "Tool result" : "System",
+      role === "user" ? "You" : role === "tool" ? "Tool result" : "System",
     );
   }
 }


### PR DESCRIPTION
## What

The chat-app transcript is rebuilt from the persisted Session-Store transcript on every re-hydrate — page reload, opening a saved session, and the **Capabilities ↻** refresh. `renderSessionTranscript` dropped any session item without text content, so assistant **tool-call** turns (which carry `tool_calls` but no text) silently disappeared. The most visible symptom was the one this PR originally targeted: clicking Capabilities ↻ mid-conversation made tool-call bubbles vanish.

The original version of this PR avoided that one symptom by not re-hydrating on the Capabilities refresh. Since then the chat UI was refactored on `main` (the `hydrateChat` split, model picker, decluttering), and the better fix is to make re-hydrate itself lossless — so reload and open-session keep tool calls too.

## Fix

- `runtime/ui.py` (`_chat_session_items`): keep session items that carry `tool_calls` even when they have no `content`.
- `ui/app.js` (`renderSessionTranscript`): render an assistant tool-call as a "Tool request" bubble (mirroring the streaming path), and skip only genuinely empty items.

Applied to both chat-app templates (`agent-langgraph`, `agent-openai`), with a unit test for the kept-tool-call case.

## Testing

- `node --check` on both `app.js`.
- Exercised `_chat_session_items` for both templates: a tool-call-without-content item is kept, a genuinely empty item is dropped, and the existing exclusion test still holds.

This pull request and its description were written by Isaac.
