### PR TITLE
[mason] Retry transient API errors and stop rendering `None` on message-less failures

### DIFF
--- a/integrations/mason/src/databricks_mason/client.py
+++ b/integrations/mason/src/databricks_mason/client.py
@@ -25,10 +25,9 @@ from databricks_mason.errors import TRANSIENT_ERROR_CODES, AgentCliError, wrap_a
 _BASE = "/api/agents/v1"
 _MCP_SERVICES_PATH = "/api/2.1/unity-catalog/mcp-services"
 
-# Transient backend failures (e.g. a CANCELLED RPC) usually clear on a retry, so retry once
-# before surfacing them. The SDK only retries on connection/timeout errors, not on these
-# error-code responses. Creates are safe to retry: a duplicate surfaces ALREADY_EXISTS, which
-# the ensure-store callers already treat as success.
+# Transient backend failures (e.g. a CANCELLED RPC) usually clear on a retry, so retry safe
+# requests once before surfacing them. Mutating requests must opt in explicitly: their first
+# attempt may have committed even when its response was lost.
 _MAX_ATTEMPTS = 2
 _RETRY_BASE_DELAY_S = 0.2
 
@@ -148,14 +147,23 @@ class MasonClient:
         self._w.workspace.mkdirs(path)
 
     def _do(
-        self, method: str, path: str, *, query: Optional[dict] = None, body: Optional[dict] = None
+        self,
+        method: str,
+        path: str,
+        *,
+        query: Optional[dict] = None,
+        body: Optional[dict] = None,
+        safe_to_retry: bool = False,
     ) -> Any:
+        retry_allowed = method == "GET" or safe_to_retry
         delay = _RETRY_BASE_DELAY_S
         for attempt in range(1, _MAX_ATTEMPTS + 1):
             try:
                 return self._w.api_client.do(method, path, query=query, body=body)
             except Exception as exc:  # noqa: BLE001 - normalized to AgentCliError
-                retryable = getattr(exc, "error_code", None) in TRANSIENT_ERROR_CODES
+                retryable = (
+                    retry_allowed and getattr(exc, "error_code", None) in TRANSIENT_ERROR_CODES
+                )
                 if not retryable or attempt == _MAX_ATTEMPTS:
                     raise wrap_api_error(exc) from exc
                 time.sleep(delay)
@@ -179,7 +187,10 @@ class MasonClient:
         self, display_name: str, description: Optional[str] = None
     ) -> models.MemoryStore:
         body = _query(display_name=display_name, description=description)
-        return _as(models.MemoryStore, self._do("POST", f"{_BASE}/memory-stores", body=body))
+        return _as(
+            models.MemoryStore,
+            self._do("POST", f"{_BASE}/memory-stores", body=body, safe_to_retry=True),
+        )
 
     def get_memory_store(self, name: str) -> models.MemoryStore:
         return _as(models.MemoryStore, self._do("GET", f"{_BASE}/{memory_store_path(name)}"))
