### PR TITLE
mason: reauthenticate stale profiles during login

### DIFF
--- a/integrations/mason/README.md
+++ b/integrations/mason/README.md
@@ -38,11 +38,13 @@ mason login --profile <profile>
 mason sessions stores list
 ```
 
-`mason login` does not create credentials; it stores the selected profile in
-`~/.mason/config.json`. `mason logout` forgets that selection without revoking the
-underlying credentials. If Databricks SDK default authentication is already configured,
-you can skip `mason login`. You can also pass `--profile/-p` for an individual command.
-Use `--output json` for scripting.
+`mason login` does not create a missing profile; it validates the selected profile and stores it
+in `~/.mason/config.json`. If an existing Databricks CLI OAuth profile has an invalid refresh
+token, an interactive `mason login` automatically runs `databricks auth login` and retries. In
+non-interactive or JSON mode, it reports the command to run instead of starting a browser flow.
+`mason logout` forgets the selection without revoking the underlying credentials. If Databricks
+SDK default authentication is already configured, you can skip `mason login`. You can also pass
+`--profile/-p` for an individual command. Use `--output json` for scripting.
 
 ## Python SDK
 

--- a/integrations/mason/src/databricks_mason/auth.py
+++ b/integrations/mason/src/databricks_mason/auth.py
@@ -1,10 +1,11 @@
 """`mason login` / `logout` — remember an optional Databricks profile.
 
-`login` validates a named profile and persists the selection; the root group falls back
-to it whenever `-p` is omitted. Without a saved profile, the Databricks SDK performs its
-normal default authentication resolution. `logout` removes only Mason's saved selection,
-not the underlying credentials. State lives in a small JSON file under `~/.mason`
-(override the directory with `MASON_CONFIG_HOME`, mainly for tests).
+`login` validates a named profile and persists the selection; if an interactive login finds
+an expired Databricks CLI refresh token, it reauthenticates the profile through the CLI first.
+The root group falls back to the saved profile whenever `-p` is omitted. Without one, the
+Databricks SDK performs its normal default authentication resolution. `logout` removes only
+Mason's saved selection, not the underlying credentials. State lives in a small JSON file under
+`~/.mason` (override the directory with `MASON_CONFIG_HOME`, mainly for tests).
 """
 
 from __future__ import annotations
@@ -12,6 +13,9 @@ from __future__ import annotations
 import json
 import os
 import pathlib
+import shlex
+import subprocess
+import sys
 from typing import Optional
 
 import click
@@ -19,6 +23,8 @@ import click
 from databricks_mason import render
 from databricks_mason.client import MasonClient
 from databricks_mason.errors import AgentCliError
+
+_INVALID_REFRESH_TOKEN = "refresh token is invalid"
 
 
 def _config_file() -> pathlib.Path:
@@ -41,6 +47,46 @@ def _save_default_profile(profile: str) -> None:
     path.write_text(json.dumps({"profile": profile}, indent=2) + "\n")
 
 
+def _is_stale_cli_profile(exc: Exception) -> bool:
+    """Whether an exception chain reports the CLI's invalid OAuth refresh-token failure."""
+    seen: set[int] = set()
+    current: Optional[BaseException] = exc
+    while current is not None and id(current) not in seen:
+        seen.add(id(current))
+        if _INVALID_REFRESH_TOKEN in str(current).lower():
+            return True
+        current = current.__cause__ or current.__context__
+    return False
+
+
+def _can_auto_reauthenticate(output: str) -> bool:
+    """Browser login is appropriate only for a human-facing, interactive invocation."""
+    return output == "text" and sys.stdin.isatty()
+
+
+def _reauthenticate(profile: str) -> None:
+    command = ["databricks", "auth", "login", "--profile", profile]
+    click.echo(f"Databricks credentials for profile {profile!r} have expired; reauthenticating...")
+    try:
+        result = subprocess.run(command, check=False)
+    except OSError as exc:
+        raise AgentCliError(
+            f"Could not start Databricks authentication: {exc}",
+            hint=f"Run `{shlex.join(command)}` manually, then retry `mason login`.",
+        ) from exc
+    if result.returncode != 0:
+        raise AgentCliError(
+            f"Could not reauthenticate Databricks profile {profile!r} (exit {result.returncode}).",
+            hint=f"Run `{shlex.join(command)}` manually, then retry `mason login`.",
+        )
+
+
+def _validated_client(profile: str) -> tuple[MasonClient, str]:
+    client = MasonClient(profile)
+    user = client.current_user  # round-trips current_user.me(), so a bad profile fails here
+    return client, user
+
+
 @click.command()
 @click.option(
     "--profile",
@@ -50,15 +96,26 @@ def _save_default_profile(profile: str) -> None:
 )
 @click.pass_obj
 def login(obj, profile) -> None:
-    """Validate a profile's credentials and save it as the default, so later commands can omit -p."""
+    """Authenticate a profile and save it as the default, so later commands can omit -p."""
     profile = profile or obj.profile
     if not profile:
         raise AgentCliError(
             "No profile to save.",
             hint="Pass one to remember, e.g. `mason login --profile my-workspace`.",
         )
-    client = MasonClient(profile)
-    user = client.current_user  # round-trips current_user.me(), so a bad profile fails here
+    try:
+        client, user = _validated_client(profile)
+    except Exception as exc:
+        if not _is_stale_cli_profile(exc):
+            raise
+        command = ["databricks", "auth", "login", "--profile", profile]
+        if not _can_auto_reauthenticate(obj.output):
+            raise AgentCliError(
+                f"Databricks credentials for profile {profile!r} have expired.",
+                hint=f"Run `{shlex.join(command)}`, then retry `mason login`.",
+            ) from exc
+        _reauthenticate(profile)
+        client, user = _validated_client(profile)
     _save_default_profile(profile)
     if obj.output == "json":
         render.emit_json({"profile": profile, "user": user, "host": client.host})

--- a/integrations/mason/tests/unit_tests/auth_test.py
+++ b/integrations/mason/tests/unit_tests/auth_test.py
@@ -23,10 +23,22 @@ class _Ctx:
 
 
 def _stub_client(monkeypatch, user="me@example.com", host="https://ws"):
+    fake = _fake_client(user=user, host=host)
+    monkeypatch.setattr(auth, "MasonClient", lambda profile: fake)
+
+
+def _fake_client(user="me@example.com", host="https://ws"):
     fake = mock.Mock()
     fake.current_user = user
     fake.host = host
-    monkeypatch.setattr(auth, "MasonClient", lambda profile: fake)
+    return fake
+
+
+def _stale_profile_error():
+    return auth.AgentCliError(
+        "Could not initialize Databricks auth: cannot get access token: "
+        "the refresh token is invalid."
+    )
 
 
 def test_load_default_profile_missing_returns_none(tmp_path, monkeypatch):
@@ -68,6 +80,102 @@ def test_login_without_any_profile_errors(tmp_path, monkeypatch):
     result = CliRunner().invoke(auth.login, [], obj=_Ctx(profile=None))
     assert result.exit_code != 0
     assert auth.load_default_profile() is None
+
+
+def test_login_reauthenticates_stale_profile_and_retries(tmp_path, monkeypatch):
+    monkeypatch.setenv("MASON_CONFIG_HOME", str(tmp_path))
+    clients = mock.Mock(side_effect=[_stale_profile_error(), _fake_client()])
+    monkeypatch.setattr(auth, "MasonClient", clients)
+    monkeypatch.setattr(auth, "_can_auto_reauthenticate", lambda output: True)
+    run = mock.Mock(return_value=mock.Mock(returncode=0))
+    monkeypatch.setattr(auth.subprocess, "run", run)
+
+    result = CliRunner().invoke(auth.login, ["--profile", "dogfood"], obj=_Ctx())
+
+    assert result.exit_code == 0, result.output
+    assert auth.load_default_profile() == "dogfood"
+    assert clients.call_args_list == [mock.call("dogfood"), mock.call("dogfood")]
+    run.assert_called_once_with(
+        ["databricks", "auth", "login", "--profile", "dogfood"],
+        check=False,
+    )
+
+
+def test_login_does_not_reauthenticate_unrelated_auth_failure(tmp_path, monkeypatch):
+    monkeypatch.setenv("MASON_CONFIG_HOME", str(tmp_path))
+    monkeypatch.setattr(
+        auth,
+        "MasonClient",
+        mock.Mock(side_effect=auth.AgentCliError("profile has conflicting auth settings")),
+    )
+    monkeypatch.setattr(auth, "_can_auto_reauthenticate", lambda output: True)
+    run = mock.Mock()
+    monkeypatch.setattr(auth.subprocess, "run", run)
+
+    result = CliRunner().invoke(auth.login, ["--profile", "broken"], obj=_Ctx())
+
+    assert result.exit_code != 0
+    assert auth.load_default_profile() is None
+    run.assert_not_called()
+
+
+def test_login_noninteractive_stale_profile_keeps_actionable_error(tmp_path, monkeypatch):
+    monkeypatch.setenv("MASON_CONFIG_HOME", str(tmp_path))
+    monkeypatch.setattr(auth, "MasonClient", mock.Mock(side_effect=_stale_profile_error()))
+    monkeypatch.setattr(auth, "_can_auto_reauthenticate", lambda output: False)
+    run = mock.Mock()
+    monkeypatch.setattr(auth.subprocess, "run", run)
+
+    result = CliRunner().invoke(auth.login, ["--profile", "dogfood"], obj=_Ctx())
+
+    assert result.exit_code != 0
+    assert "databricks auth login --profile dogfood" in result.output
+    assert auth.load_default_profile() is None
+    run.assert_not_called()
+
+
+def test_auto_reauthentication_requires_text_mode_and_tty(monkeypatch):
+    monkeypatch.setattr(auth.sys.stdin, "isatty", lambda: True)
+    assert auth._can_auto_reauthenticate("text") is True
+    assert auth._can_auto_reauthenticate("json") is False
+
+    monkeypatch.setattr(auth.sys.stdin, "isatty", lambda: False)
+    assert auth._can_auto_reauthenticate("text") is False
+
+
+def test_login_does_not_save_profile_when_reauthentication_fails(tmp_path, monkeypatch):
+    monkeypatch.setenv("MASON_CONFIG_HOME", str(tmp_path))
+    clients = mock.Mock(side_effect=_stale_profile_error())
+    monkeypatch.setattr(auth, "MasonClient", clients)
+    monkeypatch.setattr(auth, "_can_auto_reauthenticate", lambda output: True)
+    monkeypatch.setattr(
+        auth.subprocess,
+        "run",
+        mock.Mock(return_value=mock.Mock(returncode=1)),
+    )
+
+    result = CliRunner().invoke(auth.login, ["--profile", "dogfood"], obj=_Ctx())
+
+    assert result.exit_code != 0
+    assert "could not reauthenticate" in result.output.lower()
+    assert auth.load_default_profile() is None
+    assert clients.call_count == 1
+
+
+def test_login_retries_only_once_after_reauthentication(tmp_path, monkeypatch):
+    monkeypatch.setenv("MASON_CONFIG_HOME", str(tmp_path))
+    clients = mock.Mock(side_effect=[_stale_profile_error(), _stale_profile_error()])
+    monkeypatch.setattr(auth, "MasonClient", clients)
+    monkeypatch.setattr(auth, "_can_auto_reauthenticate", lambda output: True)
+    run = mock.Mock(return_value=mock.Mock(returncode=0))
+    monkeypatch.setattr(auth.subprocess, "run", run)
+
+    result = CliRunner().invoke(auth.login, ["--profile", "dogfood"], obj=_Ctx())
+
+    assert result.exit_code != 0
+    assert auth.load_default_profile() is None
+    assert clients.call_count == 2
+    assert run.call_count == 1
 
 
 def test_logout_clears_saved_profile(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary

- detect invalid Databricks CLI refresh tokens during interactive `mason login`
- run `databricks auth login --profile <profile>` and retry validation once
- preserve actionable errors for JSON/non-interactive logins and unrelated auth failures
- document the reauthentication behavior

## Testing

### Automated

- `uv run pytest tests/unit_tests/ -q` (230 passed)
- `uv run ruff check`
- `uv run ruff format --check`
- `uv run ty check`

### End-to-end

Tested the branch CLI against a genuinely stale `databricks-cli` OAuth profile in a live workspace, with Mason state isolated via `MASON_CONFIG_HOME`:

- confirmed the profile initially failed because its refresh token was invalid
- ran interactive `mason login --profile <profile>` and observed Mason automatically launch `databricks auth login`
- completed browser OAuth and confirmed Mason retried validation, reported the authenticated user/host, saved the selected profile, and exited 0
- confirmed the refreshed profile authenticates successfully afterward
- confirmed a separate stale profile in JSON/non-interactive mode returns the structured recovery command and does not start browser authentication