### PR TITLE
[mason] Per-user memory/session isolation + agent.toml store bindings

### DIFF
--- a/integrations/mason/src/databricks_mason/agent_project.py
+++ b/integrations/mason/src/databricks_mason/agent_project.py
@@ -15,6 +15,7 @@ from tomlkit import TOMLDocument
 from tomlkit.exceptions import ParseError
 
 from databricks_mason.errors import AgentCliError
+from databricks_mason.runtime.tool_manifest import MEMORY_STORE_TABLE, SESSION_STORE_TABLE
 
 _SCHEMA_VERSION = 1
 _SUPPORTED_FRAMEWORKS = {"langgraph", "openai"}
@@ -191,6 +192,15 @@ def _required_string(value: object, description: str) -> str:
     return value
 
 
+def _store_name_from_manifest(value: object, table: str) -> str | None:
+    """Read the ``name`` from a ``[memory_store]`` / ``[session_store]`` table, or None if absent."""
+    if value is None:
+        return None
+    if not isinstance(value, Mapping):
+        raise AgentCliError(f"agent.toml [{table}] must be a table.")
+    return _required_string(cast(Mapping[str, Any], value).get("name"), f"[{table}] name")
+
+
 def _scope_from_manifest(value: object) -> Scope:
     if not isinstance(value, Mapping):
         raise AgentCliError("Sandbox downscope entries must be TOML tables.")
@@ -275,12 +285,17 @@ class AgentProject:
         document: TOMLDocument,
         framework: str,
         tools: list[ToolSpec],
+        memory_store: str | None = None,
+        session_store: str | None = None,
     ) -> None:
         self.root = root
         self.path = root / "agent.toml"
         self._document = document
         self.framework = framework
         self.tools = tools
+        # Managed store bindings declared in agent.toml; None = unbound.
+        self.memory_store = memory_store
+        self.session_store = session_store
 
     @classmethod
     def load(cls, root: pathlib.Path | str) -> "AgentProject":
@@ -314,7 +329,13 @@ class AgentProject:
         ids = [tool.id for tool in tools]
         if len(ids) != len(set(ids)):
             raise AgentCliError("agent.toml tool ids must be unique.")
-        return cls(project_root, document, framework, tools)
+        memory_store = _store_name_from_manifest(
+            document.get(MEMORY_STORE_TABLE), MEMORY_STORE_TABLE
+        )
+        session_store = _store_name_from_manifest(
+            document.get(SESSION_STORE_TABLE), SESSION_STORE_TABLE
+        )
+        return cls(project_root, document, framework, tools, memory_store, session_store)
 
     @classmethod
     def create(cls, root: pathlib.Path | str, *, framework: str) -> "AgentProject":
@@ -365,6 +386,44 @@ class AgentProject:
             raise AgentCliError("agent.toml tools must be an array of tables.")
         del raw_tools[index]
         del self.tools[index]
+        return True
+
+    def bind_memory_store(self, name: str) -> bool:
+        """Declare the memory store binding in agent.toml. Returns True if it changed."""
+        return self._set_store(MEMORY_STORE_TABLE, name)
+
+    def bind_session_store(self, name: str) -> bool:
+        """Declare the session store binding in agent.toml. Returns True if it changed."""
+        return self._set_store(SESSION_STORE_TABLE, name)
+
+    def unbind_memory_store(self) -> bool:
+        """Remove the memory store binding from agent.toml. Returns True if it was present."""
+        return self._clear_store(MEMORY_STORE_TABLE)
+
+    def unbind_session_store(self) -> bool:
+        """Remove the session store binding from agent.toml. Returns True if it was present."""
+        return self._clear_store(SESSION_STORE_TABLE)
+
+    def _set_store(self, table: str, name: str) -> bool:
+        name = _required_string(name, f"[{table}] name")
+        if getattr(self, table) == name:
+            return False
+        existing = self._document.get(table)
+        if isinstance(existing, Mapping):
+            existing["name"] = name
+        else:
+            store_table = tomlkit.table()
+            store_table.add("name", name)
+            self._document.append(table, store_table)
+        setattr(self, table, name)
+        return True
+
+    def _clear_store(self, table: str) -> bool:
+        if getattr(self, table) is None:
+            return False
+        if table in self._document:
+            del self._document[table]
+        setattr(self, table, None)
         return True
 
     def write(self) -> pathlib.Path:

--- a/integrations/mason/src/databricks_mason/deploy.py
+++ b/integrations/mason/src/databricks_mason/deploy.py
@@ -26,9 +26,7 @@ from databricks_mason.store_access import _databricks, apply_postgres_resources,
 from databricks_mason.tracing import TRACES_DEST_ENV, TRACES_EXPERIMENT_ENV, default_experiment
 
 _MEMORY_ENV = "AGENT_MEMORY_STORE"
-_MEMORY_ACTOR_ENV = "AGENT_MEMORY_ACTOR_ID"
 _SESSION_ENV = "AGENT_SESSION_STORE"
-_SESSION_ACTOR_ENV = "AGENT_SESSION_ACTOR_ID"
 
 # TEMPORARY: the Apps build environment currently can't reach the internal pypi proxy, so builds
 # time out installing dependencies. Point the build at public PyPI (sanctioned interim workaround)
