### PR TITLE
mason: add tools remove command

### DIFF
--- a/integrations/mason/README.md
+++ b/integrations/mason/README.md
@@ -148,12 +148,13 @@ mason tools add sandbox --scope table:samples.nyctaxi.trips
 mason tools add mcp system.ai.web_search
 mason tools add uc-function catalog.schema.lookup_ticket
 mason tools add python lookup-ticket
-mason tools remove web_search
+mason tools remove mcp system.ai.web_search
 mason tools list
 ```
 
-Remove bindings by the ID shown in `mason tools list`. Removal updates only `agent.toml`; Python
-source and test files remain user-owned.
+For MCP services, the remove command accepts the same service name as the add command. You can also
+remove any binding by the ID shown in `mason tools list`, for example `mason tools remove
+web_search`. Removal updates only `agent.toml`; Python source and test files remain user-owned.
 
 Discover the MCP Services available to your user before adding one. By default Mason lists the
 Databricks-managed services in `system.ai`; pass `--schema catalog.schema` for another Unity Catalog

--- a/integrations/mason/README.md
+++ b/integrations/mason/README.md
@@ -148,8 +148,12 @@ mason tools add sandbox --scope table:samples.nyctaxi.trips
 mason tools add mcp system.ai.web_search
 mason tools add uc-function catalog.schema.lookup_ticket
 mason tools add python lookup-ticket
+mason tools remove web_search
 mason tools list
 ```
+
+Remove bindings by the ID shown in `mason tools list`. Removal updates only `agent.toml`; Python
+source and test files remain user-owned.
 
 Discover the MCP Services available to your user before adding one. By default Mason lists the
 Databricks-managed services in `system.ai`; pass `--schema catalog.schema` for another Unity Catalog

--- a/integrations/mason/src/databricks_mason/help.py
+++ b/integrations/mason/src/databricks_mason/help.py
@@ -112,7 +112,10 @@ _EXAMPLES: dict[CommandPath, tuple[str, ...]] = {
     ("tools", "add", "mcp"): ("mason tools add mcp system.ai.web_search",),
     ("tools", "add", "uc-function"): ("mason tools add uc-function catalog.schema.lookup_ticket",),
     ("tools", "add", "python"): ("mason tools add python lookup-ticket",),
-    ("tools", "remove"): ("mason tools remove web_search",),
+    ("tools", "remove"): (
+        "mason tools remove mcp system.ai.web_search",
+        "mason tools remove web_search",
+    ),
     ("tools", "list"): ("mason tools list",),
 }
 

