### PR TITLE
[mason] Point session-store create at `mason deploy --with-session-store`

### DIFF
--- a/integrations/mason/src/databricks_mason/sessions.py
+++ b/integrations/mason/src/databricks_mason/sessions.py
@@ -79,6 +79,7 @@ def stores_create(obj, name, description, metadata) -> None:
         next_steps=[
             f"mason sessions create --store {name} --actor-id <id>",
             f"mason sessions stores get {name}",
+            f"mason deploy <agent> --source <path> --with-session-store {name}",
         ],
     )
 


### PR DESCRIPTION
The `mason sessions stores create` next-steps only showed how to create a session or inspect the store, never how to attach the store to an agent. Add the `mason deploy --with-session-store` step so the primary "use it" path is surfaced.