@@ -276,7 +287,12 @@ class MasonClient:
         body = _query(actor_id=actor_id, query=query, limit=limit)
         return _as(
             models.MemorySearchResult,
-            self._do("POST", f"{_BASE}/{memory_store_path(store)}/entries:search", body=body),
+            self._do(
+                "POST",
+                f"{_BASE}/{memory_store_path(store)}/entries:search",
+                body=body,
+                safe_to_retry=True,
+            ),
         )
 
     def update_memory_entry(
@@ -306,7 +322,11 @@ class MasonClient:
         return _as(
             models.SessionStore,
             self._do(
-                "POST", f"{_BASE}/session-stores", query={"session_store_name": name}, body=body
+                "POST",
+                f"{_BASE}/session-stores",
+                query={"session_store_name": name},
+                body=body,
+                safe_to_retry=True,
             ),
         )
 

--- a/integrations/mason/src/databricks_mason/client.py
+++ b/integrations/mason/src/databricks_mason/client.py
@@ -14,15 +14,23 @@ from __future__ import annotations
 import configparser
 import os
 import pathlib
+import time
 from typing import Any, Optional
 
 from databricks.sdk import WorkspaceClient
 
 from databricks_mason import models
-from databricks_mason.errors import AgentCliError, wrap_api_error
+from databricks_mason.errors import TRANSIENT_ERROR_CODES, AgentCliError, wrap_api_error
 
 _BASE = "/api/agents/v1"
 _MCP_SERVICES_PATH = "/api/2.1/unity-catalog/mcp-services"
+
+# Transient backend failures (e.g. a CANCELLED RPC) usually clear on a retry, so absorb a
+# few before surfacing them. The SDK only retries on connection/timeout errors, not on these
+# error-code responses. Creates are safe to retry: a duplicate surfaces ALREADY_EXISTS, which
+# the ensure-store callers already treat as success.
+_MAX_ATTEMPTS = 3
+_RETRY_BASE_DELAY_S = 0.5
 
 
 def _query(**kwargs: Any) -> dict[str, Any]:
@@ -142,10 +150,16 @@ class MasonClient:
     def _do(
         self, method: str, path: str, *, query: Optional[dict] = None, body: Optional[dict] = None
     ) -> Any:
-        try:
-            return self._w.api_client.do(method, path, query=query, body=body)
-        except Exception as exc:  # noqa: BLE001 - normalized to AgentCliError
-            raise wrap_api_error(exc) from exc
+        delay = _RETRY_BASE_DELAY_S
+        for attempt in range(1, _MAX_ATTEMPTS + 1):
+            try:
+                return self._w.api_client.do(method, path, query=query, body=body)
+            except Exception as exc:  # noqa: BLE001 - normalized to AgentCliError
+                retryable = getattr(exc, "error_code", None) in TRANSIENT_ERROR_CODES
+                if not retryable or attempt == _MAX_ATTEMPTS:
+                    raise wrap_api_error(exc) from exc
+                time.sleep(delay)
+                delay *= 2
 
     # --- Unity Catalog MCP Services -----------------------------------------
 

--- a/integrations/mason/src/databricks_mason/client.py
+++ b/integrations/mason/src/databricks_mason/client.py
@@ -25,12 +25,12 @@ from databricks_mason.errors import TRANSIENT_ERROR_CODES, AgentCliError, wrap_a
 _BASE = "/api/agents/v1"
 _MCP_SERVICES_PATH = "/api/2.1/unity-catalog/mcp-services"
 
-# Transient backend failures (e.g. a CANCELLED RPC) usually clear on a retry, so absorb a
-# few before surfacing them. The SDK only retries on connection/timeout errors, not on these
+# Transient backend failures (e.g. a CANCELLED RPC) usually clear on a retry, so retry once
+# before surfacing them. The SDK only retries on connection/timeout errors, not on these
 # error-code responses. Creates are safe to retry: a duplicate surfaces ALREADY_EXISTS, which
 # the ensure-store callers already treat as success.
-_MAX_ATTEMPTS = 3
-_RETRY_BASE_DELAY_S = 0.5
+_MAX_ATTEMPTS = 2
+_RETRY_BASE_DELAY_S = 0.2
 
 
 def _query(**kwargs: Any) -> dict[str, Any]:

--- a/integrations/mason/src/databricks_mason/client.py
+++ b/integrations/mason/src/databricks_mason/client.py
@@ -184,12 +184,21 @@ class MasonClient:
     # --- memory stores -------------------------------------------------------
 
     def create_memory_store(
-        self, display_name: str, description: Optional[str] = None
+        self,
+        display_name: str,
+        description: Optional[str] = None,
+        *,
+        retry_transient: bool = False,
     ) -> models.MemoryStore:
         body = _query(display_name=display_name, description=description)
         return _as(
             models.MemoryStore,
-            self._do("POST", f"{_BASE}/memory-stores", body=body, safe_to_retry=True),
+            self._do(
+                "POST",
+                f"{_BASE}/memory-stores",
+                body=body,
+                safe_to_retry=retry_transient,
+            ),
         )
 
     def get_memory_store(self, name: str) -> models.MemoryStore:
@@ -316,7 +325,12 @@ class MasonClient:
     # --- session stores ------------------------------------------------------
 
     def create_session_store(
-        self, name: str, description: Optional[str] = None, metadata: Optional[dict] = None
+        self,
+        name: str,
+        description: Optional[str] = None,
+        metadata: Optional[dict] = None,
+        *,
+        retry_transient: bool = False,
     ) -> models.SessionStore:
         body = _query(description=description, metadata=metadata)
         return _as(
@@ -326,7 +340,7 @@ class MasonClient:
                 f"{_BASE}/session-stores",
                 query={"session_store_name": name},
                 body=body,
-                safe_to_retry=True,
+                safe_to_retry=retry_transient,
             ),
         )
 

--- a/integrations/mason/src/databricks_mason/deploy.py
+++ b/integrations/mason/src/databricks_mason/deploy.py
@@ -192,7 +192,7 @@ def _resolve_memory_store(client, display_name: str) -> Optional[dict]:
 
 def _ensure_memory_store(client, display_name: str) -> dict:
     try:
