### PR TITLE
[mason] add documentation to enable shell completion

### DIFF
--- a/integrations/mason/README.md
+++ b/integrations/mason/README.md
@@ -26,6 +26,12 @@ For tracing commands, install Mason with tracing extras:
 pip install 'databricks-mason[tracing]'
 ```
 
+## Shell completion
+Add this to `~/.zshrc`:
+```sh
+eval "$(_MASON_COMPLETE=zsh_source mason)"
+```
+
 ## Authentication
 
 Mason uses [Databricks authentication](https://docs.databricks.com/aws/en/dev-tools/cli/authentication).

--- a/integrations/mason/src/databricks_mason/deploy.py
+++ b/integrations/mason/src/databricks_mason/deploy.py
@@ -354,9 +354,7 @@ def _grant_store_access(
     "--pip-index-url",
     default=_DEFAULT_PIP_INDEX_URL,
     show_default=True,
-    help="Package index the Apps build installs from. Defaults to public PyPI as a temporary "
-    "workaround: the Apps build environment currently can't reach the internal proxy. Pass an "
-    "empty string to use the build's default index.",
+    help="Base URL of the Python Package Index. Defaults to public PyPI.",
 )
 @click.option(
     "--workspace-path",


### PR DESCRIPTION
* Added documentation to enable zsh auto completion per Click [documentation](https://click.palletsprojects.com/en/stable/shell-completion/)

<img width="623" height="117" alt="image" src="https://github.com/user-attachments/assets/2a89a37f-5cfc-4d96-94e7-a336fcf0b53a" />

* Updated help message for `mason deploy --pip-index-url` by removing references to _Apps build environment currently can't reach the internal proxy_

<img width="739" height="452" alt="image" src="https://github.com/user-attachments/assets/5570e57a-7ae1-424c-a6cf-591d5ed94693" />
