### PR TITLE
[mason] Show memory setup in command help

### DIFF
--- a/integrations/mason/src/databricks_mason/help.py
+++ b/integrations/mason/src/databricks_mason/help.py
@@ -20,7 +20,10 @@ _EXAMPLES: dict[CommandPath, tuple[str, ...]] = {
     ("logout",): ("mason logout",),
     ("init",): ("mason init my-agent",),
     ("dev",): ("mason dev",),
-    ("memory",): ("mason memory stores list", "mason memory entries search --help"),
+    ("memory",): (
+        "mason memory stores create --display-name agent-memory",
+        "mason deploy <agent> --memory agent-memory",
+    ),
     ("memory", "stores"): ("mason memory stores list",),
     ("memory", "stores", "create"): ("mason memory stores create --display-name agent-memory",),
     ("memory", "stores", "list"): ("mason memory stores list",),

--- a/integrations/mason/tests/unit_tests/cli_test.py
+++ b/integrations/mason/tests/unit_tests/cli_test.py
@@ -90,6 +90,10 @@ def test_help_examples_recommend_the_default_happy_path():
         ),
         ("init",): ("mason init my-agent",),
         ("dev",): ("mason dev",),
+        ("memory",): (
+            "mason memory stores create --display-name agent-memory",
+            "mason deploy <agent> --memory agent-memory",
+        ),
         ("deploy",): ("mason deploy my-agent",),
     }
 


### PR DESCRIPTION
## What

Show the memory-store creation and deployment commands in `mason memory -h`:

```bash
mason memory stores create --display-name agent-memory
mason deploy <agent> --memory agent-memory
```

Add a rendered Click help assertion for both commands.

## Why

`mason memory -h` currently exposes the `stores` and `entries` subgroups but only demonstrates listing/searching. The setup workflow is therefore easy to miss even though store creation already exists under `mason memory stores create`.

## Design doc

[Custom agent durability discussion](https://docs.google.com/document/d/1pyGNtE19V8TlG9UnOEF1xKQ_utgMdo5rGebSg5V1P18/edit?tab=t.0)

## Proof of work

`mason memory -h` now renders:

```text
Examples:
  mason memory stores create --display-name agent-memory
  mason deploy <agent> --memory agent-memory
```

## Testing

- `python -m pytest tests/unit_tests -q` — 239 passed
- `ruff check src/databricks_mason/help.py tests/unit_tests/cli_test.py`
- `ruff format --check src/databricks_mason/help.py tests/unit_tests/cli_test.py`
- `ty check`
- `git diff --check`

This pull request and its description were written by Isaac.