-        return client.create_memory_store(display_name)
+        return client.create_memory_store(display_name, retry_transient=True)
     except AgentCliError as exc:
         if exc.error_code != "ALREADY_EXISTS":
             raise
@@ -204,7 +204,7 @@ def _ensure_memory_store(client, display_name: str) -> dict:
 
 def _ensure_session_store(client, name: str) -> dict:
     try:
-        return client.create_session_store(name)
+        return client.create_session_store(name, retry_transient=True)
     except AgentCliError as exc:
         if exc.error_code != "ALREADY_EXISTS":
             raise

--- a/integrations/mason/src/databricks_mason/errors.py
+++ b/integrations/mason/src/databricks_mason/errors.py
@@ -16,6 +16,12 @@ from rich.text import Text
 # Error codes indicating that a preview API is unavailable in the workspace.
 _PREVIEW_ERROR_CODES = frozenset({"NOT_IMPLEMENTED", "UNIMPLEMENTED", "FEATURE_DISABLED"})
 
+# gRPC-style status codes the backend returns for transient failures (a cancelled or
+# deadline-exceeded RPC, a briefly unavailable service). Shared with the client, which
+# retries these before surfacing them. `client._do` retries; the hint here covers the
+# case where retries are still exhausted.
+TRANSIENT_ERROR_CODES = frozenset({"CANCELLED", "UNAVAILABLE", "DEADLINE_EXCEEDED", "ABORTED"})
+
 # Process-global output mode, set once by the root CLI group. When "json", errors are
 # emitted as a machine-readable JSON object instead of the styled text one-liner, so a
 # script driving `mason -o json` can parse failures instead of scraping human text.
@@ -32,6 +38,10 @@ _PREVIEW_HINT = (
     "These agents/v1 APIs are in preview and gated per workspace. This handler is "
     "not enabled on the target workspace yet — try a different --profile or contact "
     "your workspace administrator."
+)
+
+_TRANSIENT_HINT = (
+    "This is usually a transient backend issue — re-running the command often succeeds."
 )
 
 