@@ -343,12 +341,6 @@ def _grant_store_access(
     help="Session store name to wire in via AGENT_SESSION_STORE.",
 )
 @click.option(
-    "--actor-id",
-    default="agent",
-    show_default=True,
-    help="Actor id used for managed memory entries and sessions.",
-)
-@click.option(
     "--with-traces",
     "traces_destination",
     default=None,
@@ -384,7 +376,6 @@ def deploy(
     source,
     memory_store,
     session_store,
-    actor_id,
     traces_destination,
     traces_experiment,
     no_create_stores,
@@ -414,10 +405,8 @@ def deploy(
     provisioned: dict[str, Any] = {}
     if _MEMORY_ENV in env_updates:
         provisioned["Memory store"] = env_updates[_MEMORY_ENV]
-        env_updates[_MEMORY_ACTOR_ENV] = actor_id
     if _SESSION_ENV in env_updates:
         provisioned["Session store"] = env_updates[_SESSION_ENV]
-        env_updates[_SESSION_ACTOR_ENV] = actor_id
     if traces_destination:
         provisioned["Traces"] = traces_destination
     if pip_index_url:

--- a/integrations/mason/src/databricks_mason/help.py
+++ b/integrations/mason/src/databricks_mason/help.py
@@ -29,6 +29,12 @@ _EXAMPLES: dict[CommandPath, tuple[Example, ...]] = {
         ("mason memory stores create --display-name agent-memory", "create a memory store"),
         ("mason deploy <agent> --memory agent-memory", "wire it into a deployment"),
     ),
+    ("memory", "bind"): (
+        ("mason memory bind agent-memory --source .", "declare a memory store in agent.toml"),
+    ),
+    ("memory", "unbind"): (
+        ("mason memory unbind --source .", "remove the memory store binding from agent.toml"),
+    ),
     ("memory", "stores"): (("mason memory stores list", "list managed memory stores"),),
     ("memory", "stores", "create"): (
         ("mason memory stores create --display-name agent-memory", "create a memory store"),
@@ -81,6 +87,12 @@ _EXAMPLES: dict[CommandPath, tuple[Example, ...]] = {
     ("sessions",): (
         ("mason sessions stores list", "list managed session stores"),
         ("mason sessions list --help", "see how to list sessions"),
+    ),
+    ("sessions", "bind"): (
+        ("mason sessions bind agent-sessions --source .", "declare a session store in agent.toml"),
+    ),
+    ("sessions", "unbind"): (
+        ("mason sessions unbind --source .", "remove the session store binding from agent.toml"),
     ),
     ("sessions", "stores"): (("mason sessions stores list", "list managed session stores"),),
     ("sessions", "stores", "create"): (

--- a/integrations/mason/src/databricks_mason/langgraph/__init__.py
+++ b/integrations/mason/src/databricks_mason/langgraph/__init__.py
@@ -33,7 +33,7 @@ from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from databricks_mason.langgraph.mcp import mcp_tools
-    from databricks_mason.langgraph.memory import memory_tools, recall, remember
+    from databricks_mason.langgraph.memory import memory_tools
     from databricks_mason.langgraph.session_store import checkpointer, thread_config
     from databricks_mason.runtime import tag_session, workspace_client, workspace_headers
 
@@ -56,8 +56,6 @@ __all__ = [
     "mcp_tools",
     # Long-term memory tools (opt-in via AGENT_MEMORY_STORE) — add to your tool list.
     "memory_tools",
-    "remember",
-    "recall",
     # Session persistence — pass checkpointer() to create_agent(checkpointer=...) and
     # thread_config(session_id) as the per-request run config.
     "checkpointer",
@@ -75,8 +73,6 @@ __all__ = [
 _MODULE_BY_NAME = {
     "mcp_tools": "databricks_mason.langgraph.mcp",
     "memory_tools": "databricks_mason.langgraph.memory",
-    "remember": "databricks_mason.langgraph.memory",
-    "recall": "databricks_mason.langgraph.memory",
     "checkpointer": "databricks_mason.langgraph.session_store",
     "thread_config": "databricks_mason.langgraph.session_store",
     "tag_session": "databricks_mason.runtime",

--- a/integrations/mason/src/databricks_mason/langgraph/memory.py
+++ b/integrations/mason/src/databricks_mason/langgraph/memory.py
@@ -16,8 +16,6 @@ and ``recall``'s own parameters and cannot set or spoof the actor. Pass a fixed 
 memory (e.g. a team knowledge base).
 """
 
-import os
-
 from langchain_core.tools import BaseTool, tool
 
 from databricks_mason.runtime.workspace import workspace_client
@@ -25,30 +23,32 @@ from databricks_mason.runtime.workspace import workspace_client
 _AGENTS_V1 = "/api/agents/v1"
 
 
-def _store_path() -> str:
-    return f"{_AGENTS_V1}/memory-stores/{os.environ['AGENT_MEMORY_STORE']}"
-
-
 def _api():
     # Build the client lazily (needs workspace auth) so importing this module stays cheap.
     return workspace_client().api_client
 
 
-def memory_tools(actor: str) -> list[BaseTool]:
-    """The long-term-memory tools for ``actor`` when ``AGENT_MEMORY_STORE`` is set, else none.
+def memory_tools(actor: str, store: str | None = None) -> list[BaseTool]:
+    """The long-term-memory tools for ``actor`` when a memory store is configured, else none.
 
-    ``actor`` partitions the memory store; it is captured in the tools' closures (not exposed to the
-    model). Call this per request with the identity whose memory to use (e.g. the signed-in user).
+    The store resolves ``store`` arg → ``AGENT_MEMORY_STORE`` env → the ``[memory_store]`` binding in
+    agent.toml (`mason memory bind`) → none (no tools). ``actor`` partitions the store; it is captured
+    in the tools' closures (not exposed to the model). Call this per request with the identity whose
+    memory to use (e.g. the signed-in user).
     """
-    if not os.getenv("AGENT_MEMORY_STORE"):
+    from databricks_mason.runtime.tool_manifest import resolve_memory_store
+
+    store = resolve_memory_store(store)
+    if not store:
         return []
+    store_path = f"{_AGENTS_V1}/memory-stores/{store}"
 
     @tool
     def remember(fact: str, topic: str) -> str:
         """Persist a durable fact about the user in long-term memory."""
         _api().do(
             "POST",
-            f"{_store_path()}/entries",
+            f"{store_path}/entries",
             body={"actor_id": actor, "path": f"/{topic}/{fact[:8]}.md", "content": fact},
         )
         return "stored"
@@ -58,7 +58,7 @@ def memory_tools(actor: str) -> list[BaseTool]:
         """Search the user's long-term memory for facts relevant to the query."""
         data = _api().do(
             "POST",
-            f"{_store_path()}/entries:search",
+            f"{store_path}/entries:search",
             body={"actor_id": actor, "query": query, "limit": 5},
         )
         entries = data.get("managed_memory_entries") or []

--- a/integrations/mason/src/databricks_mason/langgraph/memory.py
+++ b/integrations/mason/src/databricks_mason/langgraph/memory.py
@@ -4,13 +4,16 @@ Unlike the session store (short-term transcript for one conversation), long-term
 to the model as two tools — ``remember`` and ``recall`` — over the Databricks managed memory store's
 ``agents/v1`` entries API. Facts persist across conversations.
 
-``memory_tools()`` returns the tools when ``AGENT_MEMORY_STORE`` is set, else an empty list, so the
-model never sees them when memory is unconfigured. ``create_agent_graph`` composes them into its
+``memory_tools(actor)`` returns the tools when ``AGENT_MEMORY_STORE`` is set, else an empty list, so
+the model never sees them when memory is unconfigured. ``create_agent_graph`` composes them into its
 tool list. This is a stand-in for a future ``databricks-langchain`` memory helper — when the SDK
 provides one, swap the import in ``agent.py`` and delete this file.
 
-Memory entries are per-actor. This uses the store name as the actor id, giving the agent one shared
-long-term memory; change ``_actor_id`` to scope per user (e.g. from request context) if needed.
+Memory entries are per-actor. ``actor`` is the identity whose memory these tools read and write — the
+caller (the agent server) supplies it, typically the signed-in user, so each user gets their own
+long-term memory. It is **closed over**, not a tool argument: the model only ever sees ``remember``'s
+and ``recall``'s own parameters and cannot set or spoof the actor. Pass a fixed value for one shared
+memory (e.g. a team knowledge base).
 """
 
 import os
@@ -22,10 +25,6 @@ from databricks_mason.runtime.workspace import workspace_client
 _AGENTS_V1 = "/api/agents/v1"
 
 
-def _actor_id() -> str:
-    return os.getenv("AGENT_MEMORY_ACTOR_ID", "agent")
-
-
 def _store_path() -> str:
     return f"{_AGENTS_V1}/memory-stores/{os.environ['AGENT_MEMORY_STORE']}"
 
@@ -35,29 +34,34 @@ def _api():
     return workspace_client().api_client
 
 
-@tool
-def remember(fact: str, topic: str) -> str:
-    """Persist a durable fact about the user in long-term memory."""
-    _api().do(
-        "POST",
-        f"{_store_path()}/entries",
-        body={"actor_id": _actor_id(), "path": f"/{topic}/{fact[:8]}.md", "content": fact},
-    )
-    return "stored"
+def memory_tools(actor: str) -> list[BaseTool]:
+    """The long-term-memory tools for ``actor`` when ``AGENT_MEMORY_STORE`` is set, else none.
 
+    ``actor`` partitions the memory store; it is captured in the tools' closures (not exposed to the
+    model). Call this per request with the identity whose memory to use (e.g. the signed-in user).
+    """
+    if not os.getenv("AGENT_MEMORY_STORE"):
+        return []
 
-@tool
-def recall(query: str) -> str:
-    """Search the user's long-term memory for facts relevant to the query."""
-    data = _api().do(
-        "POST",
-        f"{_store_path()}/entries:search",
-        body={"actor_id": _actor_id(), "query": query, "limit": 5},
-    )
-    entries = data.get("managed_memory_entries") or []
-    return "\n".join(f"- {e.get('content')}" for e in entries) or "No relevant memories."
+    @tool
+    def remember(fact: str, topic: str) -> str:
+        """Persist a durable fact about the user in long-term memory."""
+        _api().do(
+            "POST",
+            f"{_store_path()}/entries",
+            body={"actor_id": actor, "path": f"/{topic}/{fact[:8]}.md", "content": fact},
+        )
+        return "stored"
 
+    @tool
+    def recall(query: str) -> str:
+        """Search the user's long-term memory for facts relevant to the query."""
+        data = _api().do(
+            "POST",
+            f"{_store_path()}/entries:search",
+            body={"actor_id": actor, "query": query, "limit": 5},
+        )
+        entries = data.get("managed_memory_entries") or []
+        return "\n".join(f"- {e.get('content')}" for e in entries) or "No relevant memories."
 
-def memory_tools() -> list[BaseTool]:
-    """The long-term-memory tools when ``AGENT_MEMORY_STORE`` is set, else none."""
-    return [remember, recall] if os.getenv("AGENT_MEMORY_STORE") else []
+    return [remember, recall]

--- a/integrations/mason/src/databricks_mason/langgraph/session_store.py
+++ b/integrations/mason/src/databricks_mason/langgraph/session_store.py
@@ -74,15 +74,15 @@ def checkpointer() -> BaseCheckpointSaver:
     return _saver
 
 
-def thread_config(session_id: str) -> dict:
+def thread_config(session_id: str, actor: str | None = None) -> dict:
     """Run config that anchors this request to ``session_id``'s conversation thread.
 
     Includes ``actor_id`` because the durable saver maps it onto the Session's actor; it's ignored by
-    the in-memory default. ``AGENT_SESSION_ACTOR_ID`` selects the actor partition; without it, each
-    session id is its own actor for backward compatibility.
+    the in-memory default. ``actor`` partitions the durable store — the caller supplies it (typically
+    the signed-in user), so each user's threads stay separate; it defaults to ``session_id`` (one
+    actor per conversation).
     """
-    actor_id = os.getenv("AGENT_SESSION_ACTOR_ID") or session_id
-    return {"configurable": {"thread_id": session_id, "actor_id": actor_id}}
+    return {"configurable": {"thread_id": session_id, "actor_id": actor or session_id}}
 
 
 class DatabricksSessionStoreSaver(BaseCheckpointSaver[str]):

--- a/integrations/mason/src/databricks_mason/langgraph/session_store.py
+++ b/integrations/mason/src/databricks_mason/langgraph/session_store.py
@@ -23,7 +23,6 @@ from __future__ import annotations
 import base64
 import builtins
 import hashlib
-import os
 import random
 from collections import defaultdict
 from typing import Any, Iterator, Optional, Sequence
@@ -43,8 +42,6 @@ from langgraph.checkpoint.memory import InMemorySaver
 
 from databricks_mason.runtime.session_store_client import Session, SessionStoreClient
 
-_SESSION_STORE_ENV = "AGENT_SESSION_STORE"
-
 # Discriminators stored inside each session item's `data` JSON.
 _EVENT_CHECKPOINT = "checkpoint"
 _EVENT_CHANNEL_DATA = "channel_data"
@@ -61,15 +58,18 @@ _ORDER_BY = "create_time asc"
 _saver: BaseCheckpointSaver | None = None
 
 
-def checkpointer() -> BaseCheckpointSaver:
+def checkpointer(store: str | None = None) -> BaseCheckpointSaver:
     """The checkpointer the agent persists conversation state to (built once, then shared).
 
-    In-memory by default; a durable ``DatabricksSessionStoreSaver`` when ``AGENT_SESSION_STORE`` names
-    a managed Session Store.
+    In-memory by default; a durable ``DatabricksSessionStoreSaver`` when a managed store is
+    configured. The store resolves ``store`` arg → ``AGENT_SESSION_STORE`` env → the
+    ``[session_store]`` binding in agent.toml (`mason sessions bind`) → none (in-memory).
     """
+    from databricks_mason.runtime.tool_manifest import resolve_session_store
+
     global _saver
     if _saver is None:
-        store = os.getenv(_SESSION_STORE_ENV)
+        store = resolve_session_store(store)
         _saver = DatabricksSessionStoreSaver(store) if store else InMemorySaver()
     return _saver
 

--- a/integrations/mason/src/databricks_mason/memory.py
+++ b/integrations/mason/src/databricks_mason/memory.py
@@ -102,12 +102,15 @@ def memory_bind(obj, store: str, source: pathlib.Path, no_create_stores: bool) -
 
     client = obj.client()
     if no_create_stores:
-        if _resolve_memory_store(client, store) is None:
+        with render.status(f"Resolving memory store '{store}'…"):
+            exists = _resolve_memory_store(client, store) is not None
+        if not exists:
             raise AgentCliError(
                 f"Memory store '{store}' does not exist (drop --no-create-stores to create it)."
             )
     else:
-        _ensure_memory_store(client, store)
+        with render.status(f"Provisioning memory store '{store}'…"):
+            _ensure_memory_store(client, store)
 
     project = AgentProject.load(source)
     project.bind_memory_store(store)
@@ -210,7 +213,8 @@ def _render_store_detail(obj, store: dict) -> None:
 @click.pass_obj
 def stores_create(obj, display_name, description) -> None:
     """Create a memory store."""
-    data = obj.client().create_memory_store(display_name, description)
+    with render.status(f"Creating memory store '{display_name}'…"):
+        data = obj.client().create_memory_store(display_name, description)
     if obj.output == "json":
         render.emit_json(data)
         return

--- a/integrations/mason/src/databricks_mason/memory.py
+++ b/integrations/mason/src/databricks_mason/memory.py
@@ -69,6 +69,78 @@ def entries() -> None:
     """Memory entries within a store, partitioned by actor."""
 
 
+# --- bind a store to an agent project (agent.toml) --------------------------
+
+
+def _source_option(function):
+    return click.option(
+        "--source",
+        type=click.Path(exists=True, file_okay=False, path_type=pathlib.Path),
+        default=pathlib.Path("."),
+        show_default=True,
+        help="Mason agent project containing agent.toml.",
+    )(function)
+
+
+@memory.command("bind")
+@click.argument("store")
+@_source_option
+@click.option(
+    "--no-create-stores",
+    is_flag=True,
+    help="Require the store to already exist. By default a missing store is created (idempotent).",
+)
+@click.pass_obj
+def memory_bind(obj, store: str, source: pathlib.Path, no_create_stores: bool) -> None:
+    """Bind memory STORE to the agent, declaring it in agent.toml (creating it if it doesn't exist).
+
+    `mason dev` / `mason deploy` sync the bound store into the deployment's app.yaml env and grant the
+    app access. Pass --no-create-stores to require the store to already exist.
+    """
+    from databricks_mason.agent_project import AgentProject
+    from databricks_mason.deploy import _ensure_memory_store, _resolve_memory_store
+
+    client = obj.client()
+    if no_create_stores:
+        if _resolve_memory_store(client, store) is None:
+            raise AgentCliError(
+                f"Memory store '{store}' does not exist (drop --no-create-stores to create it)."
+            )
+    else:
+        _ensure_memory_store(client, store)
+
+    project = AgentProject.load(source)
+    project.bind_memory_store(store)
+    project.write()
+    if obj.output == "json":
+        render.emit_json({"memory_store": store, "manifest": str(project.path)})
+        return
+    render.success(
+        f"Bound memory store '{store}'",
+        fields={"agent.toml": str(project.path)},
+        next_steps=["mason dev", "mason deploy <name>"],
+    )
+
+
+@memory.command("unbind")
+@_source_option
+@click.pass_obj
+def memory_unbind(obj, source: pathlib.Path) -> None:
+    """Remove the memory store binding from the agent's agent.toml.
+
+    Only edits agent.toml; the managed store itself is untouched (delete it with
+    `mason memory stores delete`).
+    """
+    from databricks_mason.agent_project import AgentProject
+
+    project = AgentProject.load(source)
+    if project.unbind_memory_store():
+        project.write()
+        render.success("Removed memory store binding", fields={"agent.toml": str(project.path)})
+    else:
+        click.echo(f"No memory store binding in {project.path}.")
+
+
 # --- stores -----------------------------------------------------------------
 
 

--- a/integrations/mason/src/databricks_mason/openai/__init__.py
+++ b/integrations/mason/src/databricks_mason/openai/__init__.py
@@ -31,7 +31,7 @@ from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from databricks_mason.openai.mcp import mcp_servers
-    from databricks_mason.openai.memory import memory_tools, recall, remember
+    from databricks_mason.openai.memory import memory_tools
     from databricks_mason.openai.sessions import session_store
     from databricks_mason.runtime import tag_session, workspace_client, workspace_headers
 
@@ -54,8 +54,6 @@ __all__ = [
     "mcp_servers",
     # Long-term memory tools (opt-in via AGENT_MEMORY_STORE) — add to your tool list.
     "memory_tools",
-    "remember",
-    "recall",
     # Session persistence — pass session_store(session_id) to Runner.run(session=...).
     "session_store",
     # MLflow tracing (OpenAI autolog bound in) — call configure_tracing() once at startup.
@@ -71,8 +69,6 @@ __all__ = [
 _MODULE_BY_NAME = {
     "mcp_servers": "databricks_mason.openai.mcp",
     "memory_tools": "databricks_mason.openai.memory",
-    "remember": "databricks_mason.openai.memory",
-    "recall": "databricks_mason.openai.memory",
     "session_store": "databricks_mason.openai.sessions",
     "tag_session": "databricks_mason.runtime",
     "workspace_client": "databricks_mason.runtime",

--- a/integrations/mason/src/databricks_mason/openai/memory.py
+++ b/integrations/mason/src/databricks_mason/openai/memory.py
@@ -16,8 +16,6 @@ and ``recall``'s own parameters and cannot set or spoof the actor. Pass a fixed 
 memory (e.g. a team knowledge base).
 """
 
-import os
-
 from agents import FunctionTool, function_tool
 
 from databricks_mason.runtime.workspace import workspace_client
@@ -25,30 +23,32 @@ from databricks_mason.runtime.workspace import workspace_client
 _AGENTS_V1 = "/api/agents/v1"
 
 
-def _store_path() -> str:
-    return f"{_AGENTS_V1}/memory-stores/{os.environ['AGENT_MEMORY_STORE']}"
-
-
 def _api():
     # Build the client lazily (needs workspace auth) so importing this module stays cheap.
     return workspace_client().api_client
 
 
-def memory_tools(actor: str) -> list[FunctionTool]:
-    """The long-term-memory tools for ``actor`` when ``AGENT_MEMORY_STORE`` is set, else none.
+def memory_tools(actor: str, store: str | None = None) -> list[FunctionTool]:
+    """The long-term-memory tools for ``actor`` when a memory store is configured, else none.
 
-    ``actor`` partitions the memory store; it is captured in the tools' closures (not exposed to the
-    model). Call this per request with the identity whose memory to use (e.g. the signed-in user).
+    The store resolves ``store`` arg → ``AGENT_MEMORY_STORE`` env → the ``[memory_store]`` binding in
+    agent.toml (`mason memory bind`) → none (no tools). ``actor`` partitions the store; it is captured
+    in the tools' closures (not exposed to the model). Call this per request with the identity whose
+    memory to use (e.g. the signed-in user).
     """
-    if not os.getenv("AGENT_MEMORY_STORE"):
+    from databricks_mason.runtime.tool_manifest import resolve_memory_store
+
+    store = resolve_memory_store(store)
+    if not store:
         return []
+    store_path = f"{_AGENTS_V1}/memory-stores/{store}"
 
     @function_tool
     def remember(fact: str, topic: str) -> str:
         """Persist a durable fact about the user in long-term memory."""
         _api().do(
             "POST",
-            f"{_store_path()}/entries",
+            f"{store_path}/entries",
             body={"actor_id": actor, "path": f"/{topic}/{fact[:8]}.md", "content": fact},
         )
         return "stored"
@@ -58,7 +58,7 @@ def memory_tools(actor: str) -> list[FunctionTool]:
         """Search the user's long-term memory for facts relevant to the query."""
         data = _api().do(
             "POST",
-            f"{_store_path()}/entries:search",
+            f"{store_path}/entries:search",
             body={"actor_id": actor, "query": query, "limit": 5},
         )
         entries = data.get("managed_memory_entries") or []

--- a/integrations/mason/src/databricks_mason/openai/memory.py
+++ b/integrations/mason/src/databricks_mason/openai/memory.py
@@ -4,13 +4,16 @@ Unlike the session store (short-term transcript for one conversation), long-term
 to the model as two tools — ``remember`` and ``recall`` — over the Databricks managed memory store's
 ``agents/v1`` entries API. Facts persist across conversations.
 
-``memory_tools()`` returns the tools when ``AGENT_MEMORY_STORE`` is set, else an empty list, so the
-model never sees them when memory is unconfigured. The agent composes them into its tool list. This
-is a stand-in for a future ``databricks-openai`` memory helper — when the SDK provides one, swap the
-import in ``agent.py`` and delete this file.
+``memory_tools(actor)`` returns the tools when ``AGENT_MEMORY_STORE`` is set, else an empty list, so
+the model never sees them when memory is unconfigured. The agent composes them into its tool list.
+This is a stand-in for a future ``databricks-openai`` memory helper — when the SDK provides one, swap
+the import in ``agent.py`` and delete this file.
 
-Memory entries are per-actor. This uses the store name as the actor id, giving the agent one shared
-long-term memory; change ``_actor_id`` to scope per user (e.g. from request context) if needed.
+Memory entries are per-actor. ``actor`` is the identity whose memory these tools read and write — the
+caller (the agent server) supplies it, typically the signed-in user, so each user gets their own
+long-term memory. It is **closed over**, not a tool argument: the model only ever sees ``remember``'s
+and ``recall``'s own parameters and cannot set or spoof the actor. Pass a fixed value for one shared
+memory (e.g. a team knowledge base).
 """
 
 import os
@@ -22,10 +25,6 @@ from databricks_mason.runtime.workspace import workspace_client
 _AGENTS_V1 = "/api/agents/v1"
 
 
-def _actor_id() -> str:
-    return os.getenv("AGENT_MEMORY_ACTOR_ID", "agent")
-
-
 def _store_path() -> str:
     return f"{_AGENTS_V1}/memory-stores/{os.environ['AGENT_MEMORY_STORE']}"
 
@@ -35,29 +34,34 @@ def _api():
     return workspace_client().api_client
 
 
-@function_tool
-def remember(fact: str, topic: str) -> str:
-    """Persist a durable fact about the user in long-term memory."""
-    _api().do(
-        "POST",
-        f"{_store_path()}/entries",
-        body={"actor_id": _actor_id(), "path": f"/{topic}/{fact[:8]}.md", "content": fact},
-    )
-    return "stored"
+def memory_tools(actor: str) -> list[FunctionTool]:
+    """The long-term-memory tools for ``actor`` when ``AGENT_MEMORY_STORE`` is set, else none.
 
+    ``actor`` partitions the memory store; it is captured in the tools' closures (not exposed to the
+    model). Call this per request with the identity whose memory to use (e.g. the signed-in user).
+    """
+    if not os.getenv("AGENT_MEMORY_STORE"):
+        return []
 
-@function_tool
-def recall(query: str) -> str:
-    """Search the user's long-term memory for facts relevant to the query."""
-    data = _api().do(
-        "POST",
-        f"{_store_path()}/entries:search",
-        body={"actor_id": _actor_id(), "query": query, "limit": 5},
-    )
-    entries = data.get("managed_memory_entries") or []
-    return "\n".join(f"- {e.get('content')}" for e in entries) or "No relevant memories."
+    @function_tool
+    def remember(fact: str, topic: str) -> str:
+        """Persist a durable fact about the user in long-term memory."""
+        _api().do(
+            "POST",
+            f"{_store_path()}/entries",
+            body={"actor_id": actor, "path": f"/{topic}/{fact[:8]}.md", "content": fact},
+        )
+        return "stored"
 
+    @function_tool
+    def recall(query: str) -> str:
+        """Search the user's long-term memory for facts relevant to the query."""
+        data = _api().do(
+            "POST",
+            f"{_store_path()}/entries:search",
+            body={"actor_id": actor, "query": query, "limit": 5},
+        )
+        entries = data.get("managed_memory_entries") or []
+        return "\n".join(f"- {e.get('content')}" for e in entries) or "No relevant memories."
 
-def memory_tools() -> list[FunctionTool]:
-    """The long-term-memory tools when ``AGENT_MEMORY_STORE`` is set, else none."""
-    return [remember, recall] if os.getenv("AGENT_MEMORY_STORE") else []
+    return [remember, recall]

--- a/integrations/mason/src/databricks_mason/openai/sessions.py
+++ b/integrations/mason/src/databricks_mason/openai/sessions.py
@@ -25,7 +25,6 @@ unpublished dependency; swap it for the published package when it lands.
 
 from __future__ import annotations
 
-import os
 from typing import Any, Optional
 
 from agents import SQLiteSession, TResponseInputItem
@@ -33,8 +32,6 @@ from agents.memory import SessionABC
 
 from databricks_mason.runtime.session_store_client import Session as _StoreSession
 from databricks_mason.runtime.session_store_client import SessionStoreClient
-
-_SESSION_STORE_ENV = "AGENT_SESSION_STORE"
 
 # Fetch items oldest-first so the transcript replays in write order.
 _ORDER_BY = "create_time asc"
@@ -44,15 +41,20 @@ _ORDER_BY = "create_time asc"
 _local_sessions: dict[str, SQLiteSession] = {}
 
 
-def session_store(session_id: str, actor: str | None = None) -> SessionABC:
+def session_store(
+    session_id: str, actor: str | None = None, store: str | None = None
+) -> SessionABC:
     """The Session the agent persists conversation state to for ``session_id``.
 
-    In-memory ``SQLiteSession`` by default; a durable ``DatabricksSessionStore`` when
-    ``AGENT_SESSION_STORE`` names a managed Session Store. ``actor`` partitions the durable store —
-    the caller supplies it (typically the signed-in user), so each user's transcripts stay separate;
-    it defaults to ``session_id`` (one actor per conversation) and is ignored by the in-memory store.
+    In-memory ``SQLiteSession`` by default; a durable ``DatabricksSessionStore`` when a managed store
+    is configured. The store name resolves ``store`` arg → ``AGENT_SESSION_STORE`` env → the
+    ``[session_store]`` binding in agent.toml (`mason sessions bind`) → none. ``actor`` partitions the
+    durable store — the caller supplies it (typically the signed-in user), so each user's transcripts
+    stay separate; it defaults to ``session_id`` and is ignored by the in-memory store.
     """
-    store = os.getenv(_SESSION_STORE_ENV)
+    from databricks_mason.runtime.tool_manifest import resolve_session_store
+
+    store = resolve_session_store(store)
     if store:
         return DatabricksSessionStore(session_id, store, actor_id=actor or session_id)
     cached = _local_sessions.get(session_id)

--- a/integrations/mason/src/databricks_mason/openai/sessions.py
+++ b/integrations/mason/src/databricks_mason/openai/sessions.py
@@ -35,7 +35,6 @@ from databricks_mason.runtime.session_store_client import Session as _StoreSessi
 from databricks_mason.runtime.session_store_client import SessionStoreClient
 
 _SESSION_STORE_ENV = "AGENT_SESSION_STORE"
-_SESSION_ACTOR_ENV = "AGENT_SESSION_ACTOR_ID"
 
 # Fetch items oldest-first so the transcript replays in write order.
 _ORDER_BY = "create_time asc"
@@ -45,20 +44,17 @@ _ORDER_BY = "create_time asc"
 _local_sessions: dict[str, SQLiteSession] = {}
 
 
-def _session_actor(session_id: str) -> str:
-    """Actor partition for the durable store. Defaults to the session id (one actor per session)."""
-    return os.getenv(_SESSION_ACTOR_ENV) or session_id
-
-
-def session_store(session_id: str) -> SessionABC:
+def session_store(session_id: str, actor: str | None = None) -> SessionABC:
     """The Session the agent persists conversation state to for ``session_id``.
 
     In-memory ``SQLiteSession`` by default; a durable ``DatabricksSessionStore`` when
-    ``AGENT_SESSION_STORE`` names a managed Session Store.
+    ``AGENT_SESSION_STORE`` names a managed Session Store. ``actor`` partitions the durable store —
+    the caller supplies it (typically the signed-in user), so each user's transcripts stay separate;
+    it defaults to ``session_id`` (one actor per conversation) and is ignored by the in-memory store.
     """
     store = os.getenv(_SESSION_STORE_ENV)
     if store:
-        return DatabricksSessionStore(session_id, store, actor_id=_session_actor(session_id))
+        return DatabricksSessionStore(session_id, store, actor_id=actor or session_id)
     cached = _local_sessions.get(session_id)
     if cached is None:
         cached = SQLiteSession(session_id)  # ":memory:" — process-local, non-durable

--- a/integrations/mason/src/databricks_mason/render.py
+++ b/integrations/mason/src/databricks_mason/render.py
@@ -7,7 +7,8 @@ Functions accept an optional `console` for testability; default is stdout.
 from __future__ import annotations
 
 import json
-from typing import Any, Iterable, Literal, Optional, Sequence
+from contextlib import contextmanager
+from typing import Any, Iterable, Iterator, Literal, Optional, Sequence
 
 import click
 from rich import box
@@ -26,6 +27,18 @@ _stdout = Console()
 
 def console() -> Console:
     return _stdout
+
+
+@contextmanager
+def status(message: str, con: Optional[Console] = None) -> Iterator[None]:
+    """Show an animated spinner with ``message`` while a slow call runs, then clear it.
+
+    Wraps ``rich``'s console status; a no-op spinner (no TTY) still runs the body. Use around
+    network work like store provisioning so the CLI doesn't look hung.
+    """
+    con = con or _stdout
+    with con.status(message, spinner="dots"):
+        yield
 
 
 # --- small helpers -----------------------------------------------------------

--- a/integrations/mason/src/databricks_mason/runtime/tool_manifest.py
+++ b/integrations/mason/src/databricks_mason/runtime/tool_manifest.py
@@ -12,6 +12,13 @@ try:
 except ModuleNotFoundError:
     import tomli as tomllib
 
+# agent.toml table names for the managed store bindings (`mason memory/sessions bind`) and the env
+# vars that override them at deploy time.
+MEMORY_STORE_TABLE = "memory_store"
+SESSION_STORE_TABLE = "session_store"
+MEMORY_STORE_ENV = "AGENT_MEMORY_STORE"
+SESSION_STORE_ENV = "AGENT_SESSION_STORE"
+
 
 @dataclass(frozen=True)
 class ScopeRecord:
@@ -133,6 +140,46 @@ def load_tools(*, expected_framework: str) -> tuple[ToolRecord, ...]:
     if len(ids) != len(set(ids)):
         raise RuntimeError("agent.toml tool ids must be unique.")
     return tools
+
+
+def store_binding(table: str) -> str | None:
+    """The store ``name`` declared in agent.toml's ``[memory_store]`` / ``[session_store]``, or None.
+
+    Read at runtime so `mason memory/sessions bind` (which writes these tables) takes effect without
+    any env plumbing. Returns None when the project has no agent.toml, no such table, or no name — the
+    adapters treat that as "unbound" and fall back to their default. Never raises: a malformed or
+    missing manifest just means "no binding here".
+    """
+    try:
+        path = project_root() / "agent.toml"
+        with path.open("rb") as input_file:
+            document: dict[str, Any] = tomllib.load(input_file)
+    except (RuntimeError, OSError, tomllib.TOMLDecodeError):
+        return None
+    section = document.get(table)
+    if isinstance(section, dict):
+        name = section.get("name")
+        if isinstance(name, str) and name:
+            return name
+    return None
+
+
+def resolve_memory_store(explicit: str | None = None) -> str | None:
+    """The memory store name: ``explicit`` arg → ``AGENT_MEMORY_STORE`` env → agent.toml binding.
+
+    The one place the store-resolution precedence lives, shared by the framework adapters and the
+    chat-app UI so they always agree on which store is in effect. None means "no memory store".
+    """
+    return explicit or os.getenv(MEMORY_STORE_ENV) or store_binding(MEMORY_STORE_TABLE)
+
+
+def resolve_session_store(explicit: str | None = None) -> str | None:
+    """The session store name: ``explicit`` arg → ``AGENT_SESSION_STORE`` env → agent.toml binding.
+
+    Shared precedence for the framework adapters and the chat-app UI (see ``resolve_memory_store``).
+    None means "no session store" (the in-memory default).
+    """
+    return explicit or os.getenv(SESSION_STORE_ENV) or store_binding(SESSION_STORE_TABLE)
 
 
 def downscope_wire(tool: ToolRecord) -> dict[str, list[dict[str, str]]]:

--- a/integrations/mason/src/databricks_mason/sessions.py
+++ b/integrations/mason/src/databricks_mason/sessions.py
@@ -72,14 +72,16 @@ def sessions_bind(obj, store: str, source: pathlib.Path, no_create_stores: bool)
     client = obj.client()
     if no_create_stores:
         try:
-            client.get_session_store(store)
+            with render.status(f"Resolving session store '{store}'…"):
+                client.get_session_store(store)
         except AgentCliError as exc:
             raise AgentCliError(
                 f"Session store '{store}' does not exist (drop --no-create-stores to create it).",
                 error_code=exc.error_code,
             ) from exc
     else:
-        _ensure_session_store(client, store)
+        with render.status(f"Provisioning session store '{store}'…"):
+            _ensure_session_store(client, store)
 
     project = AgentProject.load(source)
     project.bind_session_store(store)
@@ -145,7 +147,8 @@ def _render_store_detail(store: dict) -> None:
 @click.pass_obj
 def stores_create(obj, name, description, metadata) -> None:
     """Create a session store."""
-    data = obj.client().create_session_store(name, description, _parse_metadata(metadata))
+    with render.status(f"Creating session store '{name}'…"):
+        data = obj.client().create_session_store(name, description, _parse_metadata(metadata))
     if obj.output == "json":
         render.emit_json(data)
         return

--- a/integrations/mason/src/databricks_mason/sessions.py
+++ b/integrations/mason/src/databricks_mason/sessions.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import pathlib
 from typing import Any, Optional
 
 import click
@@ -35,6 +36,81 @@ def stores() -> None:
 @sessions.group()
 def items() -> None:
     """Transcript items within a session."""
+
+
+# --- bind a store to an agent project (agent.toml) --------------------------
+
+
+def _source_option(function):
+    return click.option(
+        "--source",
+        type=click.Path(exists=True, file_okay=False, path_type=pathlib.Path),
+        default=pathlib.Path("."),
+        show_default=True,
+        help="Mason agent project containing agent.toml.",
+    )(function)
+
+
+@sessions.command("bind")
+@click.argument("store")
+@_source_option
+@click.option(
+    "--no-create-stores",
+    is_flag=True,
+    help="Require the store to already exist. By default a missing store is created (idempotent).",
+)
+@click.pass_obj
+def sessions_bind(obj, store: str, source: pathlib.Path, no_create_stores: bool) -> None:
+    """Bind session STORE to the agent, declaring it in agent.toml (creating it if it doesn't exist).
+
+    `mason dev` / `mason deploy` sync the bound store into the deployment's app.yaml env and grant the
+    app access. Pass --no-create-stores to require the store to already exist.
+    """
+    from databricks_mason.agent_project import AgentProject
+    from databricks_mason.deploy import _ensure_session_store
+
+    client = obj.client()
+    if no_create_stores:
+        try:
+            client.get_session_store(store)
+        except AgentCliError as exc:
+            raise AgentCliError(
+                f"Session store '{store}' does not exist (drop --no-create-stores to create it).",
+                error_code=exc.error_code,
+            ) from exc
+    else:
+        _ensure_session_store(client, store)
+
+    project = AgentProject.load(source)
+    project.bind_session_store(store)
+    project.write()
+    if obj.output == "json":
+        render.emit_json({"session_store": store, "manifest": str(project.path)})
+        return
+    render.success(
+        f"Bound session store '{store}'",
+        fields={"agent.toml": str(project.path)},
+        next_steps=["mason dev", "mason deploy <name>"],
+    )
+
+
+@sessions.command("unbind")
+@_source_option
+@click.pass_obj
+def sessions_unbind(obj, source: pathlib.Path) -> None:
+    """Remove the session store binding from the agent's agent.toml.
+
+    Only edits agent.toml; the managed store itself is untouched (delete it with
+    `mason sessions stores delete`).
+    """
+    from databricks_mason.agent_project import AgentProject
+
+    project = AgentProject.load(source)
+    if project.unbind_session_store():
+        project.write()
+        render.success("Removed session store binding", fields={"agent.toml": str(project.path)})
+    else:
+        click.echo(f"No session store binding in {project.path}.")
 
 
 # --- session stores ---------------------------------------------------------

--- a/integrations/mason/templates/agent-langgraph/.env.example
+++ b/integrations/mason/templates/agent-langgraph/.env.example
@@ -22,9 +22,10 @@ DATABRICKS_CONFIG_PROFILE=DEFAULT
 
 # --- Optional: long-term memory tools ---
 # Leave UNSET to skip. Set to a managed memory store ID to register the remember/recall tools
-# (persist/search facts across conversations); see databricks_mason/langgraph/memory.py.
+# (persist/search facts across conversations); see databricks_mason/langgraph/memory.py. Memory is
+# partitioned per user: the agent uses the signed-in user as the actor (falls back to "agent"
+# locally); edit `_actor` in agent/agent.py to change that.
 # AGENT_MEMORY_STORE=<memory-store-id>
-# AGENT_MEMORY_ACTOR_ID=alice
 
 # --- Optional: durable state (managed Session Store) ---
 # Leave UNSET to keep the in-process LangGraph checkpointer (InMemorySaver): multi-turn and HITL
@@ -33,4 +34,3 @@ DATABRICKS_CONFIG_PROFILE=DEFAULT
 # durable graph state incl. paused HITL runs, over RPCs (no DB connection). Access uses your normal
 # Databricks auth (must have access to the store). See databricks_mason/langgraph/session_store.py.
 # AGENT_SESSION_STORE=my-agent-sessions
-# AGENT_SESSION_ACTOR_ID=alice

--- a/integrations/mason/templates/agent-langgraph/AGENTS.md
+++ b/integrations/mason/templates/agent-langgraph/AGENTS.md
@@ -111,7 +111,8 @@ a file to `agent/tools/`.
   survives restarts/replicas. Adapted from the first-party `databricks_agent_client.langgraph`
   prototype over a vendored REST client (`session_store_client.py`); swap both for the published
   package when it lands. Requires `thread_id` + `actor_id` in the run config (see `thread_config`);
-  `AGENT_SESSION_ACTOR_ID` selects the saver actor partition.
+  `thread_config(session_id, actor)` partitions by actor — the handler passes the signed-in user
+  (`_actor`), so each user's threads stay separate.
 - Background mode is in-memory / single-process — non-durable. The store is `databricks_mason/runtime/background.py`
   (wired in `runtime/runtime.py`); swap it for a durable backend for cross-restart/replica recovery.
 - Human-in-the-loop: tools in `REQUIRE_APPROVAL` (`agent/agent.py`) pause via LangChain's

--- a/integrations/mason/templates/agent-langgraph/README.md
+++ b/integrations/mason/templates/agent-langgraph/README.md
@@ -152,7 +152,8 @@ When initialized with the chat app (the default for `mason init --framework lang
   managed Session Store.
 - `GET /api/demo/memory/entries`, `POST /api/demo/memory/entries`, and
   `POST /api/demo/memory/search` for managed long-term memory. Created entries are tagged with the
-  current cookie-backed session id; actor partitioning comes from `AGENT_MEMORY_ACTOR_ID`.
+  current cookie-backed session id; entries are partitioned by the signed-in user (the request's
+  forwarded-identity header), so the panel shows that user's own memory.
 
 ### Human-in-the-loop (tool approval)
 
@@ -237,9 +238,9 @@ Deploy with the [Mason](../../README.md) CLI:
 mason deploy agent-langgraph --source .
 ```
 
-Add `--memory <name> --session <name> --actor-id <actor>` to wire managed state. Mason
-provisions or resolves the stores (creating them if missing), injects the store/actor env vars, and
-deploys the App.
+Add `--memory <name> --session <name>` to wire managed state. Mason provisions or resolves the
+stores (creating them if missing), injects the store env vars, and deploys the App. Memory and
+session data are partitioned per signed-in user automatically (see `_actor` in `agent/agent.py`).
 
 `app.yaml` carries the app's start command and env. By default the deployed app is the same lean
 backend: in-process session state, tracing off.
@@ -289,9 +290,7 @@ replicas, over RPCs only. No agent code changes; the checkpointer swap is the on
 | `DATABRICKS_CONFIG_PROFILE` | `DEFAULT` | Auth profile used to call the model (local dev) |
 | `PORT` | `8000` | Port the server listens on |
 | `AGENT_MEMORY_STORE` | _unset_ | Managed memory store ID → registers `remember`/`recall` long-term-memory tools |
-| `AGENT_MEMORY_ACTOR_ID` | `agent` | Actor partition used by memory tools |
 | `AGENT_SESSION_STORE` | _unset_ | Managed Session Store name → durable checkpointer (REST-backed); unset = in-process `InMemorySaver` |
-| `AGENT_SESSION_ACTOR_ID` | session id | Actor used by the durable saver |
 | `MLFLOW_TRACKING_URI` | _unset_ | Trace destination (e.g. `databricks`). A destination + an experiment enables tracing |
 | `MLFLOW_TRACING_DESTINATION` | _unset_ | Alt destination — experiment id or `catalog.schema` (either destination var works) |
 | `MLFLOW_EXPERIMENT_ID` | _unset_ | Experiment to trace to (by id) |

--- a/integrations/mason/templates/agent-langgraph/agent/agent.py
+++ b/integrations/mason/templates/agent-langgraph/agent/agent.py
@@ -73,12 +73,16 @@ def _check_databricks_auth() -> None:
         ) from e
 
 
-async def create_agent_graph():
-    """Build the LangGraph agent: local tools + long-term-memory tools + any MCP tools."""
+async def create_agent_graph(actor: str):
+    """Build the LangGraph agent: local tools + long-term-memory tools + any MCP tools.
+
+    ``actor`` is the identity whose long-term memory the agent reads/writes; it's captured in the
+    memory tools' closures (never exposed to the model). See ``_actor``.
+    """
     # Join the manifest's MCP servers (from agent.toml) with your own hand-declared ones (mcps.py),
     # then fetch their tools. Edit build_mcp_servers in agent/mcps.py to add servers.
     mcp = await mcp_tools(build_mcp_servers())
-    tools = [*all_tools(), *memory_tools(), *mcp]
+    tools = [*all_tools(), *memory_tools(actor), *mcp]
     middleware = (
         [HumanInTheLoopMiddleware(interrupt_on=REQUIRE_APPROVAL)] if REQUIRE_APPROVAL else []
     )
@@ -97,6 +101,17 @@ def _session_id(request: dict) -> str:
     the handler after resolving the deployed Apps cookie or the local-development fallback cookie.
     """
     return str(request["session_id"])
+
+
+def _actor(request: dict) -> str:
+    """The identity that owns this request's memory and session data.
+
+    The runtime injects ``actor`` from the request's signed-in user (a forwarded-identity header the
+    deployment platform sets); it partitions long-term memory and the durable session store so each
+    user's data stays separate. Falls back to ``"agent"`` (one shared identity) when no user is
+    present — e.g. local development. Change this to key off a tenant id or anything else you prefer.
+    """
+    return str(request.get("actor") or "agent")
 
 
 async def invoke_handler(request: dict) -> dict:
@@ -125,9 +140,10 @@ async def invoke_handler(request: dict) -> dict:
 async def stream_handler(request: dict) -> AsyncGenerator[dict, None]:
     """Stream the agent's run events as JSON dicts. Called by the runtime when stream=true."""
     session_id = _session_id(request)
+    actor = _actor(request)
     tag_session(session_id)
 
-    agent = await create_agent_graph()
+    agent = await create_agent_graph(actor)
     # A `resume` payload continues a session paused awaiting approval; otherwise start a new turn from
     # `input`. Either way the checkpointer keys off session_id's thread for prior history / paused state.
     # LangChain accepts message dicts natively, so `input` is passed straight through (new turn only).
@@ -138,7 +154,9 @@ async def stream_handler(request: dict) -> AsyncGenerator[dict, None]:
 
     async for event in _serialize_events(
         agent.astream(
-            input=agent_input, config=thread_config(session_id), stream_mode=["updates", "messages"]
+            input=agent_input,
+            config=thread_config(session_id, actor),
+            stream_mode=["updates", "messages"],
         )
     ):
         yield event

--- a/integrations/mason/templates/agent-langgraph/app.yaml
+++ b/integrations/mason/templates/agent-langgraph/app.yaml
@@ -12,14 +12,11 @@ command: ["uv", "run", "start-server"]
 #     value: "databricks"
 #   - name: MLFLOW_EXPERIMENT_ID
 #     value: "<experiment-id>"
-#   # Long-term memory tools: a managed memory store ID (registers remember/recall).
+#   # Long-term memory tools: a managed memory store ID (registers remember/recall). Memory is
+#   # partitioned per signed-in user automatically (see agent/agent.py `_actor`).
 #   - name: AGENT_MEMORY_STORE
 #     value: "<memory-store-id>"
-#   - name: AGENT_MEMORY_ACTOR_ID
-#     value: "alice"
 #   # Durable state: a managed Session Store name → checkpoints persisted via its REST API
 #   # (durable multi-turn + HITL pauses, no DB connection). Access uses the app's service principal.
 #   - name: AGENT_SESSION_STORE
 #     value: "<session-store-name>"
-#   - name: AGENT_SESSION_ACTOR_ID
-#     value: "alice"

--- a/integrations/mason/templates/agent-langgraph/pyproject.toml
+++ b/integrations/mason/templates/agent-langgraph/pyproject.toml
@@ -11,7 +11,7 @@ dependencies = [
     # The agent-side runtime helpers (databricks_mason.runtime) plus the agent stack they need
     # (langgraph, langchain, fastapi, mlflow, …) come from this extra — see the package's
     # [project.optional-dependencies] runtime.
-    "databricks-mason[runtime]>=0.1.1.dev0",
+    "databricks-mason[runtime]>=0.1.3.dev0",
     "uvicorn>=0.41.0",
     "python-dotenv>=1.2.1",
     "databricks-sdk>=0.79.0",

--- a/integrations/mason/templates/agent-langgraph/runtime/runtime.py
+++ b/integrations/mason/templates/agent-langgraph/runtime/runtime.py
@@ -40,6 +40,9 @@ _REQUEST_SESSION_ID_HEADER_KEY = (
 _TRACE_NAME_TAG = "mlflow.traceName"
 _ROUTING_COOKIE = "__Host-databricks-app-router"
 _LOCAL_SESSION_COOKIE = "mason-local-session"
+# Forwarded-identity headers for the signed-in user, in priority order — the deployment platform
+# sets these; absent locally. Their value becomes the request's actor (memory / session partition).
+_USER_HEADERS = ("X-Forwarded-Email", "X-Forwarded-User")
 
 # TODO: Replace the Apps routing cookie with X-Routing-Key when Databricks Apps supports it.
 
@@ -133,6 +136,16 @@ def build_app(invoke_handler: InvokeHandler, stream_handler: StreamHandler) -> F
         is_background = bool(data.pop(_REQUEST_BACKGROUND_PARAM_KEY, False))
         data.pop("session_id", None)
         data["session_id"] = request.state.session_id
+        # The signed-in user (from the platform's forwarded-identity headers) becomes the request's
+        # actor, so the agent partitions memory + session data per user. Absent (e.g. local dev) → the
+        # handler defaults it. Clients can't set it: any body value is dropped in favor of the header.
+        data.pop("actor", None)
+        actor = next(
+            (v for h in _USER_HEADERS if (v := request.headers.get(h))),
+            None,
+        )
+        if actor:
+            data["actor"] = actor
 
         if is_background:
             invocation_id = runs.start()

--- a/integrations/mason/templates/agent-langgraph/tests/test_agent.py
+++ b/integrations/mason/templates/agent-langgraph/tests/test_agent.py
@@ -79,9 +79,9 @@ def test_thread_config_from_session_id():
     }
 
 
-def test_thread_config_uses_configured_actor(monkeypatch):
-    monkeypatch.setenv("AGENT_SESSION_ACTOR_ID", "alice")
-    assert thread_config("abc-123") == {
+def test_thread_config_uses_supplied_actor():
+    # A caller-supplied actor (e.g. the signed-in user) partitions the durable store per user.
+    assert thread_config("abc-123", "alice") == {
         "configurable": {"thread_id": "abc-123", "actor_id": "alice"}
     }
 
@@ -239,9 +239,9 @@ async def test_agent_responds_end_to_end():
     from agent.agent import configure, create_agent_graph
 
     configure()
-    agent = await create_agent_graph()
+    agent = await create_agent_graph("test-actor")
     result = await agent.ainvoke(
         {"messages": [{"role": "user", "content": "Reply with the single word: pong"}]},
-        config=thread_config("test-e2e"),
+        config=thread_config("test-e2e", "test-actor"),
     )
     assert result["messages"][-1].content

--- a/integrations/mason/templates/agent-openai/.env.example
+++ b/integrations/mason/templates/agent-openai/.env.example
@@ -22,9 +22,10 @@ DATABRICKS_CONFIG_PROFILE=DEFAULT
 
 # --- Optional: long-term memory tools ---
 # Leave UNSET to skip. Set to a managed memory store ID to register the remember/recall tools
-# (persist/search facts across conversations); see databricks_mason/openai/memory.py.
+# (persist/search facts across conversations); see databricks_mason/openai/memory.py. Memory is
+# partitioned per user: the agent uses the signed-in user as the actor (falls back to "agent"
+# locally); edit `_actor` in agent/agent.py to change that.
 # AGENT_MEMORY_STORE=<memory-store-id>
-# AGENT_MEMORY_ACTOR_ID=alice
 
 # --- Optional: durable state (managed Session Store) ---
 # Leave UNSET to keep the in-process session (SQLiteSession in :memory:): multi-turn works within one
@@ -34,4 +35,3 @@ DATABRICKS_CONFIG_PROFILE=DEFAULT
 # store). NOTE: this persists the transcript only; paused human-in-the-loop runs are in-process even
 # when this is set. See databricks_mason/openai/sessions.py.
 # AGENT_SESSION_STORE=my-agent-sessions
-# AGENT_SESSION_ACTOR_ID=alice

--- a/integrations/mason/templates/agent-openai/AGENTS.md
+++ b/integrations/mason/templates/agent-openai/AGENTS.md
@@ -111,7 +111,8 @@ add a file to `agent/tools/`.
   returns a `DatabricksSessionStore` — an Agents SDK `Session` that stores each Responses item via the
   Session Store REST API (no DB connection), so the transcript survives restarts/replicas. Over a
   vendored REST client (`session_store_client.py`); swap for the published package when it lands.
-  `AGENT_SESSION_ACTOR_ID` selects the actor partition.
+  `session_store(session_id, actor)` partitions by actor — the handler passes the signed-in user
+  (`_actor`), so each user's threads stay separate.
 - Background mode is in-memory / single-process — non-durable. The store is
   `databricks_mason/runtime/background.py` (wired in `runtime/runtime.py`); swap it for a durable
   backend for cross-restart/replica recovery.

--- a/integrations/mason/templates/agent-openai/README.md
+++ b/integrations/mason/templates/agent-openai/README.md
@@ -153,7 +153,8 @@ When initialized with the chat app (the default for `mason init --framework open
   managed Session Store.
 - `GET /api/demo/memory/entries`, `POST /api/demo/memory/entries`, and
   `POST /api/demo/memory/search` for managed long-term memory. Created entries are tagged with the
-  current cookie-backed session id; actor partitioning comes from `AGENT_MEMORY_ACTOR_ID`.
+  current cookie-backed session id; entries are partitioned by the signed-in user (the request's
+  forwarded-identity header), so the panel shows that user's own memory.
 
 ### Human-in-the-loop (tool approval)
 
@@ -236,9 +237,9 @@ Deploy with the [Mason](../../README.md) CLI:
 mason deploy agent-openai --source .
 ```
 
-Add `--memory <name> --session <name> --actor-id <actor>` to wire managed state. Mason
-provisions or resolves the stores (creating them if missing), injects the store/actor env vars, and
-deploys the App.
+Add `--memory <name> --session <name>` to wire managed state. Mason provisions or resolves the
+stores (creating them if missing), injects the store env vars, and deploys the App. Memory and
+session data are partitioned per signed-in user automatically (see `_actor` in `agent/agent.py`).
 
 `app.yaml` carries the app's start command and env. By default the deployed app is the same lean
 backend: in-process session state, tracing off.
@@ -292,9 +293,7 @@ only difference.
 | `DATABRICKS_CONFIG_PROFILE` | `DEFAULT` | Auth profile used to call the model (local dev) |
 | `PORT` | `8000` | Port the server listens on |
 | `AGENT_MEMORY_STORE` | _unset_ | Managed memory store ID → registers `remember`/`recall` long-term-memory tools |
-| `AGENT_MEMORY_ACTOR_ID` | `agent` | Actor partition used by memory tools |
 | `AGENT_SESSION_STORE` | _unset_ | Managed Session Store name → durable transcript (REST-backed); unset = in-process `SQLiteSession` |
-| `AGENT_SESSION_ACTOR_ID` | session id | Actor used by the durable session store |
 | `MLFLOW_TRACKING_URI` | _unset_ | Trace destination (e.g. `databricks`). A destination + an experiment enables tracing |
 | `MLFLOW_TRACING_DESTINATION` | _unset_ | Alt destination — experiment id or `catalog.schema` (either destination var works) |
 | `MLFLOW_EXPERIMENT_ID` | _unset_ | Experiment to trace to (by id) |

--- a/integrations/mason/templates/agent-openai/agent/agent.py
+++ b/integrations/mason/templates/agent-openai/agent/agent.py
@@ -71,13 +71,17 @@ def _check_databricks_auth() -> None:
         ) from e
 
 
-def create_agent(mcp=None) -> Agent:
-    """Build the OpenAI Agents SDK agent: local tools + long-term-memory tools + any MCP servers."""
+def create_agent(actor: str, mcp=None) -> Agent:
+    """Build the OpenAI Agents SDK agent: local tools + long-term-memory tools + any MCP servers.
+
+    ``actor`` is the identity whose long-term memory the agent reads/writes; it's captured in the
+    memory tools' closures (never exposed to the model). See ``_actor``.
+    """
     return Agent(
         name="Agent",
         instructions="You are a helpful assistant.",
         model=MODEL,
-        tools=[*all_tools(), *memory_tools()],
+        tools=[*all_tools(), *memory_tools(actor)],
         mcp_servers=mcp or [],
     )
 
@@ -89,6 +93,17 @@ def _session_id(request: dict) -> str:
     the handler after resolving the deployed Apps cookie or the local-development fallback cookie.
     """
     return str(request["session_id"])
+
+
+def _actor(request: dict) -> str:
+    """The identity that owns this request's memory and session data.
+
+    The runtime injects ``actor`` from the request's signed-in user (a forwarded-identity header the
+    deployment platform sets); it partitions long-term memory and the durable session store so each
+    user's data stays separate. Falls back to ``"agent"`` (one shared identity) when no user is
+    present — e.g. local development. Change this to key off a tenant id or anything else you prefer.
+    """
+    return str(request.get("actor") or "agent")
 
 
 async def invoke_handler(request: dict) -> dict:
@@ -117,6 +132,7 @@ async def invoke_handler(request: dict) -> dict:
 async def stream_handler(request: dict) -> AsyncGenerator[dict, None]:
     """Stream the agent's run events as JSON dicts. Called by the runtime when stream=true."""
     session_id = _session_id(request)
+    actor = _actor(request)
     tag_session(session_id)
 
     servers = await mcp_servers(build_mcp_servers())
@@ -141,7 +157,7 @@ async def stream_handler(request: dict) -> AsyncGenerator[dict, None]:
             finally:
                 server.tool_filter = tool_filter
 
-        agent = create_agent(mcp)
+        agent = create_agent(actor, mcp)
 
         # A `resume` payload continues a session paused awaiting approval; otherwise start a new turn
         # from `input`. A resumed run re-runs the stashed RunState (with decisions applied); a new
@@ -152,7 +168,9 @@ async def stream_handler(request: dict) -> AsyncGenerator[dict, None]:
             result = Runner.run_streamed(agent, run_input)
         else:
             result = Runner.run_streamed(
-                agent, request.get("input") or [], session=session_store(session_id)
+                agent,
+                request.get("input") or [],
+                session=session_store(session_id, actor),
             )
 
         async for event in _serialize_events(result, session_id):

--- a/integrations/mason/templates/agent-openai/app.yaml
+++ b/integrations/mason/templates/agent-openai/app.yaml
@@ -12,14 +12,11 @@ command: ["uv", "run", "start-server"]
 #     value: "databricks"
 #   - name: MLFLOW_EXPERIMENT_ID
 #     value: "<experiment-id>"
-#   # Long-term memory tools: a managed memory store ID (registers remember/recall).
+#   # Long-term memory tools: a managed memory store ID (registers remember/recall). Memory is
+#   # partitioned per signed-in user automatically (see agent/agent.py `_actor`).
 #   - name: AGENT_MEMORY_STORE
 #     value: "<memory-store-id>"
-#   - name: AGENT_MEMORY_ACTOR_ID
-#     value: "alice"
 #   # Durable state: a managed Session Store name → transcript persisted via its REST API
 #   # (durable multi-turn history, no DB connection). Access uses the app's service principal.
 #   - name: AGENT_SESSION_STORE
 #     value: "<session-store-name>"
-#   - name: AGENT_SESSION_ACTOR_ID
-#     value: "alice"

--- a/integrations/mason/templates/agent-openai/pyproject.toml
+++ b/integrations/mason/templates/agent-openai/pyproject.toml
@@ -11,7 +11,7 @@ dependencies = [
     # The agent-side runtime helpers (databricks_mason.runtime) plus the agent stack they need
     # (openai-agents, databricks-openai, fastapi, mlflow, …) come from this extra — see the package's
     # [project.optional-dependencies] runtime-openai.
-    "databricks-mason[runtime-openai]>=0.1.2.dev0",
+    "databricks-mason[runtime-openai]>=0.1.3.dev0",
     "uvicorn>=0.41.0",
     "python-dotenv>=1.2.1",
     "databricks-sdk>=0.79.0",

--- a/integrations/mason/templates/agent-openai/runtime/runtime.py
+++ b/integrations/mason/templates/agent-openai/runtime/runtime.py
@@ -40,6 +40,9 @@ _REQUEST_SESSION_ID_HEADER_KEY = (
 _TRACE_NAME_TAG = "mlflow.traceName"
 _ROUTING_COOKIE = "__Host-databricks-app-router"
 _LOCAL_SESSION_COOKIE = "mason-local-session"
+# Forwarded-identity headers for the signed-in user, in priority order — the deployment platform
+# sets these; absent locally. Their value becomes the request's actor (memory / session partition).
+_USER_HEADERS = ("X-Forwarded-Email", "X-Forwarded-User")
 
 # TODO: Replace the Apps routing cookie with X-Routing-Key when Databricks Apps supports it.
 
@@ -133,6 +136,16 @@ def build_app(invoke_handler: InvokeHandler, stream_handler: StreamHandler) -> F
         is_background = bool(data.pop(_REQUEST_BACKGROUND_PARAM_KEY, False))
         data.pop("session_id", None)
         data["session_id"] = request.state.session_id
+        # The signed-in user (from the platform's forwarded-identity headers) becomes the request's
+        # actor, so the agent partitions memory + session data per user. Absent (e.g. local dev) → the
+        # handler defaults it. Clients can't set it: any body value is dropped in favor of the header.
+        data.pop("actor", None)
+        actor = next(
+            (v for h in _USER_HEADERS if (v := request.headers.get(h))),
+            None,
+        )
+        if actor:
+            data["actor"] = actor
 
         if is_background:
             invocation_id = runs.start()

--- a/integrations/mason/templates/agent-openai/tests/test_agent.py
+++ b/integrations/mason/templates/agent-openai/tests/test_agent.py
@@ -106,7 +106,7 @@ async def test_stream_handler_omits_unavailable_mcp_servers(monkeypatch):
     monkeypatch.setattr(agent_module, "build_mcp_servers", lambda: [])
     monkeypatch.setattr(agent_module, "create_agent", create_agent)
     monkeypatch.setattr(agent_module, "tag_session", lambda _session_id: None)
-    monkeypatch.setattr(agent_module, "session_store", lambda _session_id: None)
+    monkeypatch.setattr(agent_module, "session_store", lambda _session_id, _actor: None)
     monkeypatch.setattr(
         agent_module.Runner,
         "run_streamed",
@@ -114,7 +114,8 @@ async def test_stream_handler_omits_unavailable_mcp_servers(monkeypatch):
     )
 
     assert [event async for event in agent_module.stream_handler({"session_id": "s"})] == []
-    assert create_agent.call_args.args[0] == [healthy]
+    # create_agent(actor, mcp) — the healthy servers are the second positional arg.
+    assert create_agent.call_args.args[1] == [healthy]
     assert healthy.cache_tools_list is True
     assert all(
         server.tool_filter is tool_filter
@@ -234,10 +235,10 @@ async def test_agent_responds_end_to_end():
     from databricks_mason.openai import session_store
 
     configure()
-    agent = create_agent()
+    agent = create_agent("test-actor")
     result = await Runner.run(
         agent,
         [{"role": "user", "content": "Reply with the single word: pong"}],
-        session=session_store("test-e2e"),
+        session=session_store("test-e2e", "test-actor"),
     )
     assert result.final_output

--- a/integrations/mason/templates/ui/agent-langgraph/runtime/ui.py
+++ b/integrations/mason/templates/ui/agent-langgraph/runtime/ui.py
@@ -19,8 +19,6 @@ from runtime.runtime import rotate_session_cookie
 
 _UI_ROOT = Path(__file__).resolve().parent.parent / "ui"
 _INSTANCE_ID = uuid.uuid4().hex[:12]  # identifies this process in the UI
-_MEMORY_STORE_ENV = "AGENT_MEMORY_STORE"
-_SESSION_STORE_ENV = "AGENT_SESSION_STORE"
 _AGENTS_API = "/api/agents/v1"
 _MESSAGE_ROLES = {
     "ai",
@@ -54,11 +52,17 @@ _USER_HEADERS = ("x-forwarded-email", "x-forwarded-user")
 
 
 def _memory_store() -> str:
-    return os.getenv(_MEMORY_STORE_ENV, "").strip().strip("/")
+    # Same resolution the agent uses (AGENT_MEMORY_STORE env → agent.toml binding), so the demo
+    # panels reflect exactly the store the agent reads/writes.
+    from databricks_mason.runtime.tool_manifest import resolve_memory_store
+
+    return (resolve_memory_store() or "").strip().strip("/")
 
 
 def _session_store() -> str:
-    return os.getenv(_SESSION_STORE_ENV, "").strip()
+    from databricks_mason.runtime.tool_manifest import resolve_session_store
+
+    return (resolve_session_store() or "").strip()
 
 
 def _request_actor(request: Request) -> str:
@@ -202,7 +206,7 @@ def _require_memory() -> None:
     if not _memory_store():
         raise HTTPException(
             status_code=503,
-            detail=f"Set {_MEMORY_STORE_ENV} by deploying with --memory.",
+            detail="No memory store configured. Run `mason memory bind <store>`.",
         )
 
 
@@ -210,7 +214,7 @@ def _require_session() -> None:
     if not _session_store():
         raise HTTPException(
             status_code=503,
-            detail=f"Set {_SESSION_STORE_ENV} by deploying with --session.",
+            detail="No session store configured. Run `mason sessions bind <store>`.",
         )
 
 

--- a/integrations/mason/templates/ui/agent-langgraph/runtime/ui.py
+++ b/integrations/mason/templates/ui/agent-langgraph/runtime/ui.py
@@ -20,9 +20,7 @@ from runtime.runtime import rotate_session_cookie
 _UI_ROOT = Path(__file__).resolve().parent.parent / "ui"
 _INSTANCE_ID = uuid.uuid4().hex[:12]  # identifies this process in the UI
 _MEMORY_STORE_ENV = "AGENT_MEMORY_STORE"
-_MEMORY_ACTOR_ENV = "AGENT_MEMORY_ACTOR_ID"
 _SESSION_STORE_ENV = "AGENT_SESSION_STORE"
-_SESSION_ACTOR_ENV = "AGENT_SESSION_ACTOR_ID"
 _AGENTS_API = "/api/agents/v1"
 _MESSAGE_ROLES = {
     "ai",
@@ -52,20 +50,28 @@ class SessionItemsRequest(BaseModel):
     items: list[dict[str, Any]] = Field(min_length=1)
 
 
+_USER_HEADERS = ("x-forwarded-email", "x-forwarded-user")
+
+
 def _memory_store() -> str:
     return os.getenv(_MEMORY_STORE_ENV, "").strip().strip("/")
-
-
-def _memory_actor() -> str:
-    return os.getenv(_MEMORY_ACTOR_ENV, "agent")
 
 
 def _session_store() -> str:
     return os.getenv(_SESSION_STORE_ENV, "").strip()
 
 
-def _session_actor() -> str:
-    return os.getenv(_SESSION_ACTOR_ENV) or _memory_actor()
+def _request_actor(request: Request) -> str:
+    """The actor for a demo request — the signed-in user, so the panels show that user's own data.
+
+    Mirrors how the agent resolves its actor (same forwarded-identity headers), so the memory and
+    session views here list exactly what the agent reads/writes for the current user. Falls back to
+    ``"agent"`` locally / when unauthenticated.
+    """
+    for header in _USER_HEADERS:
+        if value := request.headers.get(header):
+            return value
+    return "agent"
 
 
 def _is_deployed() -> bool:
@@ -93,9 +99,9 @@ class _ManagedStateClient:
             )
         return result
 
-    def create_memory_entry(self, request: MemoryEntryRequest, session_id: str) -> dict:
+    def create_memory_entry(self, actor: str, request: MemoryEntryRequest, session_id: str) -> dict:
         body = {
-            "actor_id": _memory_actor(),
+            "actor_id": actor,
             "path": request.path,
             "content": request.content,
             "session_id": session_id,
@@ -104,33 +110,33 @@ class _ManagedStateClient:
             body["description"] = request.description
         return self._do("POST", f"{_AGENTS_API}/memory-stores/{_memory_store()}/entries", body=body)
 
-    def list_memory_entries(self, path_prefix: str | None = None) -> dict:
-        query = {"actor_id": _memory_actor(), "page_size": 100}
+    def list_memory_entries(self, actor: str, path_prefix: str | None = None) -> dict:
+        query = {"actor_id": actor, "page_size": 100}
         if path_prefix:
             query["path_prefix"] = path_prefix
         return self._do(
             "GET", f"{_AGENTS_API}/memory-stores/{_memory_store()}/entries", query=query
         )
 
-    def search_memory_entries(self, request: MemorySearchRequest) -> dict:
+    def search_memory_entries(self, actor: str, request: MemorySearchRequest) -> dict:
         return self._do(
             "POST",
             f"{_AGENTS_API}/memory-stores/{_memory_store()}/entries:search",
             body={
-                "actor_id": _memory_actor(),
+                "actor_id": actor,
                 "query": request.query,
                 "limit": request.limit,
             },
         )
 
-    def ensure_session(self, session_id: str) -> dict:
+    def ensure_session(self, actor: str, session_id: str) -> dict:
         try:
             return self._do(
                 "POST",
                 f"{_AGENTS_API}/session-stores/{_session_store()}/sessions",
                 query={"session_id": session_id},
                 body={
-                    "actor_id": _session_actor(),
+                    "actor_id": actor,
                     "metadata": {"client": "mason-demo-ui"},
                 },
             )
@@ -150,12 +156,12 @@ class _ManagedStateClient:
             f"{_AGENTS_API}/session-stores/{_session_store()}/sessions/{session_id}",
         )
 
-    def list_sessions(self) -> dict:
+    def list_sessions(self, actor: str) -> dict:
         return self._do(
             "GET",
             f"{_AGENTS_API}/session-stores/{_session_store()}/sessions",
             query={
-                "filter": f"actor_id = {json.dumps(_session_actor())}",
+                "filter": f"actor_id = {json.dumps(actor)}",
                 "order_by": "last_activity_time desc",
                 "page_size": 50,
             },
@@ -208,12 +214,12 @@ def _require_session() -> None:
         )
 
 
-async def _checkpoint_history(session_id: str) -> dict[str, Any]:
+async def _checkpoint_history(session_id: str, actor: str) -> dict[str, Any]:
     from agent.agent import create_agent_graph
     from databricks_mason.langgraph.session_store import thread_config
 
-    graph = await create_agent_graph()
-    snapshot = await graph.aget_state(thread_config(session_id))
+    graph = await create_agent_graph(actor)
+    snapshot = await graph.aget_state(thread_config(session_id, actor))
     values = snapshot.values if isinstance(snapshot.values, dict) else {}
     items = []
     for index, message in enumerate(values.get("messages", [])):
@@ -269,17 +275,13 @@ def install_ui(app: FastAPI) -> None:
 
     @app.get("/api/demo/config", include_in_schema=False)
     async def demo_config(request: Request) -> dict:
-        viewer = (
-            request.headers.get("x-forwarded-email")
-            or request.headers.get("x-forwarded-user")
-            or "Local developer"
-        )
+        actor = _request_actor(request)
         memory_store = _memory_store()
         session_store = _session_store()
         return {
             "session_id": request.state.session_id,
             "instance_id": _INSTANCE_ID,
-            "viewer": viewer,
+            "viewer": actor if actor != "agent" else "Local developer",
             "deployed": _is_deployed(),
             "streaming": {"enabled": True, "transport": "Server-sent events"},
             "background": {"enabled": True, "durable": False},
@@ -289,12 +291,12 @@ def install_ui(app: FastAPI) -> None:
                 "history": True,
                 "mode": "Managed Session Store" if session_store else "In-process checkpointer",
                 "store": session_store or None,
-                "actor": _session_actor(),
+                "actor": actor,
             },
             "memory": {
                 "enabled": bool(memory_store),
                 "store": f"memory-stores/{memory_store}" if memory_store else None,
-                "actor": _memory_actor(),
+                "actor": actor,
             },
         }
 
@@ -302,42 +304,53 @@ def install_ui(app: FastAPI) -> None:
     async def create_memory_entry(request: Request, payload: MemoryEntryRequest) -> dict:
         _require_memory()
         return await _managed_call(
-            _state_client().create_memory_entry, payload, request.state.session_id
+            _state_client().create_memory_entry,
+            _request_actor(request),
+            payload,
+            request.state.session_id,
         )
 
     @app.get("/api/demo/memory/entries", include_in_schema=False)
     async def list_memory_entries(
+        request: Request,
         path_prefix: str | None = Query(default=None),
     ) -> dict:
         _require_memory()
-        return await _managed_call(_state_client().list_memory_entries, path_prefix)
+        return await _managed_call(
+            _state_client().list_memory_entries, _request_actor(request), path_prefix
+        )
 
     @app.post("/api/demo/memory/search", include_in_schema=False)
-    async def search_memory_entries(request: MemorySearchRequest) -> dict:
+    async def search_memory_entries(request: Request, payload: MemorySearchRequest) -> dict:
         _require_memory()
-        return await _managed_call(_state_client().search_memory_entries, request)
+        return await _managed_call(
+            _state_client().search_memory_entries, _request_actor(request), payload
+        )
 
     @app.post("/api/demo/sessions", include_in_schema=False)
     async def ensure_session(request: Request) -> dict:
         _require_session()
-        return await _managed_call(_state_client().ensure_session, request.state.session_id)
+        return await _managed_call(
+            _state_client().ensure_session, _request_actor(request), request.state.session_id
+        )
 
     @app.get("/api/demo/sessions", include_in_schema=False)
     async def list_sessions(request: Request) -> dict:
         session_id = request.state.session_id
+        actor = _request_actor(request)
         if not _session_store():
             return {
                 "sessions": [
                     {
                         "session_id": session_id,
-                        "actor_id": _session_actor(),
+                        "actor_id": actor,
                         "metadata": {"client": "mason-demo-ui-local"},
                     }
                 ],
                 "current_session_id": session_id,
                 "managed": False,
             }
-        result = await _managed_call(_state_client().list_sessions)
+        result = await _managed_call(_state_client().list_sessions, actor)
         return {
             **result,
             "sessions": _chat_sessions(result),
@@ -349,7 +362,7 @@ def install_ui(app: FastAPI) -> None:
     async def open_session(request: Request, session_id: str) -> JSONResponse:
         _require_session()
         session = await _managed_call(_state_client().get_session, session_id)
-        if session.get("actor_id") != _session_actor():
+        if session.get("actor_id") != _request_actor(request):
             raise HTTPException(status_code=403, detail="Session belongs to another actor.")
         previous_session_id = request.state.session_id
         request.state.session_id = session_id
@@ -383,4 +396,4 @@ def install_ui(app: FastAPI) -> None:
         if _session_store():
             result = await _managed_call(_state_client().list_session_items, session_id)
             return _chat_session_items(result)
-        return await _checkpoint_history(session_id)
+        return await _checkpoint_history(session_id, _request_actor(request))

--- a/integrations/mason/templates/ui/agent-langgraph/tests/test_demo_ui.py
+++ b/integrations/mason/templates/ui/agent-langgraph/tests/test_demo_ui.py
@@ -5,26 +5,27 @@ from runtime.runtime import build_app
 
 
 class _FakeStateClient:
-    def create_memory_entry(self, request, session_id):
+    def create_memory_entry(self, actor, request, session_id):
         return {
             "name": "memory-stores/store/entries/entry",
             "session_id": session_id,
+            "actor_id": actor,
             **request.model_dump(),
         }
 
-    def list_memory_entries(self, path_prefix=None):
+    def list_memory_entries(self, actor, path_prefix=None):
         return {"managed_memory_entries": [{"path": f"{path_prefix or ''}/profile.md"}]}
 
-    def search_memory_entries(self, request):
+    def search_memory_entries(self, actor, request):
         return {"managed_memory_entries": [{"path": "/profile.md", "content": request.query}]}
 
-    def ensure_session(self, session_id):
-        return {"session_id": session_id, "actor_id": "alice"}
+    def ensure_session(self, actor, session_id):
+        return {"session_id": session_id, "actor_id": actor}
 
     def get_session(self, session_id):
         return {"session_id": session_id, "actor_id": "alice"}
 
-    def list_sessions(self):
+    def list_sessions(self, actor):
         return {
             "sessions": [
                 {
@@ -71,7 +72,7 @@ class _FakeInterrupt:
         self.id = id
 
 
-async def _session_history(session_id):
+async def _session_history(session_id, actor):
     return {
         "session_id": session_id,
         "session_items": [
@@ -85,9 +86,7 @@ async def _session_history(session_id):
 def _client(monkeypatch, *, configured=False, history=False, session_id="routing-session"):
     if configured:
         monkeypatch.setenv("AGENT_MEMORY_STORE", "store")
-        monkeypatch.setenv("AGENT_MEMORY_ACTOR_ID", "alice")
         monkeypatch.setenv("AGENT_SESSION_STORE", "sessions")
-        monkeypatch.setenv("AGENT_SESSION_ACTOR_ID", "alice")
         monkeypatch.setattr(ui, "_state_client", lambda: _FakeStateClient())
     else:
         monkeypatch.delenv("AGENT_MEMORY_STORE", raising=False)
@@ -106,6 +105,10 @@ def _client(monkeypatch, *, configured=False, history=False, session_id="routing
     ui.install_ui(app)
     client = TestClient(app, base_url="https://testserver")
     client.cookies.set("__Host-databricks-app-router", session_id)
+    if configured:
+        # The actor is the signed-in user from this forwarded-identity header (ui._request_actor);
+        # unconfigured requests have no header and fall back to the "agent" actor.
+        client.headers["X-Forwarded-Email"] = "alice"
     return client
 
 
@@ -182,14 +185,14 @@ def test_unmanaged_checkpoint_history_route(monkeypatch):
 
 def test_managed_session_list_is_actor_scoped(monkeypatch):
     monkeypatch.setenv("AGENT_SESSION_STORE", "sessions")
-    monkeypatch.setenv("AGENT_SESSION_ACTOR_ID", 'alice "demo"')
     state_client = object.__new__(ui._ManagedStateClient)
     calls = []
     state_client._do = lambda method, path, **kwargs: calls.append((method, path, kwargs)) or {
         "sessions": []
     }
 
-    assert state_client.list_sessions() == {"sessions": []}
+    # The actor (a signed-in user) is escaped into the list filter.
+    assert state_client.list_sessions('alice "demo"') == {"sessions": []}
     assert calls == [
         (
             "GET",
@@ -231,8 +234,6 @@ def test_chat_session_items_exclude_non_message_items():
 async def test_checkpoint_history_reads_messages_and_interrupts(monkeypatch):
     import agent.agent as agent_module
 
-    monkeypatch.delenv("AGENT_SESSION_ACTOR_ID", raising=False)
-
     class Message:
         id = "message-1"
 
@@ -254,16 +255,17 @@ async def test_checkpoint_history_reads_messages_and_interrupts(monkeypatch):
             assert config == {
                 "configurable": {
                     "thread_id": "saved-session",
-                    "actor_id": "saved-session",
+                    "actor_id": "alice",
                 }
             }
             return Snapshot()
 
-    async def fake_create_agent_graph():
+    async def fake_create_agent_graph(actor):
+        assert actor == "alice"
         return FakeAgent()
 
     monkeypatch.setattr(agent_module, "create_agent_graph", fake_create_agent_graph)
-    result = await ui._checkpoint_history("saved-session")
+    result = await ui._checkpoint_history("saved-session", "alice")
 
     assert result == {
         "session_id": "saved-session",

--- a/integrations/mason/templates/ui/agent-openai/runtime/ui.py
+++ b/integrations/mason/templates/ui/agent-openai/runtime/ui.py
@@ -19,8 +19,6 @@ from runtime.runtime import rotate_session_cookie
 
 _UI_ROOT = Path(__file__).resolve().parent.parent / "ui"
 _INSTANCE_ID = uuid.uuid4().hex[:12]  # identifies this process in the UI
-_MEMORY_STORE_ENV = "AGENT_MEMORY_STORE"
-_SESSION_STORE_ENV = "AGENT_SESSION_STORE"
 _AGENTS_API = "/api/agents/v1"
 _MESSAGE_ROLES = {
     "ai",
@@ -54,11 +52,17 @@ _USER_HEADERS = ("x-forwarded-email", "x-forwarded-user")
 
 
 def _memory_store() -> str:
-    return os.getenv(_MEMORY_STORE_ENV, "").strip().strip("/")
+    # Same resolution the agent uses (AGENT_MEMORY_STORE env → agent.toml binding), so the demo
+    # panels reflect exactly the store the agent reads/writes.
+    from databricks_mason.runtime.tool_manifest import resolve_memory_store
+
+    return (resolve_memory_store() or "").strip().strip("/")
 
 
 def _session_store() -> str:
-    return os.getenv(_SESSION_STORE_ENV, "").strip()
+    from databricks_mason.runtime.tool_manifest import resolve_session_store
+
+    return (resolve_session_store() or "").strip()
 
 
 def _request_actor(request: Request) -> str:
@@ -202,7 +206,7 @@ def _require_memory() -> None:
     if not _memory_store():
         raise HTTPException(
             status_code=503,
-            detail=f"Set {_MEMORY_STORE_ENV} by deploying with --memory.",
+            detail="No memory store configured. Run `mason memory bind <store>`.",
         )
 
 
@@ -210,7 +214,7 @@ def _require_session() -> None:
     if not _session_store():
         raise HTTPException(
             status_code=503,
-            detail=f"Set {_SESSION_STORE_ENV} by deploying with --session.",
+            detail="No session store configured. Run `mason sessions bind <store>`.",
         )
 
 

--- a/integrations/mason/templates/ui/agent-openai/runtime/ui.py
+++ b/integrations/mason/templates/ui/agent-openai/runtime/ui.py
@@ -20,9 +20,7 @@ from runtime.runtime import rotate_session_cookie
 _UI_ROOT = Path(__file__).resolve().parent.parent / "ui"
 _INSTANCE_ID = uuid.uuid4().hex[:12]  # identifies this process in the UI
 _MEMORY_STORE_ENV = "AGENT_MEMORY_STORE"
-_MEMORY_ACTOR_ENV = "AGENT_MEMORY_ACTOR_ID"
 _SESSION_STORE_ENV = "AGENT_SESSION_STORE"
-_SESSION_ACTOR_ENV = "AGENT_SESSION_ACTOR_ID"
 _AGENTS_API = "/api/agents/v1"
 _MESSAGE_ROLES = {
     "ai",
@@ -52,20 +50,28 @@ class SessionItemsRequest(BaseModel):
     items: list[dict[str, Any]] = Field(min_length=1)
 
 
+_USER_HEADERS = ("x-forwarded-email", "x-forwarded-user")
+
+
 def _memory_store() -> str:
     return os.getenv(_MEMORY_STORE_ENV, "").strip().strip("/")
-
-
-def _memory_actor() -> str:
-    return os.getenv(_MEMORY_ACTOR_ENV, "agent")
 
 
 def _session_store() -> str:
     return os.getenv(_SESSION_STORE_ENV, "").strip()
 
 
-def _session_actor() -> str:
-    return os.getenv(_SESSION_ACTOR_ENV) or _memory_actor()
+def _request_actor(request: Request) -> str:
+    """The actor for a demo request — the signed-in user, so the panels show that user's own data.
+
+    Mirrors how the agent resolves its actor (same forwarded-identity headers), so the memory and
+    session views here list exactly what the agent reads/writes for the current user. Falls back to
+    ``"agent"`` locally / when unauthenticated.
+    """
+    for header in _USER_HEADERS:
+        if value := request.headers.get(header):
+            return value
+    return "agent"
 
 
 def _is_deployed() -> bool:
@@ -93,9 +99,9 @@ class _ManagedStateClient:
             )
         return result
 
-    def create_memory_entry(self, request: MemoryEntryRequest, session_id: str) -> dict:
+    def create_memory_entry(self, actor: str, request: MemoryEntryRequest, session_id: str) -> dict:
         body = {
-            "actor_id": _memory_actor(),
+            "actor_id": actor,
             "path": request.path,
             "content": request.content,
             "session_id": session_id,
@@ -104,33 +110,33 @@ class _ManagedStateClient:
             body["description"] = request.description
         return self._do("POST", f"{_AGENTS_API}/memory-stores/{_memory_store()}/entries", body=body)
 
-    def list_memory_entries(self, path_prefix: str | None = None) -> dict:
-        query = {"actor_id": _memory_actor(), "page_size": 100}
+    def list_memory_entries(self, actor: str, path_prefix: str | None = None) -> dict:
+        query = {"actor_id": actor, "page_size": 100}
         if path_prefix:
             query["path_prefix"] = path_prefix
         return self._do(
             "GET", f"{_AGENTS_API}/memory-stores/{_memory_store()}/entries", query=query
         )
 
-    def search_memory_entries(self, request: MemorySearchRequest) -> dict:
+    def search_memory_entries(self, actor: str, request: MemorySearchRequest) -> dict:
         return self._do(
             "POST",
             f"{_AGENTS_API}/memory-stores/{_memory_store()}/entries:search",
             body={
-                "actor_id": _memory_actor(),
+                "actor_id": actor,
                 "query": request.query,
                 "limit": request.limit,
             },
         )
 
-    def ensure_session(self, session_id: str) -> dict:
+    def ensure_session(self, actor: str, session_id: str) -> dict:
         try:
             return self._do(
                 "POST",
                 f"{_AGENTS_API}/session-stores/{_session_store()}/sessions",
                 query={"session_id": session_id},
                 body={
-                    "actor_id": _session_actor(),
+                    "actor_id": actor,
                     "metadata": {"client": "mason-demo-ui"},
                 },
             )
@@ -150,12 +156,12 @@ class _ManagedStateClient:
             f"{_AGENTS_API}/session-stores/{_session_store()}/sessions/{session_id}",
         )
 
-    def list_sessions(self) -> dict:
+    def list_sessions(self, actor: str) -> dict:
         return self._do(
             "GET",
             f"{_AGENTS_API}/session-stores/{_session_store()}/sessions",
             query={
-                "filter": f"actor_id = {json.dumps(_session_actor())}",
+                "filter": f"actor_id = {json.dumps(actor)}",
                 "order_by": "last_activity_time desc",
                 "page_size": 50,
             },
@@ -263,17 +269,13 @@ def install_ui(app: FastAPI) -> None:
 
     @app.get("/api/demo/config", include_in_schema=False)
     async def demo_config(request: Request) -> dict:
-        viewer = (
-            request.headers.get("x-forwarded-email")
-            or request.headers.get("x-forwarded-user")
-            or "Local developer"
-        )
+        actor = _request_actor(request)
         memory_store = _memory_store()
         session_store = _session_store()
         return {
             "session_id": request.state.session_id,
             "instance_id": _INSTANCE_ID,
-            "viewer": viewer,
+            "viewer": actor if actor != "agent" else "Local developer",
             "deployed": _is_deployed(),
             "streaming": {"enabled": True, "transport": "Server-sent events"},
             "background": {"enabled": True, "durable": False},
@@ -283,12 +285,12 @@ def install_ui(app: FastAPI) -> None:
                 "history": True,
                 "mode": "Managed Session Store" if session_store else "In-process session",
                 "store": session_store or None,
-                "actor": _session_actor(),
+                "actor": actor,
             },
             "memory": {
                 "enabled": bool(memory_store),
                 "store": f"memory-stores/{memory_store}" if memory_store else None,
-                "actor": _memory_actor(),
+                "actor": actor,
             },
         }
 
@@ -296,42 +298,53 @@ def install_ui(app: FastAPI) -> None:
     async def create_memory_entry(request: Request, payload: MemoryEntryRequest) -> dict:
         _require_memory()
         return await _managed_call(
-            _state_client().create_memory_entry, payload, request.state.session_id
+            _state_client().create_memory_entry,
+            _request_actor(request),
+            payload,
+            request.state.session_id,
         )
 
     @app.get("/api/demo/memory/entries", include_in_schema=False)
     async def list_memory_entries(
+        request: Request,
         path_prefix: str | None = Query(default=None),
     ) -> dict:
         _require_memory()
-        return await _managed_call(_state_client().list_memory_entries, path_prefix)
+        return await _managed_call(
+            _state_client().list_memory_entries, _request_actor(request), path_prefix
+        )
 
     @app.post("/api/demo/memory/search", include_in_schema=False)
-    async def search_memory_entries(request: MemorySearchRequest) -> dict:
+    async def search_memory_entries(request: Request, payload: MemorySearchRequest) -> dict:
         _require_memory()
-        return await _managed_call(_state_client().search_memory_entries, request)
+        return await _managed_call(
+            _state_client().search_memory_entries, _request_actor(request), payload
+        )
 
     @app.post("/api/demo/sessions", include_in_schema=False)
     async def ensure_session(request: Request) -> dict:
         _require_session()
-        return await _managed_call(_state_client().ensure_session, request.state.session_id)
+        return await _managed_call(
+            _state_client().ensure_session, _request_actor(request), request.state.session_id
+        )
 
     @app.get("/api/demo/sessions", include_in_schema=False)
     async def list_sessions(request: Request) -> dict:
         session_id = request.state.session_id
+        actor = _request_actor(request)
         if not _session_store():
             return {
                 "sessions": [
                     {
                         "session_id": session_id,
-                        "actor_id": _session_actor(),
+                        "actor_id": actor,
                         "metadata": {"client": "mason-demo-ui-local"},
                     }
                 ],
                 "current_session_id": session_id,
                 "managed": False,
             }
-        result = await _managed_call(_state_client().list_sessions)
+        result = await _managed_call(_state_client().list_sessions, actor)
         return {
             **result,
             "sessions": _chat_sessions(result),
@@ -343,7 +356,7 @@ def install_ui(app: FastAPI) -> None:
     async def open_session(request: Request, session_id: str) -> JSONResponse:
         _require_session()
         session = await _managed_call(_state_client().get_session, session_id)
-        if session.get("actor_id") != _session_actor():
+        if session.get("actor_id") != _request_actor(request):
             raise HTTPException(status_code=403, detail="Session belongs to another actor.")
         previous_session_id = request.state.session_id
         request.state.session_id = session_id

--- a/integrations/mason/templates/ui/agent-openai/tests/test_demo_ui.py
+++ b/integrations/mason/templates/ui/agent-openai/tests/test_demo_ui.py
@@ -5,26 +5,27 @@ from runtime.runtime import build_app
 
 
 class _FakeStateClient:
-    def create_memory_entry(self, request, session_id):
+    def create_memory_entry(self, actor, request, session_id):
         return {
             "name": "memory-stores/store/entries/entry",
             "session_id": session_id,
+            "actor_id": actor,
             **request.model_dump(),
         }
 
-    def list_memory_entries(self, path_prefix=None):
+    def list_memory_entries(self, actor, path_prefix=None):
         return {"managed_memory_entries": [{"path": f"{path_prefix or ''}/profile.md"}]}
 
-    def search_memory_entries(self, request):
+    def search_memory_entries(self, actor, request):
         return {"managed_memory_entries": [{"path": "/profile.md", "content": request.query}]}
 
-    def ensure_session(self, session_id):
-        return {"session_id": session_id, "actor_id": "alice"}
+    def ensure_session(self, actor, session_id):
+        return {"session_id": session_id, "actor_id": actor}
 
     def get_session(self, session_id):
         return {"session_id": session_id, "actor_id": "alice"}
 
-    def list_sessions(self):
+    def list_sessions(self, actor):
         return {
             "sessions": [
                 {
@@ -79,9 +80,7 @@ async def _session_history(session_id):
 def _client(monkeypatch, *, configured=False, history=False, session_id="routing-session"):
     if configured:
         monkeypatch.setenv("AGENT_MEMORY_STORE", "store")
-        monkeypatch.setenv("AGENT_MEMORY_ACTOR_ID", "alice")
         monkeypatch.setenv("AGENT_SESSION_STORE", "sessions")
-        monkeypatch.setenv("AGENT_SESSION_ACTOR_ID", "alice")
         monkeypatch.setattr(ui, "_state_client", lambda: _FakeStateClient())
     else:
         monkeypatch.delenv("AGENT_MEMORY_STORE", raising=False)
@@ -100,6 +99,10 @@ def _client(monkeypatch, *, configured=False, history=False, session_id="routing
     ui.install_ui(app)
     client = TestClient(app, base_url="https://testserver")
     client.cookies.set("__Host-databricks-app-router", session_id)
+    if configured:
+        # The actor is the signed-in user from this forwarded-identity header (ui._request_actor);
+        # unconfigured requests have no header and fall back to the "agent" actor.
+        client.headers["X-Forwarded-Email"] = "alice"
     return client
 
 
@@ -177,14 +180,14 @@ def test_unmanaged_local_history_route(monkeypatch):
 
 def test_managed_session_list_is_actor_scoped(monkeypatch):
     monkeypatch.setenv("AGENT_SESSION_STORE", "sessions")
-    monkeypatch.setenv("AGENT_SESSION_ACTOR_ID", 'alice "demo"')
     state_client = object.__new__(ui._ManagedStateClient)
     calls = []
     state_client._do = lambda method, path, **kwargs: calls.append((method, path, kwargs)) or {
         "sessions": []
     }
 
-    assert state_client.list_sessions() == {"sessions": []}
+    # The actor (a signed-in user) is escaped into the list filter.
+    assert state_client.list_sessions('alice "demo"') == {"sessions": []}
     assert calls == [
         (
             "GET",

--- a/integrations/mason/tests/unit_tests/agent_project_test.py
+++ b/integrations/mason/tests/unit_tests/agent_project_test.py
@@ -101,3 +101,45 @@ def test_write_is_atomic_when_replace_fails(tmp_path: pathlib.Path, monkeypatch)
         project.write()
 
     assert path.read_text(encoding="utf-8") == before
+
+
+def test_bind_and_unbind_stores_round_trip(tmp_path: pathlib.Path):
+    _write_manifest(tmp_path)
+    project = AgentProject.load(tmp_path)
+
+    assert project.bind_session_store("sessions") is True
+    assert project.bind_memory_store("mem") is True
+    assert project.bind_session_store("sessions") is False  # idempotent no-op
+    project.write()
+
+    reloaded = AgentProject.load(tmp_path)
+    assert reloaded.session_store == "sessions"
+    assert reloaded.memory_store == "mem"
+    assert "# keep me" in (tmp_path / "agent.toml").read_text(encoding="utf-8")
+
+    assert reloaded.unbind_session_store() is True
+    assert reloaded.unbind_session_store() is False  # already gone
+    reloaded.write()
+
+    final = AgentProject.load(tmp_path)
+    assert final.session_store is None
+    assert final.memory_store == "mem"
+
+
+def test_rebinding_replaces_the_store_name(tmp_path: pathlib.Path):
+    _write_manifest(tmp_path)
+    project = AgentProject.load(tmp_path)
+    project.bind_memory_store("first")
+    project.bind_memory_store("second")
+    project.write()
+
+    assert AgentProject.load(tmp_path).memory_store == "second"
+
+
+def test_load_rejects_store_table_without_name(tmp_path: pathlib.Path):
+    _write_manifest(
+        tmp_path,
+        'schema_version = 1\n\n[agent]\nframework = "openai"\n\n[session_store]\ndescription = "x"\n',
+    )
+    with pytest.raises(AgentCliError, match="session_store"):
+        AgentProject.load(tmp_path)

--- a/integrations/mason/tests/unit_tests/deploy_test.py
+++ b/integrations/mason/tests/unit_tests/deploy_test.py
@@ -265,7 +265,7 @@ def test_wait_for_running_times_out(monkeypatch):
         pass
 
 
-def test_deploy_injects_shared_actor_for_managed_stores(tmp_path: pathlib.Path, monkeypatch):
+def test_deploy_injects_store_env_without_actor(tmp_path: pathlib.Path, monkeypatch):
     src = tmp_path / "app"
     src.mkdir()
     (src / "app.yaml").write_text(yaml.safe_dump({"command": ["x"]}))
@@ -279,17 +279,7 @@ def test_deploy_injects_shared_actor_for_managed_stores(tmp_path: pathlib.Path, 
 
     result = CliRunner().invoke(
         deploy_mod.deploy,
-        [
-            "myapp",
-            "--source",
-            str(src),
-            "--memory",
-            "mem",
-            "--session",
-            "sessions",
-            "--actor-id",
-            "alice",
-        ],
+        ["myapp", "--source", str(src), "--memory", "mem", "--session", "sessions"],
         obj=_FakeCtx(),
     )
 
@@ -298,8 +288,11 @@ def test_deploy_injects_shared_actor_for_managed_stores(tmp_path: pathlib.Path, 
         entry["name"]: entry["value"]
         for entry in yaml.safe_load((src / "app.yaml").read_text())["env"]
     }
-    assert env["AGENT_MEMORY_ACTOR_ID"] == "alice"
-    assert env["AGENT_SESSION_ACTOR_ID"] == "alice"
+    assert env["AGENT_MEMORY_STORE"]  # resolved memory store id
+    assert env["AGENT_SESSION_STORE"] == "sessions"
+    # The actor is derived per request from the signed-in user, not injected at deploy time.
+    assert "AGENT_MEMORY_ACTOR_ID" not in env
+    assert "AGENT_SESSION_ACTOR_ID" not in env
 
 
 def test_deploy_with_traces_injects_tracing_env(tmp_path: pathlib.Path, monkeypatch):

--- a/integrations/mason/tests/unit_tests/memory_test.py
+++ b/integrations/mason/tests/unit_tests/memory_test.py
@@ -88,3 +88,55 @@ def test_store_list_renders_timestamps_from_create_time():
     assert result.exit_code == 0, result.output
     # A humanized relative time appears rather than "—" for the row.
     assert "ago" in result.output or "just now" in result.output
+
+
+def _bind_ctx(tmp_path):
+    """A CLI context whose client records memory-store creation, over a scaffolded agent.toml."""
+    (tmp_path / "agent.toml").write_text(
+        'schema_version = 1\n\n[agent]\nframework = "openai"\n', encoding="utf-8"
+    )
+
+    class _BindClient:
+        host = "https://example.databricks.com"
+
+        def __init__(self):
+            self.created = []
+
+        def create_memory_store(self, display_name, description=None, *, retry_transient=False):
+            self.created.append(display_name)
+            return {"name": f"memory-stores/{display_name}", "display_name": display_name}
+
+        def list_memory_stores(self, page_size=None, page_token=None):
+            return {"managed_memory_stores": []}
+
+    return _Ctx(_BindClient())
+
+
+def test_memory_bind_writes_agent_toml_and_creates_store(tmp_path):
+    from databricks_mason.agent_project import AgentProject
+    from databricks_mason.memory import memory as memory_group
+
+    ctx = _bind_ctx(tmp_path)
+    result = CliRunner().invoke(
+        memory_group, ["bind", "agent-mem", "--source", str(tmp_path)], obj=ctx
+    )
+
+    assert result.exit_code == 0, result.output
+    assert ctx.client().created == ["agent-mem"]  # created by default
+    assert AgentProject.load(tmp_path).memory_store == "agent-mem"
+
+
+def test_memory_unbind_clears_agent_toml(tmp_path):
+    from databricks_mason.agent_project import AgentProject
+    from databricks_mason.memory import memory as memory_group
+
+    (tmp_path / "agent.toml").write_text(
+        'schema_version = 1\n\n[agent]\nframework = "openai"\n\n[memory_store]\nname = "m"\n',
+        encoding="utf-8",
+    )
+    result = CliRunner().invoke(
+        memory_group, ["unbind", "--source", str(tmp_path)], obj=_Ctx(_Client())
+    )
+
+    assert result.exit_code == 0, result.output
+    assert AgentProject.load(tmp_path).memory_store is None

--- a/integrations/mason/tests/unit_tests/store_binding_test.py
+++ b/integrations/mason/tests/unit_tests/store_binding_test.py
@@ -1,0 +1,37 @@
+"""Tests for the runtime store-binding reader (databricks_mason.runtime.tool_manifest)."""
+
+from __future__ import annotations
+
+import pathlib
+
+from databricks_mason.runtime.tool_manifest import store_binding
+
+
+def _write(root: pathlib.Path, body: str) -> None:
+    (root / "agent.toml").write_text(body, encoding="utf-8")
+
+
+def test_store_binding_reads_declared_tables(tmp_path: pathlib.Path, monkeypatch):
+    _write(
+        tmp_path,
+        'schema_version = 1\n\n[agent]\nframework = "openai"\n'
+        '\n[memory_store]\nname = "mem"\n\n[session_store]\nname = "sess"\n',
+    )
+    monkeypatch.setenv("MASON_PROJECT_ROOT", str(tmp_path))
+
+    assert store_binding("memory_store") == "mem"
+    assert store_binding("session_store") == "sess"
+
+
+def test_store_binding_none_when_table_absent(tmp_path: pathlib.Path, monkeypatch):
+    _write(tmp_path, 'schema_version = 1\n\n[agent]\nframework = "openai"\n')
+    monkeypatch.setenv("MASON_PROJECT_ROOT", str(tmp_path))
+
+    assert store_binding("memory_store") is None
+    assert store_binding("session_store") is None
+
+
+def test_store_binding_none_when_no_manifest(tmp_path: pathlib.Path, monkeypatch):
+    # No agent.toml anywhere and no MASON_PROJECT_ROOT with one → never raises, just None.
+    monkeypatch.setenv("MASON_PROJECT_ROOT", str(tmp_path))
+    assert store_binding("session_store") is None


### PR DESCRIPTION
Two related changes to how a mason agent resolves its memory/session config.

**Per-user isolation** (`e2b044d`): managed memory and session data now partition by the signed-in user (`X-Forwarded-Email`) instead of one shared `"agent"` actor, so a deployed multi-user agent no longer pools everyone's memory/transcripts. The actor is a factory parameter closed over in the tools — not a tool argument — so the model can't set or spoof it. Falls back to `"agent"` locally.

**Store bindings in agent.toml** (`56b5113`): `mason memory bind <store>` / `mason sessions bind <store>` (+`unbind`) declare a `[memory_store]` / `[session_store]` table in agent.toml, creating the store if needed. The runtime resolves the store name explicit arg → `AGENT_*_STORE` env → `agent.toml` binding → none (conventional precedence; env overrides the committed default). A bind takes effect with no env plumbing.

Both templates + adapters updated; app.yaml unchanged. Tests: 231 unit, 21 openai + 25 langgraph scaffold; ruff + ty clean.

Tested e2e dev on `e2-dogfood`.