### PR TITLE
[mason] Point memory-store create at mason deploy --memory

### DIFF
--- a/integrations/mason/src/databricks_mason/memory.py
+++ b/integrations/mason/src/databricks_mason/memory.py
@@ -152,6 +152,10 @@ def stores_create(obj, display_name, description) -> None:
                 "Add a memory entry for an actor",
             ),
             (f"mason memory stores get {store_id}", "View this store's details"),
+            (
+                f"mason deploy <agent> --memory {display_name}",
+                "Wire this store into a deployment",
+            ),
         ],
     )
 

--- a/integrations/mason/tests/unit_tests/memory_test.py
+++ b/integrations/mason/tests/unit_tests/memory_test.py
@@ -18,6 +18,9 @@ class _Client:
     def get_memory_store(self, name):
         return self._store
 
+    def create_memory_store(self, display_name, description=None):
+        return self._store
+
     def list_memory_stores(self, page_size=None, page_token=None):
         return self._page
 
@@ -59,6 +62,15 @@ def test_store_get_renders_timestamps_from_create_time():
     assert result.exit_code == 0, result.output
     # Timestamps render (year present) instead of the em-dash placeholder.
     assert "2026" in result.output
+
+
+def test_store_create_suggests_deploying_with_memory():
+    store = {"name": "memory-stores/abc123", "display_name": "demo"}
+    result = CliRunner().invoke(
+        stores, ["create", "--display-name", "demo"], obj=_Ctx(_Client(store=store))
+    )
+    assert result.exit_code == 0, result.output
+    assert "mason deploy <agent> --memory demo" in result.output
 
 
 def test_store_list_renders_timestamps_from_create_time():


### PR DESCRIPTION
Follow up to #527 by surfacing the primary deployment path after `mason memory stores create`.

The success output now suggests `mason deploy <agent> --memory <display-name>`, using the current deploy flag and the display name that `mason deploy` resolves. A focused unit test covers the rendered command.

Tests:
- `pytest tests/unit_tests -q` (242 passed)
- `ruff check`
- `ruff format --check`
- `ty check`