--- a/integrations/mason/src/databricks_mason/help.py
+++ b/integrations/mason/src/databricks_mason/help.py
@@ -99,7 +99,7 @@ _EXAMPLES: dict[CommandPath, tuple[str, ...]] = {
         "mason tools add --help",
         "mason tools add sandbox --scope table:samples.nyctaxi.trips",
         "mason tools add mcp system.ai.web_search",
-        "mason tools remove web_search",
+        "mason tools remove mcp system.ai.web_search",
         "mason tools list",
     ),
     ("tools", "add"): (

--- a/integrations/mason/src/databricks_mason/help.py
+++ b/integrations/mason/src/databricks_mason/help.py
@@ -99,6 +99,7 @@ _EXAMPLES: dict[CommandPath, tuple[str, ...]] = {
         "mason tools add --help",
         "mason tools add sandbox --scope table:samples.nyctaxi.trips",
         "mason tools add mcp system.ai.web_search",
+        "mason tools remove web_search",
         "mason tools list",
     ),
     ("tools", "add"): (
@@ -111,6 +112,7 @@ _EXAMPLES: dict[CommandPath, tuple[str, ...]] = {
     ("tools", "add", "mcp"): ("mason tools add mcp system.ai.web_search",),
     ("tools", "add", "uc-function"): ("mason tools add uc-function catalog.schema.lookup_ticket",),
     ("tools", "add", "python"): ("mason tools add python lookup-ticket",),
+    ("tools", "remove"): ("mason tools remove web_search",),
     ("tools", "list"): ("mason tools list",),
 }
 

--- a/integrations/mason/src/databricks_mason/tools.py
+++ b/integrations/mason/src/databricks_mason/tools.py
@@ -341,3 +341,28 @@ def list_tools(obj: Any, source: pathlib.Path) -> None:
         [("ID", "left"), ("KIND", "left"), ("SOURCE", "left")],
         [(row["id"], row["kind"], row["source"]) for row in rows],
     )
+
+
+@tools.command("remove")
+@click.argument("tool_id")
+@_source_option
+@click.pass_obj
+def remove_tool(obj: Any, tool_id: str, source: pathlib.Path) -> None:
+    """Remove a tool binding from this agent."""
+    project = AgentProject.load(source)
+    changed = project.remove_tool(tool_id)
+    changed_files = [project.write()] if changed else []
+    if getattr(obj, "output", "text") == "json":
+        render.emit_json(
+            {
+                "schema_version": 1,
+                "changed": changed,
+                "changed_files": [str(path) for path in changed_files],
+                "tool_id": tool_id,
+            }
+        )
+        return
+    if changed:
+        render.success("Removed " + tool_id, fields={"Manifest": str(project.path)})
+    else:
+        click.echo(f"Tool {tool_id!r} is not configured in {project.path}")

--- a/integrations/mason/src/databricks_mason/tools.py
+++ b/integrations/mason/src/databricks_mason/tools.py
@@ -345,11 +345,32 @@ def list_tools(obj: Any, source: pathlib.Path) -> None:
 
 @tools.command("remove")
 @click.argument("tool_id")
+@click.argument("mcp_service", required=False)
 @_source_option
 @click.pass_obj
-def remove_tool(obj: Any, tool_id: str, source: pathlib.Path) -> None:
+def remove_tool(
+    obj: Any,
+    tool_id: str,
+    mcp_service: str | None,
+    source: pathlib.Path,
+) -> None:
     """Remove a tool binding from this agent."""
     project = AgentProject.load(source)
+    if mcp_service is not None:
+        if tool_id != "mcp":
+            raise AgentCliError("A second argument is supported only for `tools remove mcp`.")
+        ToolSpec.mcp(_default_id(mcp_service), service=mcp_service)
+        matches = [
+            tool
+            for tool in project.tools
+            if tool.source.kind == "mcp" and tool.source.service == mcp_service
+        ]
+        if len(matches) > 1:
+            raise AgentCliError(
+                f"Multiple bindings use MCP service {mcp_service!r}.",
+                hint="Run `mason tools list`, then remove the intended binding by ID.",
+            )
+        tool_id = matches[0].id if matches else _default_id(mcp_service)
     changed = project.remove_tool(tool_id)
     changed_files = [project.write()] if changed else []
     if getattr(obj, "output", "text") == "json":

--- a/integrations/mason/tests/e2e/README.md
+++ b/integrations/mason/tests/e2e/README.md
@@ -34,6 +34,9 @@ Direct authoring does not call `mason tools add`: it replaces `agent.toml` with
 four `mason tools add ...` commands, then implements the generated Python stub. Every exact command
 and generated-file step is captured in `commands.log`.
 
+The CLI path first adds an unavailable MCP service and removes it by ID. The subsequent dev and
+deployed tool matrix proves the recovered manifest no longer bricks agent startup.
+
 ## Verify existing evidence
 
 ```bash

--- a/integrations/mason/tests/e2e/tool_matrix.py
+++ b/integrations/mason/tests/e2e/tool_matrix.py
@@ -371,6 +371,34 @@ class Runner:
         return cases
 
     def _author_cli(self, project: pathlib.Path) -> None:
+        self.run(
+            [
+                str(self.mason),
+                "tools",
+                "add",
+                "mcp",
+                "system.ai.missing_service",
+                "--name",
+                "broken_mcp",
+                "--source",
+                str(project),
+            ]
+        )
+        self.run(
+            [
+                str(self.mason),
+                "tools",
+                "remove",
+                "broken_mcp",
+                "--source",
+                str(project),
+            ]
+        )
+        listed = self.run(
+            [str(self.mason), "--output", "json", "tools", "list", "--source", str(project)]
+        )
+        if any(tool["id"] == "broken_mcp" for tool in json.loads(listed.stdout)["tools"]):
+            raise MatrixError("mason tools remove left the broken MCP binding in agent.toml")
         commands = [
             ["tools", "add", "sandbox", "--scope", "table:samples.nyctaxi.trips"],
             ["tools", "add", "mcp", "system.ai.web_search"],

--- a/integrations/mason/tests/e2e/tool_matrix.py
+++ b/integrations/mason/tests/e2e/tool_matrix.py
@@ -389,7 +389,8 @@ class Runner:
                 str(self.mason),
                 "tools",
                 "remove",
-                "broken_mcp",
+                "mcp",
+                "system.ai.missing_service",
                 "--source",
                 str(project),
             ]

--- a/integrations/mason/tests/unit_tests/cli_test.py
+++ b/integrations/mason/tests/unit_tests/cli_test.py
@@ -62,7 +62,7 @@ def test_tools_help_explains_add_workflow():
     assert "List tools configured for this agent." in result.output
     assert "mason tools add --help" in result.output
     assert "mason tools add mcp system.ai.web_search" in result.output
-    assert "mason tools remove web_search" in result.output
+    assert "mason tools remove mcp system.ai.web_search" in result.output
 
 
 def test_tools_remove_help_shows_id_and_project_targeting():

--- a/integrations/mason/tests/unit_tests/cli_test.py
+++ b/integrations/mason/tests/unit_tests/cli_test.py
@@ -69,8 +69,9 @@ def test_tools_remove_help_shows_id_and_project_targeting():
     result = CliRunner().invoke(cli.mason, ["tools", "remove", "--help"])
 
     assert result.exit_code == 0, result.output
-    assert "Usage: mason tools remove [OPTIONS] TOOL_ID" in result.output
+    assert "Usage: mason tools remove [OPTIONS] TOOL_ID [MCP_SERVICE]" in result.output
     assert "--source DIRECTORY" in result.output
+    assert "mason tools remove mcp system.ai.web_search" in result.output
     assert "mason tools remove web_search" in result.output
 
 

--- a/integrations/mason/tests/unit_tests/cli_test.py
+++ b/integrations/mason/tests/unit_tests/cli_test.py
@@ -58,9 +58,20 @@ def test_tools_help_explains_add_workflow():
     assert result.exit_code == 0, result.output
     assert "Manage tools configured in an agent project's agent.toml." in result.output
     assert "Add a sandbox, MCP service, UC function, or Python tool." in result.output
+    assert "Remove a tool binding from this agent." in result.output
     assert "List tools configured for this agent." in result.output
     assert "mason tools add --help" in result.output
     assert "mason tools add mcp system.ai.web_search" in result.output
+    assert "mason tools remove web_search" in result.output
+
+
+def test_tools_remove_help_shows_id_and_project_targeting():
+    result = CliRunner().invoke(cli.mason, ["tools", "remove", "--help"])
+
+    assert result.exit_code == 0, result.output
+    assert "Usage: mason tools remove [OPTIONS] TOOL_ID" in result.output
+    assert "--source DIRECTORY" in result.output
+    assert "mason tools remove web_search" in result.output
 
 
 def test_tools_add_help_explains_types_and_project_targeting():

--- a/integrations/mason/tests/unit_tests/tools_test.py
+++ b/integrations/mason/tests/unit_tests/tools_test.py
@@ -193,6 +193,80 @@ def test_add_is_idempotent_and_json_reports_changed_files(tmp_path: pathlib.Path
     assert len(AgentProject.load(project).tools) == 1
 
 
+def test_remove_tool_updates_only_the_manifest(tmp_path: pathlib.Path):
+    project = _project(tmp_path)
+    runner = CliRunner()
+    added = runner.invoke(
+        tools,
+        ["add", "mcp", "system.ai.missing_service", "--name", "broken", "--source", str(project)],
+        obj=_Ctx(),
+    )
+    assert added.exit_code == 0, added.output
+
+    result = runner.invoke(
+        tools,
+        ["remove", "broken", "--source", str(project)],
+        obj=_Ctx(),
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "Removed broken" in result.output
+    assert AgentProject.load(project).tools == []
+    assert (project / "agent" / "mcps.py").read_text(encoding="utf-8") == "ORIGINAL = True\n"
+
+
+def test_remove_tool_is_idempotent_and_reports_json_changes(tmp_path: pathlib.Path):
+    project = _project(tmp_path)
+    runner = CliRunner()
+    added = runner.invoke(
+        tools,
+        ["add", "mcp", "system.ai.web_search", "--source", str(project)],
+        obj=_Ctx(),
+    )
+    assert added.exit_code == 0, added.output
+    args = ["remove", "web_search", "--source", str(project)]
+
+    first = runner.invoke(tools, args, obj=_Ctx(output="json"))
+    second = runner.invoke(tools, args, obj=_Ctx(output="json"))
+
+    assert first.exit_code == 0, first.output
+    assert second.exit_code == 0, second.output
+    assert json.loads(first.output) == {
+        "schema_version": 1,
+        "changed": True,
+        "changed_files": [str(project / "agent.toml")],
+        "tool_id": "web_search",
+    }
+    assert json.loads(second.output) == {
+        "schema_version": 1,
+        "changed": False,
+        "changed_files": [],
+        "tool_id": "web_search",
+    }
+
+
+def test_remove_python_tool_preserves_user_owned_files(tmp_path: pathlib.Path):
+    project = _project(tmp_path)
+    runner = CliRunner()
+    added = runner.invoke(
+        tools,
+        ["add", "python", "lookup-ticket", "--source", str(project)],
+        obj=_Ctx(),
+    )
+    assert added.exit_code == 0, added.output
+
+    result = runner.invoke(
+        tools,
+        ["remove", "lookup-ticket", "--source", str(project)],
+        obj=_Ctx(),
+    )
+
+    assert result.exit_code == 0, result.output
+    assert AgentProject.load(project).tools == []
+    assert (project / "agent" / "tools" / "lookup_ticket.py").exists()
+    assert (project / "tests" / "tools" / "test_lookup_ticket.py").exists()
+
+
 def test_tools_list_emits_manifest_records_as_json(tmp_path: pathlib.Path):
     project = _project(tmp_path)
     runner = CliRunner()

--- a/integrations/mason/tests/unit_tests/tools_test.py
+++ b/integrations/mason/tests/unit_tests/tools_test.py
@@ -215,6 +215,35 @@ def test_remove_tool_updates_only_the_manifest(tmp_path: pathlib.Path):
     assert (project / "agent" / "mcps.py").read_text(encoding="utf-8") == "ORIGINAL = True\n"
 
 
+def test_remove_mcp_accepts_the_service_from_the_add_command(tmp_path: pathlib.Path):
+    project = _project(tmp_path)
+    runner = CliRunner()
+    added = runner.invoke(
+        tools,
+        [
+            "add",
+            "mcp",
+            "system.ai.web_search",
+            "--name",
+            "web",
+            "--source",
+            str(project),
+        ],
+        obj=_Ctx(),
+    )
+    assert added.exit_code == 0, added.output
+
+    result = runner.invoke(
+        tools,
+        ["remove", "mcp", "system.ai.web_search", "--source", str(project)],
+        obj=_Ctx(),
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "Removed web" in result.output
+    assert AgentProject.load(project).tools == []
+
+
 def test_remove_tool_is_idempotent_and_reports_json_changes(tmp_path: pathlib.Path):
     project = _project(tmp_path)
     runner = CliRunner()


### PR DESCRIPTION
## What

Add `mason tools remove <tool-id>` to remove a configured tool binding from `agent.toml` without touching user-owned source files.

## Why

A bad MCP or UC-function binding can prevent the agent from starting. Users need a CLI recovery path instead of manually editing the manifest.

## Design doc

https://docs.google.com/document/d/1pyGNtE19V8TlG9UnOEF1xKQ_utgMdo5rGebSg5V1P18/edit?tab=t.0#heading=h.m4qsaqc2ofax

## Proof of work

- Built and installed the wheel, then ran the recovery CUJ on `df1`: add unavailable MCP `system.ai.missing_service` as custom ID `broken_mcp` → `mason tools remove mcp system.ai.missing_service` → `mason tools list` returned no bindings → recovered agent started successfully.
- Freshness marker tied the removal-path run to product commit `70bed82`; it was removed before the final clean build. PR head `0d69f07` only clarifies the top-level help example.
- Local endpoint proof:

  ```console
  $ curl -sS -X POST http://127.0.0.1:8410/invocations \
      -H 'Content-Type: application/json' \
      --data '{"input":[{"role":"user","content":"You must call the matrix_marker Python tool with value matrix. Return its exact result."}]}'
  HTTP 200
  ... "name":"matrix_marker" ... "content":"MASON_PYTHON_OK" ... "status":"completed"
  ```

- Final marker-free wheel SHA-256: `d621b1cbc98785b1c56474f8a673772319d8b0d3f6b1fd6e8dd27434130697dc`.
- Managed-App invocation was not completed: df1 App compute remained in `STARTING` for 20 minutes with no deployment record. After the platform timeout, the temporary App was stopped and deleted.

## Testing

- `uv run pytest tests/unit_tests -q` — 244 passed
- Ruff format/check and `ty check` on changed Python files
- GitHub Actions — all tests, format, Ruff, and typechecking passed
- E2E matrix now adds an unavailable MCP binding, removes it by ID, verifies it is absent, then runs the normal dev/deploy matrix.

Co-authored-by: Isaac <no-reply@databricks.com>

This pull request and its description were written by Isaac.
