### PR TITLE
mason: show memory setup commands in chat UI

### DIFF
--- a/integrations/mason/templates/ui/agent-langgraph/runtime/ui.py
+++ b/integrations/mason/templates/ui/agent-langgraph/runtime/ui.py
@@ -68,6 +68,12 @@ def _session_actor() -> str:
     return os.getenv(_SESSION_ACTOR_ENV) or _memory_actor()
 
 
+def _is_deployed() -> bool:
+    app_url = os.getenv("DATABRICKS_APP_URL", "")
+    is_local = app_url.startswith(("http://localhost", "http://127.0.0.1"))
+    return bool(os.getenv("DATABRICKS_APP_NAME")) and not is_local
+
+
 class _ManagedStateClient:
     def __init__(self) -> None:
         self._workspace = workspace_client()
@@ -274,7 +280,7 @@ def install_ui(app: FastAPI) -> None:
             "session_id": request.state.session_id,
             "instance_id": _INSTANCE_ID,
             "viewer": viewer,
-            "deployed": bool(os.getenv("DATABRICKS_APP_NAME")),
+            "deployed": _is_deployed(),
             "streaming": {"enabled": True, "transport": "Server-sent events"},
             "background": {"enabled": True, "durable": False},
             "session": {

--- a/integrations/mason/templates/ui/agent-langgraph/tests/test_demo_ui.py
+++ b/integrations/mason/templates/ui/agent-langgraph/tests/test_demo_ui.py
@@ -156,6 +156,15 @@ def test_demo_ui_routes(monkeypatch):
     assert client.post("/api/demo/sessions", json={"session_id": "ignored"}).status_code == 503
 
 
+def test_demo_config_distinguishes_run_local_from_a_deployed_app(monkeypatch):
+    monkeypatch.setenv("DATABRICKS_APP_NAME", "app")
+    monkeypatch.setenv("DATABRICKS_APP_URL", "http://127.0.0.1:8000")
+    assert _client(monkeypatch).get("/api/demo/config").json()["deployed"] is False
+
+    monkeypatch.setenv("DATABRICKS_APP_URL", "https://agent.example.databricksapps.com")
+    assert _client(monkeypatch).get("/api/demo/config").json()["deployed"] is True
+
+
 def test_unmanaged_checkpoint_history_route(monkeypatch):
     client = _client(monkeypatch, history=True, session_id="local-session")
 

--- a/integrations/mason/templates/ui/agent-langgraph/tests/test_demo_ui.py
+++ b/integrations/mason/templates/ui/agent-langgraph/tests/test_demo_ui.py
@@ -118,6 +118,8 @@ def test_demo_ui_routes(monkeypatch):
     assert 'id="session-list"' in index.text
     app_script = client.get("/ui-assets/app.js")
     assert app_script.status_code == 200
+    assert "mason dev --memory <store-name>" in app_script.text
+    assert "mason deploy <app-name> --source . --memory <store-name>" in app_script.text
     assert "refreshSessionView({ hydrateChat: true })" in app_script.text
     assert 'fetch("/api/session/new"' in app_script.text
     assert "/api/demo/sessions/${encodeURIComponent(sessionId)}/open" in app_script.text

--- a/integrations/mason/templates/ui/agent-langgraph/ui/app.js
+++ b/integrations/mason/templates/ui/agent-langgraph/ui/app.js
@@ -736,7 +736,9 @@ async function loadConfig() {
     elements.rejectSession.disabled = state.busy || !config.session.durable;
     elements.memoryHelp.textContent = config.memory.enabled
       ? `${config.memory.store} · actor ${config.memory.actor}`
-      : "Deploy with --memory to expose managed entries and agent memory tools.";
+      : config.deployed
+        ? "Run from the project directory: mason deploy <app-name> --source . --memory <store-name>. Mason creates the store if needed."
+        : "Run from the project directory: mason dev --memory <store-name>. Mason creates the store if needed.";
     elements.sessionStoreLabel.textContent = config.session.managed
       ? `${config.session.store} · actor ${config.session.actor} · the Apps routing cookie keys transcript and checkpoint state.`
       : config.session.history
@@ -745,7 +747,7 @@ async function loadConfig() {
     addEvent("runtime.config", config);
     void refreshSessionView({ hydrateChat: true });
     if (config.memory.enabled) void listMemoryEntries();
-    else stateMessage(elements.memoryResults, "Connect a Memory Store to manage entries.");
+    else stateMessage(elements.memoryResults, "Run the command above to connect a Memory Store and enable agent memory tools.");
     return config;
   } catch (error) {
     throw error;

--- a/integrations/mason/templates/ui/agent-langgraph/ui/index.html
+++ b/integrations/mason/templates/ui/agent-langgraph/ui/index.html
@@ -153,7 +153,7 @@
               <div><p class="eyebrow">Cross-session</p><h2>Long-term memory</h2></div>
               <button id="refresh-memory" class="icon-button" type="button" aria-label="Refresh memory entries">↻</button>
             </div>
-            <p id="memory-help" class="supporting-text">Connect a Memory Store to manage entries.</p>
+            <p id="memory-help" class="supporting-text">Run from the project directory: mason dev --memory &lt;store-name&gt;</p>
             <div id="memory-results" class="state-list" aria-live="polite">
               <div class="state-empty">Memory entries appear here.</div>
             </div>

--- a/integrations/mason/templates/ui/agent-openai/runtime/ui.py
+++ b/integrations/mason/templates/ui/agent-openai/runtime/ui.py
@@ -68,6 +68,12 @@ def _session_actor() -> str:
     return os.getenv(_SESSION_ACTOR_ENV) or _memory_actor()
 
 
+def _is_deployed() -> bool:
+    app_url = os.getenv("DATABRICKS_APP_URL", "")
+    is_local = app_url.startswith(("http://localhost", "http://127.0.0.1"))
+    return bool(os.getenv("DATABRICKS_APP_NAME")) and not is_local
+
+
 class _ManagedStateClient:
     def __init__(self) -> None:
         self._workspace = workspace_client()
@@ -268,7 +274,7 @@ def install_ui(app: FastAPI) -> None:
             "session_id": request.state.session_id,
             "instance_id": _INSTANCE_ID,
             "viewer": viewer,
-            "deployed": bool(os.getenv("DATABRICKS_APP_NAME")),
+            "deployed": _is_deployed(),
             "streaming": {"enabled": True, "transport": "Server-sent events"},
             "background": {"enabled": True, "durable": False},
             "session": {

--- a/integrations/mason/templates/ui/agent-openai/tests/test_demo_ui.py
+++ b/integrations/mason/templates/ui/agent-openai/tests/test_demo_ui.py
@@ -151,6 +151,15 @@ def test_demo_ui_routes(monkeypatch):
     assert client.post("/api/demo/sessions", json={"session_id": "ignored"}).status_code == 503
 
 
+def test_demo_config_distinguishes_run_local_from_a_deployed_app(monkeypatch):
+    monkeypatch.setenv("DATABRICKS_APP_NAME", "app")
+    monkeypatch.setenv("DATABRICKS_APP_URL", "http://127.0.0.1:8000")
+    assert _client(monkeypatch).get("/api/demo/config").json()["deployed"] is False
+
+    monkeypatch.setenv("DATABRICKS_APP_URL", "https://agent.example.databricksapps.com")
+    assert _client(monkeypatch).get("/api/demo/config").json()["deployed"] is True
+
+
 def test_unmanaged_local_history_route(monkeypatch):
     client = _client(monkeypatch, history=True, session_id="local-session")
 

--- a/integrations/mason/templates/ui/agent-openai/tests/test_demo_ui.py
+++ b/integrations/mason/templates/ui/agent-openai/tests/test_demo_ui.py
@@ -112,6 +112,8 @@ def test_demo_ui_routes(monkeypatch):
     assert 'id="session-list"' in index.text
     app_script = client.get("/ui-assets/app.js")
     assert app_script.status_code == 200
+    assert "mason dev --memory <store-name>" in app_script.text
+    assert "mason deploy <app-name> --source . --memory <store-name>" in app_script.text
     assert "refreshSessionView({ hydrateChat: true })" in app_script.text
     assert 'fetch("/api/session/new"' in app_script.text
     assert "/api/demo/sessions/${encodeURIComponent(sessionId)}/open" in app_script.text

--- a/integrations/mason/templates/ui/agent-openai/ui/app.js
+++ b/integrations/mason/templates/ui/agent-openai/ui/app.js
@@ -700,7 +700,9 @@ async function loadConfig() {
     elements.rejectSession.disabled = state.busy || !config.session.durable;
     elements.memoryHelp.textContent = config.memory.enabled
       ? `${config.memory.store} · actor ${config.memory.actor}`
-      : "Deploy with --memory to expose managed entries and agent memory tools.";
+      : config.deployed
+        ? "Run from the project directory: mason deploy <app-name> --source . --memory <store-name>. Mason creates the store if needed."
+        : "Run from the project directory: mason dev --memory <store-name>. Mason creates the store if needed.";
     elements.sessionStoreLabel.textContent = config.session.managed
       ? `${config.session.store} · actor ${config.session.actor} · the Apps routing cookie keys the session transcript.`
       : config.session.history
@@ -709,7 +711,7 @@ async function loadConfig() {
     addEvent("runtime.config", config);
     void refreshSessionView({ hydrateChat: true });
     if (config.memory.enabled) void listMemoryEntries();
-    else stateMessage(elements.memoryResults, "Connect a Memory Store to manage entries.");
+    else stateMessage(elements.memoryResults, "Run the command above to connect a Memory Store and enable agent memory tools.");
     return config;
   } catch (error) {
     throw error;

--- a/integrations/mason/templates/ui/agent-openai/ui/index.html
+++ b/integrations/mason/templates/ui/agent-openai/ui/index.html
@@ -153,7 +153,7 @@
               <div><p class="eyebrow">Cross-session</p><h2>Long-term memory</h2></div>
               <button id="refresh-memory" class="icon-button" type="button" aria-label="Refresh memory entries">↻</button>
             </div>
-            <p id="memory-help" class="supporting-text">Connect a Memory Store to manage entries.</p>
+            <p id="memory-help" class="supporting-text">Run from the project directory: mason dev --memory &lt;store-name&gt;</p>
             <div id="memory-results" class="state-list" aria-live="polite">
               <div class="state-empty">Memory entries appear here.</div>
             </div>


### PR DESCRIPTION
## Summary

- show the exact `mason dev --memory <store-name>` command when memory is disabled locally
- show the corresponding `mason deploy <app-name> --source . --memory <store-name>` command for deployed apps
- distinguish `databricks apps run-local` from a deployed App even though both set `DATABRICKS_APP_NAME`
- explain that Mason creates the store when needed
- keep the LangGraph and OpenAI chat UI templates consistent

## Testing

### Live end-to-end flow

Tested against a real Databricks workspace using a fresh LangGraph project scaffolded from this PR branch:

1. Ran `mason dev` without memory and opened the rendered UI in a real browser.
   - `/api/demo/config` reported `deployed: false` and `memory.enabled: false`.
   - The memory card showed `mason dev --memory <store-name>`.
   - No browser errors were reported.
2. Restarted the same project with `mason dev --memory mason-pr530-e2e-01a0682c`.
   - Mason created and connected the Memory Store.
   - `/api/demo/config` reported `deployed: false` and `memory.enabled: true`.
   - `GET /api/demo/memory/entries` returned 200 and the Refresh control was enabled.
3. Created `/e2e/pr-530.md` with `mason memory entries create`, refreshed the UI, and verified its content rendered.
4. Deleted the temporary Memory Store after verification.

<img width="1710" height="723" alt="Screenshot 2026-09-03 at 10 05 39 AM" src="https://github.com/user-attachments/assets/bbb92eb0-e757-4108-a550-d65ad1c45c40" />


### Automated checks

- LangGraph generated-template UI suite: 8 passed
- OpenAI generated-template UI suite: 8 passed
- Mason dev/CLI unit tests: 19 passed
- `node --check` passed for both template `app.js` files
- `git diff --check` passed