### PR TITLE
mason: explain runtime capability status on hover in the chat-app templates

### DIFF
--- a/integrations/mason/templates/ui/agent-langgraph/ui/app.js
+++ b/integrations/mason/templates/ui/agent-langgraph/ui/app.js
@@ -784,7 +784,7 @@ async function loadConfig() {
       config.session.managed
         ? `Connected to Session Store "${config.session.store}" for actor ${config.session.actor}. State is durable and shareable.`
         : "Session state is kept in process and resets when the app restarts.",
-      config.session.managed ? null : "mason deploy --session <name>",
+      config.session.managed ? null : "mason deploy <deployment-name> --session <store-name>",
     );
     setCapability(
       elements.memoryStatus,
@@ -792,7 +792,7 @@ async function loadConfig() {
       config.memory.enabled
         ? `Connected to ${config.memory.store} for actor ${config.memory.actor}.`
         : "No long-term memory is connected.",
-      config.memory.enabled ? null : "mason deploy --memory <name>",
+      config.memory.enabled ? null : "mason deploy <deployment-name> --memory <store-name>",
     );
     elements.refreshMemory.disabled = state.busy || !config.memory.enabled;
     elements.newSession.disabled = state.busy;

--- a/integrations/mason/templates/ui/agent-langgraph/ui/app.js
+++ b/integrations/mason/templates/ui/agent-langgraph/ui/app.js
@@ -97,10 +97,21 @@ function setCapability(element, state, detail) {
   element.classList.toggle("disabled", key === "disabled");
   const title = detail ? `${CAPABILITY_SUMMARY[key]} — ${detail}` : CAPABILITY_SUMMARY[key];
   element.setAttribute("role", "img");
-  element.setAttribute("aria-label", `Status: ${title}`);
-  // Tooltip on the whole row gives a larger, more discoverable hover target than the orb.
+  element.setAttribute("aria-label", `Status: ${CAPABILITY_SUMMARY[key]}`);
   const row = element.closest(".capability-row");
-  if (row) row.title = title;
+  if (!row) return;
+
+  let tooltip = row.querySelector(".capability-tooltip");
+  if (!tooltip) {
+    tooltip = document.createElement("span");
+    tooltip.id = `${element.id}-tooltip`;
+    tooltip.className = "capability-tooltip";
+    tooltip.setAttribute("role", "tooltip");
+    row.append(tooltip);
+    row.tabIndex = 0;
+    row.setAttribute("aria-describedby", tooltip.id);
+  }
+  tooltip.textContent = title;
 }
 
 function formatJson(value) {

--- a/integrations/mason/templates/ui/agent-langgraph/ui/app.js
+++ b/integrations/mason/templates/ui/agent-langgraph/ui/app.js
@@ -90,12 +90,11 @@ function setBusy(busy, label = "Working") {
 // green/amber/red states are self-explanatory.
 const CAPABILITY_SUMMARY = { enabled: "Available", degraded: "Limited", disabled: "Unavailable" };
 
-function setCapability(element, state, detail) {
+function setCapability(element, state, detail, command) {
   const key = state === true ? "enabled" : state === "degraded" ? "degraded" : "disabled";
   element.classList.toggle("enabled", key === "enabled");
   element.classList.toggle("degraded", key === "degraded");
   element.classList.toggle("disabled", key === "disabled");
-  const title = detail ? `${CAPABILITY_SUMMARY[key]} — ${detail}` : CAPABILITY_SUMMARY[key];
   element.setAttribute("role", "img");
   element.setAttribute("aria-label", `Status: ${CAPABILITY_SUMMARY[key]}`);
   const row = element.closest(".capability-row");
@@ -111,7 +110,29 @@ function setCapability(element, state, detail) {
     row.tabIndex = 0;
     row.setAttribute("aria-describedby", tooltip.id);
   }
-  tooltip.textContent = title;
+  tooltip.dataset.state = key;
+  tooltip.replaceChildren();
+
+  const summary = document.createElement("strong");
+  summary.className = "capability-tooltip-status";
+  summary.textContent = CAPABILITY_SUMMARY[key];
+  tooltip.append(summary);
+
+  if (detail) {
+    const description = document.createElement("span");
+    description.className = "capability-tooltip-detail";
+    description.textContent = detail;
+    tooltip.append(description);
+  }
+  if (command) {
+    const guidance = document.createElement("span");
+    guidance.className = "capability-tooltip-guidance";
+    guidance.textContent = "Connect by redeploying:";
+    const commandText = document.createElement("code");
+    commandText.className = "capability-tooltip-command";
+    commandText.textContent = command;
+    tooltip.append(guidance, commandText);
+  }
 }
 
 function formatJson(value) {
@@ -754,22 +775,24 @@ async function loadConfig() {
       elements.backgroundStatus,
       config.background.enabled,
       config.background.enabled
-        ? `Background invocations enabled — ${config.background.durable ? "durable" : "in-process"} run store.`
+        ? `Background invocations use a ${config.background.durable ? "durable" : "in-process"} run store.`
         : "Background invocations are disabled.",
     );
     setCapability(
       elements.sessionStatus,
       config.session.managed ? true : config.session.history ? "degraded" : false,
       config.session.managed
-        ? `Connected to Session Store "${config.session.store}" (actor ${config.session.actor}) — durable, shareable session state.`
-        : "Not connected — session state is kept in-process and resets on restart. Connect a Session Store by redeploying with:\nmason deploy --session <name>",
+        ? `Connected to Session Store "${config.session.store}" for actor ${config.session.actor}. State is durable and shareable.`
+        : "Session state is kept in process and resets when the app restarts.",
+      config.session.managed ? null : "mason deploy --session <name>",
     );
     setCapability(
       elements.memoryStatus,
       config.memory.enabled,
       config.memory.enabled
-        ? `Connected to ${config.memory.store} (actor ${config.memory.actor}).`
-        : "Not connected — no long-term memory. Connect a Memory Store by redeploying with:\nmason deploy --memory <name>",
+        ? `Connected to ${config.memory.store} for actor ${config.memory.actor}.`
+        : "No long-term memory is connected.",
+      config.memory.enabled ? null : "mason deploy --memory <name>",
     );
     elements.refreshMemory.disabled = state.busy || !config.memory.enabled;
     elements.newSession.disabled = state.busy;

--- a/integrations/mason/templates/ui/agent-langgraph/ui/app.js
+++ b/integrations/mason/templates/ui/agent-langgraph/ui/app.js
@@ -86,11 +86,21 @@ function setBusy(busy, label = "Working") {
   else if (!elements.runStatus.classList.contains("error")) setStatus("Ready");
 }
 
-function setCapability(element, state) {
-  const degraded = state === "degraded";
-  element.classList.toggle("enabled", state === true);
-  element.classList.toggle("degraded", degraded);
-  element.classList.toggle("disabled", !state);
+// Human-readable name for each orb color, surfaced as a hover tooltip so the
+// green/amber/red states are self-explanatory.
+const CAPABILITY_SUMMARY = { enabled: "Available", degraded: "Limited", disabled: "Unavailable" };
+
+function setCapability(element, state, detail) {
+  const key = state === true ? "enabled" : state === "degraded" ? "degraded" : "disabled";
+  element.classList.toggle("enabled", key === "enabled");
+  element.classList.toggle("degraded", key === "degraded");
+  element.classList.toggle("disabled", key === "disabled");
+  const title = detail ? `${CAPABILITY_SUMMARY[key]} — ${detail}` : CAPABILITY_SUMMARY[key];
+  element.setAttribute("role", "img");
+  element.setAttribute("aria-label", `Status: ${title}`);
+  // Tooltip on the whole row gives a larger, more discoverable hover target than the orb.
+  const row = element.closest(".capability-row");
+  if (row) row.title = title;
 }
 
 function formatJson(value) {
@@ -722,13 +732,34 @@ async function loadConfig() {
     elements.backgroundMode.textContent = config.background.durable ? "Durable run store" : "In-process run store";
     elements.sessionMode.textContent = config.session.mode;
     elements.memoryMode.textContent = config.memory.enabled ? `Managed · actor ${config.memory.actor}` : "Not connected";
-    setCapability(elements.streamingStatus, config.streaming.enabled);
-    setCapability(elements.backgroundStatus, config.background.enabled);
+    setCapability(
+      elements.streamingStatus,
+      config.streaming.enabled,
+      config.streaming.enabled
+        ? `Streaming responses over ${config.streaming.transport}.`
+        : "Streaming is disabled for this deployment.",
+    );
+    setCapability(
+      elements.backgroundStatus,
+      config.background.enabled,
+      config.background.enabled
+        ? `Background invocations enabled — ${config.background.durable ? "durable" : "in-process"} run store.`
+        : "Background invocations are disabled.",
+    );
     setCapability(
       elements.sessionStatus,
       config.session.managed ? true : config.session.history ? "degraded" : false,
+      config.session.managed
+        ? `Connected to Session Store "${config.session.store}" (actor ${config.session.actor}) — durable, shareable session state.`
+        : "Not connected — session state is kept in-process and resets on restart. Connect a Session Store by redeploying with:\nmason deploy --session <name>",
     );
-    setCapability(elements.memoryStatus, config.memory.enabled);
+    setCapability(
+      elements.memoryStatus,
+      config.memory.enabled,
+      config.memory.enabled
+        ? `Connected to ${config.memory.store} (actor ${config.memory.actor}).`
+        : "Not connected — no long-term memory. Connect a Memory Store by redeploying with:\nmason deploy --memory <name>",
+    );
     elements.refreshMemory.disabled = state.busy || !config.memory.enabled;
     elements.newSession.disabled = state.busy;
     elements.refreshSession.disabled = state.busy || !config.session.history;

--- a/integrations/mason/templates/ui/agent-langgraph/ui/styles.css
+++ b/integrations/mason/templates/ui/agent-langgraph/ui/styles.css
@@ -260,6 +260,7 @@ h2 {
 }
 
 .capability-row {
+  position: relative;
   display: grid;
   grid-template-columns: 34px minmax(0, 1fr) 10px;
   align-items: center;
@@ -267,11 +268,46 @@ h2 {
   min-height: 52px;
   padding: 8px 6px;
   border-bottom: 1px solid var(--line);
-  cursor: help;
 }
 
 .capability-row:last-child {
   border-bottom: 0;
+}
+
+.capability-row:focus-visible {
+  outline: 3px solid color-mix(in srgb, var(--focus) 34%, transparent);
+  outline-offset: 2px;
+}
+
+.capability-tooltip {
+  position: absolute;
+  z-index: 10;
+  top: calc(100% - 2px);
+  right: 6px;
+  left: 6px;
+  visibility: hidden;
+  padding: 9px 10px;
+  border: 1px solid var(--line-strong);
+  border-radius: 8px;
+  background: var(--surface-raised);
+  box-shadow: var(--shadow);
+  color: var(--ink);
+  font-size: 0.72rem;
+  line-height: 1.4;
+  opacity: 0;
+  pointer-events: none;
+  white-space: pre-line;
+}
+
+.capability-row:last-child .capability-tooltip {
+  top: auto;
+  bottom: calc(100% - 2px);
+}
+
+.capability-row:hover .capability-tooltip,
+.capability-row:focus-visible .capability-tooltip {
+  visibility: visible;
+  opacity: 1;
 }
 
 .capability-icon {

--- a/integrations/mason/templates/ui/agent-langgraph/ui/styles.css
+++ b/integrations/mason/templates/ui/agent-langgraph/ui/styles.css
@@ -267,6 +267,7 @@ h2 {
   min-height: 52px;
   padding: 8px 6px;
   border-bottom: 1px solid var(--line);
+  cursor: help;
 }
 
 .capability-row:last-child {

--- a/integrations/mason/templates/ui/agent-langgraph/ui/styles.css
+++ b/integrations/mason/templates/ui/agent-langgraph/ui/styles.css
@@ -285,6 +285,8 @@ h2 {
   top: calc(100% - 2px);
   right: 6px;
   left: 6px;
+  display: grid;
+  gap: 5px;
   visibility: hidden;
   padding: 9px 10px;
   border: 1px solid var(--line-strong);
@@ -296,7 +298,47 @@ h2 {
   line-height: 1.4;
   opacity: 0;
   pointer-events: none;
-  white-space: pre-line;
+}
+
+.capability-row .capability-tooltip-status {
+  margin: 0;
+  font-size: 0.65rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.capability-tooltip[data-state="enabled"] .capability-tooltip-status {
+  color: var(--success);
+}
+
+.capability-tooltip[data-state="degraded"] .capability-tooltip-status {
+  color: var(--warning);
+}
+
+.capability-tooltip[data-state="disabled"] .capability-tooltip-status {
+  color: var(--danger);
+}
+
+.capability-tooltip-detail,
+.capability-tooltip-guidance {
+  display: block;
+}
+
+.capability-tooltip-guidance {
+  margin-top: 2px;
+  color: var(--ink-soft);
+  font-size: 0.68rem;
+}
+
+.capability-tooltip .capability-tooltip-command {
+  display: block;
+  padding: 6px 7px;
+  border-radius: 6px;
+  background: var(--surface-muted);
+  color: var(--ink);
+  font-size: 0.65rem;
+  overflow-wrap: anywhere;
+  white-space: pre-wrap;
 }
 
 .capability-row:last-child .capability-tooltip {

--- a/integrations/mason/templates/ui/agent-openai/ui/app.js
+++ b/integrations/mason/templates/ui/agent-openai/ui/app.js
@@ -97,10 +97,21 @@ function setCapability(element, state, detail) {
   element.classList.toggle("disabled", key === "disabled");
   const title = detail ? `${CAPABILITY_SUMMARY[key]} — ${detail}` : CAPABILITY_SUMMARY[key];
   element.setAttribute("role", "img");
-  element.setAttribute("aria-label", `Status: ${title}`);
-  // Tooltip on the whole row gives a larger, more discoverable hover target than the orb.
+  element.setAttribute("aria-label", `Status: ${CAPABILITY_SUMMARY[key]}`);
   const row = element.closest(".capability-row");
-  if (row) row.title = title;
+  if (!row) return;
+
+  let tooltip = row.querySelector(".capability-tooltip");
+  if (!tooltip) {
+    tooltip = document.createElement("span");
+    tooltip.id = `${element.id}-tooltip`;
+    tooltip.className = "capability-tooltip";
+    tooltip.setAttribute("role", "tooltip");
+    row.append(tooltip);
+    row.tabIndex = 0;
+    row.setAttribute("aria-describedby", tooltip.id);
+  }
+  tooltip.textContent = title;
 }
 
 function formatJson(value) {

--- a/integrations/mason/templates/ui/agent-openai/ui/app.js
+++ b/integrations/mason/templates/ui/agent-openai/ui/app.js
@@ -748,7 +748,7 @@ async function loadConfig() {
       config.session.managed
         ? `Connected to Session Store "${config.session.store}" for actor ${config.session.actor}. State is durable and shareable.`
         : "Session state is kept in process and resets when the app restarts.",
-      config.session.managed ? null : "mason deploy --session <name>",
+      config.session.managed ? null : "mason deploy <deployment-name> --session <store-name>",
     );
     setCapability(
       elements.memoryStatus,
@@ -756,7 +756,7 @@ async function loadConfig() {
       config.memory.enabled
         ? `Connected to ${config.memory.store} for actor ${config.memory.actor}.`
         : "No long-term memory is connected.",
-      config.memory.enabled ? null : "mason deploy --memory <name>",
+      config.memory.enabled ? null : "mason deploy <deployment-name> --memory <store-name>",
     );
     elements.refreshMemory.disabled = state.busy || !config.memory.enabled;
     elements.newSession.disabled = state.busy;

--- a/integrations/mason/templates/ui/agent-openai/ui/app.js
+++ b/integrations/mason/templates/ui/agent-openai/ui/app.js
@@ -86,11 +86,21 @@ function setBusy(busy, label = "Working") {
   else if (!elements.runStatus.classList.contains("error")) setStatus("Ready");
 }
 
-function setCapability(element, state) {
-  const degraded = state === "degraded";
-  element.classList.toggle("enabled", state === true);
-  element.classList.toggle("degraded", degraded);
-  element.classList.toggle("disabled", !state);
+// Human-readable name for each orb color, surfaced as a hover tooltip so the
+// green/amber/red states are self-explanatory.
+const CAPABILITY_SUMMARY = { enabled: "Available", degraded: "Limited", disabled: "Unavailable" };
+
+function setCapability(element, state, detail) {
+  const key = state === true ? "enabled" : state === "degraded" ? "degraded" : "disabled";
+  element.classList.toggle("enabled", key === "enabled");
+  element.classList.toggle("degraded", key === "degraded");
+  element.classList.toggle("disabled", key === "disabled");
+  const title = detail ? `${CAPABILITY_SUMMARY[key]} — ${detail}` : CAPABILITY_SUMMARY[key];
+  element.setAttribute("role", "img");
+  element.setAttribute("aria-label", `Status: ${title}`);
+  // Tooltip on the whole row gives a larger, more discoverable hover target than the orb.
+  const row = element.closest(".capability-row");
+  if (row) row.title = title;
 }
 
 function formatJson(value) {
@@ -686,13 +696,34 @@ async function loadConfig() {
     elements.backgroundMode.textContent = config.background.durable ? "Durable run store" : "In-process run store";
     elements.sessionMode.textContent = config.session.mode;
     elements.memoryMode.textContent = config.memory.enabled ? `Managed · actor ${config.memory.actor}` : "Not connected";
-    setCapability(elements.streamingStatus, config.streaming.enabled);
-    setCapability(elements.backgroundStatus, config.background.enabled);
+    setCapability(
+      elements.streamingStatus,
+      config.streaming.enabled,
+      config.streaming.enabled
+        ? `Streaming responses over ${config.streaming.transport}.`
+        : "Streaming is disabled for this deployment.",
+    );
+    setCapability(
+      elements.backgroundStatus,
+      config.background.enabled,
+      config.background.enabled
+        ? `Background invocations enabled — ${config.background.durable ? "durable" : "in-process"} run store.`
+        : "Background invocations are disabled.",
+    );
     setCapability(
       elements.sessionStatus,
       config.session.managed ? true : config.session.history ? "degraded" : false,
+      config.session.managed
+        ? `Connected to Session Store "${config.session.store}" (actor ${config.session.actor}) — durable, shareable session state.`
+        : "Not connected — session state is kept in-process and resets on restart. Connect a Session Store by redeploying with:\nmason deploy --session <name>",
     );
-    setCapability(elements.memoryStatus, config.memory.enabled);
+    setCapability(
+      elements.memoryStatus,
+      config.memory.enabled,
+      config.memory.enabled
+        ? `Connected to ${config.memory.store} (actor ${config.memory.actor}).`
+        : "Not connected — no long-term memory. Connect a Memory Store by redeploying with:\nmason deploy --memory <name>",
+    );
     elements.refreshMemory.disabled = state.busy || !config.memory.enabled;
     elements.newSession.disabled = state.busy;
     elements.refreshSession.disabled = state.busy || !config.session.history;

--- a/integrations/mason/templates/ui/agent-openai/ui/app.js
+++ b/integrations/mason/templates/ui/agent-openai/ui/app.js
@@ -90,12 +90,11 @@ function setBusy(busy, label = "Working") {
 // green/amber/red states are self-explanatory.
 const CAPABILITY_SUMMARY = { enabled: "Available", degraded: "Limited", disabled: "Unavailable" };
 
-function setCapability(element, state, detail) {
+function setCapability(element, state, detail, command) {
   const key = state === true ? "enabled" : state === "degraded" ? "degraded" : "disabled";
   element.classList.toggle("enabled", key === "enabled");
   element.classList.toggle("degraded", key === "degraded");
   element.classList.toggle("disabled", key === "disabled");
-  const title = detail ? `${CAPABILITY_SUMMARY[key]} — ${detail}` : CAPABILITY_SUMMARY[key];
   element.setAttribute("role", "img");
   element.setAttribute("aria-label", `Status: ${CAPABILITY_SUMMARY[key]}`);
   const row = element.closest(".capability-row");
@@ -111,7 +110,29 @@ function setCapability(element, state, detail) {
     row.tabIndex = 0;
     row.setAttribute("aria-describedby", tooltip.id);
   }
-  tooltip.textContent = title;
+  tooltip.dataset.state = key;
+  tooltip.replaceChildren();
+
+  const summary = document.createElement("strong");
+  summary.className = "capability-tooltip-status";
+  summary.textContent = CAPABILITY_SUMMARY[key];
+  tooltip.append(summary);
+
+  if (detail) {
+    const description = document.createElement("span");
+    description.className = "capability-tooltip-detail";
+    description.textContent = detail;
+    tooltip.append(description);
+  }
+  if (command) {
+    const guidance = document.createElement("span");
+    guidance.className = "capability-tooltip-guidance";
+    guidance.textContent = "Connect by redeploying:";
+    const commandText = document.createElement("code");
+    commandText.className = "capability-tooltip-command";
+    commandText.textContent = command;
+    tooltip.append(guidance, commandText);
+  }
 }
 
 function formatJson(value) {
@@ -718,22 +739,24 @@ async function loadConfig() {
       elements.backgroundStatus,
       config.background.enabled,
       config.background.enabled
-        ? `Background invocations enabled — ${config.background.durable ? "durable" : "in-process"} run store.`
+        ? `Background invocations use a ${config.background.durable ? "durable" : "in-process"} run store.`
         : "Background invocations are disabled.",
     );
     setCapability(
       elements.sessionStatus,
       config.session.managed ? true : config.session.history ? "degraded" : false,
       config.session.managed
-        ? `Connected to Session Store "${config.session.store}" (actor ${config.session.actor}) — durable, shareable session state.`
-        : "Not connected — session state is kept in-process and resets on restart. Connect a Session Store by redeploying with:\nmason deploy --session <name>",
+        ? `Connected to Session Store "${config.session.store}" for actor ${config.session.actor}. State is durable and shareable.`
+        : "Session state is kept in process and resets when the app restarts.",
+      config.session.managed ? null : "mason deploy --session <name>",
     );
     setCapability(
       elements.memoryStatus,
       config.memory.enabled,
       config.memory.enabled
-        ? `Connected to ${config.memory.store} (actor ${config.memory.actor}).`
-        : "Not connected — no long-term memory. Connect a Memory Store by redeploying with:\nmason deploy --memory <name>",
+        ? `Connected to ${config.memory.store} for actor ${config.memory.actor}.`
+        : "No long-term memory is connected.",
+      config.memory.enabled ? null : "mason deploy --memory <name>",
     );
     elements.refreshMemory.disabled = state.busy || !config.memory.enabled;
     elements.newSession.disabled = state.busy;

--- a/integrations/mason/templates/ui/agent-openai/ui/styles.css
+++ b/integrations/mason/templates/ui/agent-openai/ui/styles.css
@@ -260,6 +260,7 @@ h2 {
 }
 
 .capability-row {
+  position: relative;
   display: grid;
   grid-template-columns: 34px minmax(0, 1fr) 10px;
   align-items: center;
@@ -267,11 +268,46 @@ h2 {
   min-height: 52px;
   padding: 8px 6px;
   border-bottom: 1px solid var(--line);
-  cursor: help;
 }
 
 .capability-row:last-child {
   border-bottom: 0;
+}
+
+.capability-row:focus-visible {
+  outline: 3px solid color-mix(in srgb, var(--focus) 34%, transparent);
+  outline-offset: 2px;
+}
+
+.capability-tooltip {
+  position: absolute;
+  z-index: 10;
+  top: calc(100% - 2px);
+  right: 6px;
+  left: 6px;
+  visibility: hidden;
+  padding: 9px 10px;
+  border: 1px solid var(--line-strong);
+  border-radius: 8px;
+  background: var(--surface-raised);
+  box-shadow: var(--shadow);
+  color: var(--ink);
+  font-size: 0.72rem;
+  line-height: 1.4;
+  opacity: 0;
+  pointer-events: none;
+  white-space: pre-line;
+}
+
+.capability-row:last-child .capability-tooltip {
+  top: auto;
+  bottom: calc(100% - 2px);
+}
+
+.capability-row:hover .capability-tooltip,
+.capability-row:focus-visible .capability-tooltip {
+  visibility: visible;
+  opacity: 1;
 }
 
 .capability-icon {

--- a/integrations/mason/templates/ui/agent-openai/ui/styles.css
+++ b/integrations/mason/templates/ui/agent-openai/ui/styles.css
@@ -267,6 +267,7 @@ h2 {
   min-height: 52px;
   padding: 8px 6px;
   border-bottom: 1px solid var(--line);
+  cursor: help;
 }
 
 .capability-row:last-child {

--- a/integrations/mason/templates/ui/agent-openai/ui/styles.css
+++ b/integrations/mason/templates/ui/agent-openai/ui/styles.css
@@ -285,6 +285,8 @@ h2 {
   top: calc(100% - 2px);
   right: 6px;
   left: 6px;
+  display: grid;
+  gap: 5px;
   visibility: hidden;
   padding: 9px 10px;
   border: 1px solid var(--line-strong);
@@ -296,7 +298,47 @@ h2 {
   line-height: 1.4;
   opacity: 0;
   pointer-events: none;
-  white-space: pre-line;
+}
+
+.capability-row .capability-tooltip-status {
+  margin: 0;
+  font-size: 0.65rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.capability-tooltip[data-state="enabled"] .capability-tooltip-status {
+  color: var(--success);
+}
+
+.capability-tooltip[data-state="degraded"] .capability-tooltip-status {
+  color: var(--warning);
+}
+
+.capability-tooltip[data-state="disabled"] .capability-tooltip-status {
+  color: var(--danger);
+}
+
+.capability-tooltip-detail,
+.capability-tooltip-guidance {
+  display: block;
+}
+
+.capability-tooltip-guidance {
+  margin-top: 2px;
+  color: var(--ink-soft);
+  font-size: 0.68rem;
+}
+
+.capability-tooltip .capability-tooltip-command {
+  display: block;
+  padding: 6px 7px;
+  border-radius: 6px;
+  background: var(--surface-muted);
+  color: var(--ink);
+  font-size: 0.65rem;
+  overflow-wrap: anywhere;
+  white-space: pre-wrap;
 }
 
 .capability-row:last-child .capability-tooltip {


### PR DESCRIPTION
Each capability orb (Streaming, Background, Session, Memory) showed a bare green/amber/red dot with no explanation. Attach a descriptive hover tooltip to the whole capability row naming the state and, when not connected, the `mason deploy <deployment-name> --session/--memory <store-name>` command to connect it, plus an aria-label so the status is announced to screen readers.

<img width="339" height="197" alt="Screenshot 2026-09-03 at 1 11 10 PM" src="https://github.com/user-attachments/assets/cb3c66a2-6fdc-4bba-a78f-267a264e4b4d" />