@@ -69,6 +79,24 @@ def wrap_api_error(exc: Exception) -> AgentCliError:
     hierarchy or version.
     """
     error_code = getattr(exc, "error_code", None)
-    message = str(exc).strip() or exc.__class__.__name__
-    hint = _PREVIEW_HINT if error_code in _PREVIEW_ERROR_CODES else None
+    # A message-less DatabricksError wraps `IOError(None)`, so `str(exc)` is the literal
+    # "None". Treat that (and an empty string) as "no detail" so we surface the error code
+    # instead of a bare `Error [CANCELLED]: None`.
+    detail = str(exc).strip()
+    if detail == "None":
+        detail = ""
+    message = detail or _no_detail_message(error_code) or exc.__class__.__name__
+    if error_code in _PREVIEW_ERROR_CODES:
+        hint = _PREVIEW_HINT
+    elif error_code in TRANSIENT_ERROR_CODES:
+        hint = _TRANSIENT_HINT
+    else:
+        hint = None
     return AgentCliError(message, error_code=error_code, hint=hint)
+
+
+def _no_detail_message(error_code: Optional[str]) -> Optional[str]:
+    """Fallback message when the server returns an error code but no human-readable detail."""
+    if not error_code:
+        return None
+    return f"The server returned {error_code} with no further detail."

--- a/integrations/mason/tests/unit_tests/client_test.py
+++ b/integrations/mason/tests/unit_tests/client_test.py
@@ -200,6 +200,19 @@ def test_do_does_not_retry_non_transient_error(workspace_client, sleep):
     sleep.assert_not_called()
 
 
+@mock.patch("databricks_mason.client.time.sleep")
+@mock.patch("databricks_mason.client.WorkspaceClient")
+def test_do_does_not_retry_transient_error_for_pop(workspace_client, sleep):
+    c, do = _client(workspace_client)
+    do.side_effect = _TransientError(None)
+
+    with pytest.raises(AgentCliError):
+        c.pop_session_item("store1", "sid")
+
+    assert do.call_count == 1
+    sleep.assert_not_called()
+
+
 def test_account_routed_profile_uses_configured_host_and_workspace_header():
     resolved = mock.Mock()
     resolved.config.host = "https://workspace.example.com"

--- a/integrations/mason/tests/unit_tests/client_test.py
+++ b/integrations/mason/tests/unit_tests/client_test.py
@@ -178,7 +178,7 @@ def test_do_stops_after_max_attempts(workspace_client, sleep):
     with pytest.raises(AgentCliError) as excinfo:
         c.list_memory_stores()
 
-    assert do.call_count == 3
+    assert do.call_count == 2
     assert excinfo.value.error_code == "CANCELLED"
     assert "None" not in excinfo.value.message
 

--- a/integrations/mason/tests/unit_tests/client_test.py
+++ b/integrations/mason/tests/unit_tests/client_test.py
@@ -151,6 +151,55 @@ def test_auth_error_hint_explains_profile_selection_and_login(_workspace_client)
     assert "`databricks auth login --profile <name>`" not in hint
 
 
+class _TransientError(RuntimeError):
+    error_code = "CANCELLED"
+
+
+@mock.patch("databricks_mason.client.time.sleep")
+@mock.patch("databricks_mason.client.WorkspaceClient")
+def test_do_retries_transient_error_then_succeeds(workspace_client, sleep):
+    c, do = _client(workspace_client)
+    # First attempt is a transient CANCELLED (str() == "None"), second succeeds.
+    do.side_effect = [_TransientError(None), {"session_store_name": "s"}]
+
+    store = c.create_session_store("s")
+
+    assert store["session_store_name"] == "s"
+    assert do.call_count == 2
+    sleep.assert_called_once()
+
+
+@mock.patch("databricks_mason.client.time.sleep")
+@mock.patch("databricks_mason.client.WorkspaceClient")
+def test_do_stops_after_max_attempts(workspace_client, sleep):
+    c, do = _client(workspace_client)
+    do.side_effect = _TransientError(None)
+
+    with pytest.raises(AgentCliError) as excinfo:
+        c.list_memory_stores()
+
+    assert do.call_count == 3
+    assert excinfo.value.error_code == "CANCELLED"
+    assert "None" not in excinfo.value.message
+
+
+@mock.patch("databricks_mason.client.time.sleep")
+@mock.patch("databricks_mason.client.WorkspaceClient")
+def test_do_does_not_retry_non_transient_error(workspace_client, sleep):
+    c, do = _client(workspace_client)
+
+    class NotFoundError(RuntimeError):
+        error_code = "NOT_FOUND"
+
+    do.side_effect = NotFoundError("missing")
+
+    with pytest.raises(AgentCliError):
+        c.list_memory_stores()
+
+    assert do.call_count == 1
+    sleep.assert_not_called()
+
+
 def test_account_routed_profile_uses_configured_host_and_workspace_header():
     resolved = mock.Mock()
     resolved.config.host = "https://workspace.example.com"

--- a/integrations/mason/tests/unit_tests/client_test.py
+++ b/integrations/mason/tests/unit_tests/client_test.py
@@ -162,11 +162,33 @@ def test_do_retries_transient_error_then_succeeds(workspace_client, sleep):
     # First attempt is a transient CANCELLED (str() == "None"), second succeeds.
     do.side_effect = [_TransientError(None), {"session_store_name": "s"}]
 
-    store = c.create_session_store("s")
+    store = c.create_session_store("s", retry_transient=True)
 
     assert store["session_store_name"] == "s"
     assert do.call_count == 2
     sleep.assert_called_once()
+
+
+@mock.patch("databricks_mason.client.time.sleep")
+@mock.patch("databricks_mason.client.WorkspaceClient")
+@pytest.mark.parametrize(
+    ("method_name", "args"),
+    [
+        ("create_memory_store", ("m",)),
+        ("create_session_store", ("s",)),
+    ],
+)
+def test_create_store_does_not_retry_transient_error_by_default(
+    workspace_client, sleep, method_name, args
+):
+    c, do = _client(workspace_client)
+    do.side_effect = _TransientError(None)
+
+    with pytest.raises(AgentCliError):
+        getattr(c, method_name)(*args)
+
+    assert do.call_count == 1
+    sleep.assert_not_called()
 
 
 @mock.patch("databricks_mason.client.time.sleep")

--- a/integrations/mason/tests/unit_tests/deploy_test.py
+++ b/integrations/mason/tests/unit_tests/deploy_test.py
@@ -48,6 +48,21 @@ def test_ensure_session_store_reuses_on_already_exists():
     client.create_session_store.side_effect = AgentCliError("exists", error_code="ALREADY_EXISTS")
     client.get_session_store.return_value = {"session_store_name": "s"}
     assert deploy_mod._ensure_session_store(client, "s") == {"session_store_name": "s"}
+    client.create_session_store.assert_called_once_with("s", retry_transient=True)
+
+
+def test_ensure_memory_store_reuses_on_already_exists():
+    client = mock.Mock()
+    client.create_memory_store.side_effect = AgentCliError("exists", error_code="ALREADY_EXISTS")
+    client.list_memory_stores.return_value = {
+        "managed_memory_stores": [{"name": "memory-stores/mem-id-123", "display_name": "mem"}]
+    }
+
+    assert deploy_mod._ensure_memory_store(client, "mem") == {
+        "name": "memory-stores/mem-id-123",
+        "display_name": "mem",
+    }
+    client.create_memory_store.assert_called_once_with("mem", retry_transient=True)
 
 
 class _FakeClient:
@@ -65,14 +80,14 @@ class _FakeClient:
             "next_page_token": "",
         }
 
-    def create_memory_store(self, display_name):
+    def create_memory_store(self, display_name, *, retry_transient=False):
         # Create-if-not-exists is the deploy default; return the same id resolution would find.
         return {"name": "memory-stores/mem-id-123", "display_name": display_name}
 
     def get_session_store(self, name):
         return {"session_store_name": name}
 
-    def create_session_store(self, name):
+    def create_session_store(self, name, *, retry_transient=False):
         return {"session_store_name": name}
 
 
@@ -383,7 +398,7 @@ def test_deploy_creates_missing_stores_by_default(tmp_path: pathlib.Path, monkey
     )
 
     class _CreatingClient(_FakeClient):
-        def create_memory_store(self, display_name):
+        def create_memory_store(self, display_name, *, retry_transient=False):
             created.append(display_name)
             return {"name": "memory-stores/mem-id-123", "display_name": display_name}
 

--- a/integrations/mason/tests/unit_tests/errors_test.py
+++ b/integrations/mason/tests/unit_tests/errors_test.py
@@ -7,7 +7,7 @@ import json
 import pytest
 
 from databricks_mason import errors
-from databricks_mason.errors import AgentCliError
+from databricks_mason.errors import AgentCliError, wrap_api_error
 
 
 @pytest.fixture(autouse=True)
@@ -43,3 +43,33 @@ def test_error_renders_text_in_text_mode(capsys):
     # Not JSON in text mode.
     with pytest.raises(json.JSONDecodeError):
         json.loads(err)
+
+
+class _NoDetailError(RuntimeError):
+    """Mimics a databricks-sdk error with a code but no message (str() == 'None')."""
+
+    error_code = "CANCELLED"
+
+
+def test_message_less_error_surfaces_code_not_none():
+    # The SDK stringifies a message-less DatabricksError as the literal "None"; the wrapped
+    # error must surface the code instead of a bare `None`.
+    mapped = wrap_api_error(_NoDetailError(None))
+    assert mapped.error_code == "CANCELLED"
+    assert "None" not in mapped.message
+    assert "CANCELLED" in mapped.message
+
+
+def test_transient_error_gets_retry_hint():
+    mapped = wrap_api_error(_NoDetailError(None))
+    assert mapped.hint is not None
+    assert "transient" in mapped.hint.lower()
+
+
+def test_non_transient_error_keeps_original_message():
+    class NotFoundError(RuntimeError):
+        error_code = "NOT_FOUND"
+
+    mapped = wrap_api_error(NotFoundError("store not found"))
+    assert mapped.message == "store not found"
+    assert mapped.hint is None


### PR DESCRIPTION
`mason dev -s <store>` (and other agents/v1 commands) could fail with an unhelpful `Error [CANCELLED]: None` that only succeeded on a second try. Two independent causes:

- The backend returned a transient `CANCELLED` with no message. The databricks SDK stringifies a message-less error as the literal `"None"`, and our fallback treated that non-empty string as a real message and printed it verbatim.
- Nothing retried the transient failure — the SDK only retries connection/timeout errors, not these error-code responses.

This PR:
- Retries transient gRPC-style codes (`CANCELLED`, `UNAVAILABLE`, `DEADLINE_EXCEEDED`, `ABORTED`) once for requests that are safe to replay: reads, read-only search, and exclusive store creation. Stateful operations such as session-item append and pop are never retried because the first attempt may have committed even when its response was lost. Duplicate store creation surfaces `ALREADY_EXISTS`, which the ensure-store callers already reconcile as success.
- Stops printing the literal `None`: falls back to the error code and adds a "usually transient — re-run" hint for these codes.

Found during the Custom Agents bug bash.

This pull request and its description were written by Isaac.
