### PR TITLE
[mason] Make the chat-UI model selectable from a picker

### DIFF
--- a/integrations/mason/templates/agent-langgraph/agent/agent.py
+++ b/integrations/mason/templates/agent-langgraph/agent/agent.py
@@ -73,11 +73,15 @@ def _check_databricks_auth() -> None:
         ) from e
 
 
-async def create_agent_graph(actor: str):
+async def create_agent_graph(actor: str, model: str | None = None):
     """Build the LangGraph agent: local tools + long-term-memory tools + any MCP tools.
 
     ``actor`` is the identity whose long-term memory the agent reads/writes; it's captured in the
     memory tools' closures (never exposed to the model). See ``_actor``.
+
+    ``model`` selects the serving endpoint for this run; the chat UI passes the picker's choice and
+    everything else falls back to ``MODEL``. The agent is rebuilt per turn, so the endpoint can vary
+    request to request.
     """
     # Join the manifest's MCP servers (from agent.toml) with your own hand-declared ones (mcps.py),
     # then fetch their tools. Edit build_mcp_servers in agent/mcps.py to add servers.
@@ -86,8 +90,9 @@ async def create_agent_graph(actor: str):
     middleware = (
         [HumanInTheLoopMiddleware(interrupt_on=REQUIRE_APPROVAL)] if REQUIRE_APPROVAL else []
     )
+    endpoint = model or MODEL
     return create_agent(
-        model=_RoutedChatDatabricks(endpoint=MODEL, workspace_client=workspace_client()),
+        model=_RoutedChatDatabricks(endpoint=endpoint, workspace_client=workspace_client()),
         tools=tools,
         middleware=middleware,
         checkpointer=checkpointer(),
@@ -143,7 +148,7 @@ async def stream_handler(request: dict) -> AsyncGenerator[dict, None]:
     actor = _actor(request)
     tag_session(session_id)
 
-    agent = await create_agent_graph(actor)
+    agent = await create_agent_graph(actor, request.get("model"))
     # A `resume` payload continues a session paused awaiting approval; otherwise start a new turn from
     # `input`. Either way the checkpointer keys off session_id's thread for prior history / paused state.
     # LangChain accepts message dicts natively, so `input` is passed straight through (new turn only).

--- a/integrations/mason/templates/agent-openai/agent/agent.py
+++ b/integrations/mason/templates/agent-openai/agent/agent.py
@@ -71,16 +71,20 @@ def _check_databricks_auth() -> None:
         ) from e
 
 
-def create_agent(actor: str, mcp=None) -> Agent:
+def create_agent(actor: str, mcp=None, model: str | None = None) -> Agent:
     """Build the OpenAI Agents SDK agent: local tools + long-term-memory tools + any MCP servers.
 
     ``actor`` is the identity whose long-term memory the agent reads/writes; it's captured in the
     memory tools' closures (never exposed to the model). See ``_actor``.
+
+    ``model`` selects the serving endpoint for this run; the chat UI passes the picker's choice and
+    everything else falls back to ``MODEL``. The agent is rebuilt per turn, so the endpoint can vary
+    request to request.
     """
     return Agent(
         name="Agent",
         instructions="You are a helpful assistant.",
-        model=MODEL,
+        model=model or MODEL,
         tools=[*all_tools(), *memory_tools(actor)],
         mcp_servers=mcp or [],
     )
@@ -157,7 +161,7 @@ async def stream_handler(request: dict) -> AsyncGenerator[dict, None]:
             finally:
                 server.tool_filter = tool_filter
 
-        agent = create_agent(actor, mcp)
+        agent = create_agent(actor, mcp, model=request.get("model"))
 
         # A `resume` payload continues a session paused awaiting approval; otherwise start a new turn
         # from `input`. A resumed run re-runs the stashed RunState (with decisions applied); a new

--- a/integrations/mason/templates/ui/agent-langgraph/CHAT_APP.md
+++ b/integrations/mason/templates/ui/agent-langgraph/CHAT_APP.md
@@ -17,6 +17,13 @@ The capability indicators are automatic. Streaming and background reflect the ru
 Session reflects checkpoint history; Memory requires `AGENT_MEMORY_STORE`. The transport selector is
 the only manual capability choice.
 
+The chat header's model picker lists the workspace's ready chat serving endpoints
+(`GET /api/demo/config` → `models`, discovered from `serving_endpoints.list()` and filtered to the
+`llm/v1/chat` task), with `agent.agent.MODEL` pinned as the default. Each request sends the selected
+endpoint as `model` in the invocation body; the agent is rebuilt per turn, so the picker changes the
+model for the next turn without a restart. Discovery is best-effort: if listing is unavailable (e.g.
+no permission), the picker falls back to just the default. Omitting `model` uses `MODEL`.
+
 The UI reads local history from the LangGraph checkpoint and managed history from Session Store
 items. The Databricks Apps `__Host-databricks-app-router` cookie is both the sticky routing key and
 the application session id; request bodies do not carry `session_id`. Local development uses the

--- a/integrations/mason/templates/ui/agent-langgraph/CHAT_APP.md
+++ b/integrations/mason/templates/ui/agent-langgraph/CHAT_APP.md
@@ -24,6 +24,11 @@ endpoint as `model` in the invocation body; the agent is rebuilt per turn, so th
 model for the next turn without a restart. Discovery is best-effort: if listing is unavailable (e.g.
 no permission), the picker falls back to just the default. Omitting `model` uses `MODEL`.
 
+A large workspace can expose thousands of endpoints, so the picker is capped (`_MODEL_LIMIT`, 20)
+and ranked — default first, then `databricks-*` foundation models, then other custom/external chat
+endpoints — so the cap keeps the canonical choices. The list call is unpaginated and occasionally
+fails on big workspaces, so it is retried a few times before falling back to the default.
+
 The UI reads local history from the LangGraph checkpoint and managed history from Session Store
 items. The Databricks Apps `__Host-databricks-app-router` cookie is both the sticky routing key and
 the application session id; request bodies do not carry `session_id`. Local development uses the

--- a/integrations/mason/templates/ui/agent-langgraph/runtime/ui.py
+++ b/integrations/mason/templates/ui/agent-langgraph/runtime/ui.py
@@ -87,6 +87,11 @@ def _is_deployed() -> bool:
 # The task string the Model Serving API reports for chat/completions endpoints; only these can back
 # a conversational agent, so the picker filters the workspace's endpoints down to them.
 _CHAT_TASK = "llm/v1/chat"
+# Cap the picker: a big workspace exposes thousands of endpoints, far too many for a dropdown.
+_MODEL_LIMIT = 20
+# The list API ignores page_size and returns every endpoint in one large, occasionally-failing
+# response; retry a few times before giving up so a transient error doesn't blank the picker.
+_LIST_ATTEMPTS = 3
 
 
 def _default_model() -> str:
@@ -100,30 +105,60 @@ def _default_model() -> str:
     return MODEL
 
 
-def _discover_chat_models() -> list[str]:
-    """List the workspace's ready chat serving endpoints, the agent's default pinned first.
+def _list_chat_endpoints() -> list[str]:
+    """Names of the workspace's ready chat serving endpoints, retrying the flaky list call.
 
-    Powers the chat UI's model picker. Best-effort: any failure (missing list permission, transient
-    API error) yields just the default so the picker still works. The default is always present and
-    first even if the listing omits it.
+    The `/api/2.0/serving-endpoints` list is unpaginated and can intermittently 500 on large
+    workspaces, so retry a few times. Raises the last error if every attempt fails.
     """
-    default = _default_model()
-    names: list[str] = []
-    try:
-        for endpoint in workspace_client().serving_endpoints.list():
-            if endpoint.task != _CHAT_TASK:
-                continue
-            state = getattr(endpoint.state, "ready", None)
-            if state is not None and getattr(state, "value", state) != "READY":
-                continue
-            if endpoint.name:
-                names.append(endpoint.name)
-    except Exception:
-        names = []
-    # Pin the configured default first and drop duplicates while preserving discovery order.
-    ordered = [default, *(n for n in names if n != default)]
+    import time
+
+    last_error: Exception | None = None
+    for attempt in range(_LIST_ATTEMPTS):
+        try:
+            names = []
+            for endpoint in workspace_client().serving_endpoints.list():
+                if endpoint.task != _CHAT_TASK:
+                    continue
+                state = getattr(endpoint.state, "ready", None)
+                if state is not None and getattr(state, "value", state) != "READY":
+                    continue
+                if endpoint.name:
+                    names.append(endpoint.name)
+            return names
+        except Exception as exc:  # noqa: BLE001 - retry any list failure, then surface the last one
+            last_error = exc
+            if attempt < _LIST_ATTEMPTS - 1:
+                time.sleep(0.5)
+    raise last_error if last_error else RuntimeError("serving-endpoints list returned nothing")
+
+
+def _rank_models(default: str, names: list[str]) -> list[str]:
+    """Order the picker so its capped slots stay useful, and drop duplicates.
+
+    The default is pinned first; then Databricks foundation models (``databricks-*``), which are the
+    canonical choices; then any other custom/external chat endpoints. Truncation therefore sheds the
+    least-canonical endpoints first, not an arbitrary alphabetical slice.
+    """
+    foundation = sorted(n for n in names if n.startswith("databricks-") and n != default)
+    other = sorted(n for n in names if not n.startswith("databricks-") and n != default)
+    ordered = [default, *foundation, *other]
     seen: set[str] = set()
     return [n for n in ordered if not (n in seen or seen.add(n))]
+
+
+def _discover_chat_models() -> list[str]:
+    """The chat serving endpoints for the picker: default first, foundation models next, capped.
+
+    Best-effort: if listing fails (missing permission, repeated transient errors), fall back to just
+    the default so the picker still works. The default is always present and first.
+    """
+    default = _default_model()
+    try:
+        names = _list_chat_endpoints()
+    except Exception:  # noqa: BLE001 - a broken listing must not break the whole config endpoint
+        names = []
+    return _rank_models(default, names)[:_MODEL_LIMIT]
 
 
 class _ManagedStateClient:

--- a/integrations/mason/templates/ui/agent-langgraph/runtime/ui.py
+++ b/integrations/mason/templates/ui/agent-langgraph/runtime/ui.py
@@ -84,6 +84,48 @@ def _is_deployed() -> bool:
     return bool(os.getenv("DATABRICKS_APP_NAME")) and not is_local
 
 
+# The task string the Model Serving API reports for chat/completions endpoints; only these can back
+# a conversational agent, so the picker filters the workspace's endpoints down to them.
+_CHAT_TASK = "llm/v1/chat"
+
+
+def _default_model() -> str:
+    """The agent's configured default endpoint (``agent.agent.MODEL``), imported lazily.
+
+    Imported inside the function, not at module load, so the light UI import path doesn't pull in the
+    agent stack (matching ``_checkpoint_history`` below).
+    """
+    from agent.agent import MODEL
+
+    return MODEL
+
+
+def _discover_chat_models() -> list[str]:
+    """List the workspace's ready chat serving endpoints, the agent's default pinned first.
+
+    Powers the chat UI's model picker. Best-effort: any failure (missing list permission, transient
+    API error) yields just the default so the picker still works. The default is always present and
+    first even if the listing omits it.
+    """
+    default = _default_model()
+    names: list[str] = []
+    try:
+        for endpoint in workspace_client().serving_endpoints.list():
+            if endpoint.task != _CHAT_TASK:
+                continue
+            state = getattr(endpoint.state, "ready", None)
+            if state is not None and getattr(state, "value", state) != "READY":
+                continue
+            if endpoint.name:
+                names.append(endpoint.name)
+    except Exception:
+        names = []
+    # Pin the configured default first and drop duplicates while preserving discovery order.
+    ordered = [default, *(n for n in names if n != default)]
+    seen: set[str] = set()
+    return [n for n in ordered if not (n in seen or seen.add(n))]
+
+
 class _ManagedStateClient:
     def __init__(self) -> None:
         self._workspace = workspace_client()
@@ -282,11 +324,14 @@ def install_ui(app: FastAPI) -> None:
         actor = _request_actor(request)
         memory_store = _memory_store()
         session_store = _session_store()
+        # Off-thread: serving_endpoints.list() is a blocking SDK call.
+        available_models = await asyncio.to_thread(_discover_chat_models)
         return {
             "session_id": request.state.session_id,
             "instance_id": _INSTANCE_ID,
             "viewer": actor if actor != "agent" else "Local developer",
             "deployed": _is_deployed(),
+            "models": {"default": _default_model(), "available": available_models},
             "streaming": {"enabled": True, "transport": "Server-sent events"},
             "background": {"enabled": True, "durable": False},
             "session": {

--- a/integrations/mason/templates/ui/agent-langgraph/tests/test_demo_ui.py
+++ b/integrations/mason/templates/ui/agent-langgraph/tests/test_demo_ui.py
@@ -93,6 +93,8 @@ def _client(monkeypatch, *, configured=False, history=False, session_id="routing
         monkeypatch.delenv("AGENT_SESSION_STORE", raising=False)
     if history:
         monkeypatch.setattr(ui, "_checkpoint_history", _session_history)
+    # Keep model discovery deterministic and offline (no serving_endpoints.list() call).
+    monkeypatch.setattr(ui, "_discover_chat_models", lambda: ["databricks-gpt-5-2"])
 
     async def invoke_handler(request):
         return {"output": [], "session_id": request["session_id"]}
@@ -119,11 +121,13 @@ def test_demo_ui_routes(monkeypatch):
     assert index.status_code == 200
     assert 'id="new-session"' in index.text
     assert 'id="session-list"' in index.text
+    assert 'id="model-select"' in index.text
     app_script = client.get("/ui-assets/app.js")
     assert app_script.status_code == 200
     assert "mason dev --memory <store-name>" in app_script.text
     assert "mason deploy <app-name> --source . --memory <store-name>" in app_script.text
     assert "refreshSessionView({ hydrateChat: true })" in app_script.text
+    assert "function renderModels(" in app_script.text
     assert 'fetch("/api/session/new"' in app_script.text
     assert "/api/demo/sessions/${encodeURIComponent(sessionId)}/open" in app_script.text
     assert "session_id: ensureSessionId()" not in app_script.text
@@ -134,6 +138,10 @@ def test_demo_ui_routes(monkeypatch):
     config = client.get("/api/demo/config").json()
     assert config["session_id"] == "routing-session"
     assert config["deployed"] is False
+    assert config["models"] == {
+        "default": "databricks-gpt-5-2",
+        "available": ["databricks-gpt-5-2"],
+    }
     assert config["streaming"]["enabled"] is True
     assert config["background"]["enabled"] is True
     assert config["memory"]["enabled"] is False
@@ -228,6 +236,42 @@ def test_chat_session_items_exclude_non_message_items():
         ],
         "next_page_token": "next",
     }
+
+
+def _endpoint(name, task="llm/v1/chat", ready="READY"):
+    state = type("State", (), {"ready": type("Ready", (), {"value": ready})()})()
+    return type("Endpoint", (), {"name": name, "task": task, "state": state})()
+
+
+def test_discover_chat_models_filters_pins_default_and_dedups(monkeypatch):
+    monkeypatch.setattr(ui, "_default_model", lambda: "databricks-gpt-5-2")
+    endpoints = [
+        _endpoint("databricks-claude-sonnet-4"),
+        _endpoint("an-embedding-model", task="llm/v1/embeddings"),  # dropped: wrong task
+        _endpoint("half-ready", ready="NOT_READY"),  # dropped: not ready
+        _endpoint("databricks-gpt-5-2"),  # the default, surfaced again by discovery
+    ]
+    fake_wc = type(
+        "WC", (), {"serving_endpoints": type("SE", (), {"list": lambda self: endpoints})()}
+    )()
+    monkeypatch.setattr(ui, "workspace_client", lambda: fake_wc)
+
+    # Default pinned first, chat endpoints only, no duplicate of the default.
+    assert ui._discover_chat_models() == ["databricks-gpt-5-2", "databricks-claude-sonnet-4"]
+
+
+def test_discover_chat_models_falls_back_to_default_on_error(monkeypatch):
+    monkeypatch.setattr(ui, "_default_model", lambda: "databricks-gpt-5-2")
+
+    def _boom():
+        raise PermissionError("no listing permission")
+
+    fake_wc = type(
+        "WC", (), {"serving_endpoints": type("SE", (), {"list": lambda self: _boom()})()}
+    )()
+    monkeypatch.setattr(ui, "workspace_client", lambda: fake_wc)
+
+    assert ui._discover_chat_models() == ["databricks-gpt-5-2"]
 
 
 @pytest.mark.asyncio

--- a/integrations/mason/templates/ui/agent-langgraph/tests/test_demo_ui.py
+++ b/integrations/mason/templates/ui/agent-langgraph/tests/test_demo_ui.py
@@ -274,6 +274,46 @@ def test_discover_chat_models_falls_back_to_default_on_error(monkeypatch):
     assert ui._discover_chat_models() == ["databricks-gpt-5-2"]
 
 
+def test_discover_chat_models_ranks_foundation_first_and_caps(monkeypatch):
+    monkeypatch.setattr(ui, "_default_model", lambda: "databricks-gpt-5-2")
+    # A big workspace: many custom endpoints plus a few foundation models. The cap must keep the
+    # default and the databricks-* foundation models, not an arbitrary alphabetical slice of customs.
+    endpoints = [_endpoint(f"zz-custom-{i:03d}") for i in range(30)]
+    endpoints += [_endpoint("databricks-gpt-5-5"), _endpoint("databricks-claude-sonnet-4")]
+    fake_wc = type(
+        "WC", (), {"serving_endpoints": type("SE", (), {"list": lambda self: endpoints})()}
+    )()
+    monkeypatch.setattr(ui, "workspace_client", lambda: fake_wc)
+
+    result = ui._discover_chat_models()
+    assert len(result) == 20  # capped
+    assert result[0] == "databricks-gpt-5-2"  # default pinned
+    # Foundation models win slots ahead of any custom endpoint.
+    assert result[1:3] == ["databricks-claude-sonnet-4", "databricks-gpt-5-5"]
+    assert all(name.startswith(("databricks-", "zz-custom-")) for name in result)
+
+
+def test_discover_chat_models_retries_transient_list_error(monkeypatch):
+    import time
+
+    monkeypatch.setattr(ui, "_default_model", lambda: "databricks-gpt-5-2")
+    monkeypatch.setattr(time, "sleep", lambda _s: None)  # don't actually wait between retries
+    calls = {"n": 0}
+
+    def _list(self):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise RuntimeError("transient 500")
+        return [_endpoint("databricks-gpt-5-5")]
+
+    fake_wc = type("WC", (), {"serving_endpoints": type("SE", (), {"list": _list})()})()
+    monkeypatch.setattr(ui, "workspace_client", lambda: fake_wc)
+
+    # First attempt fails, second succeeds -> the endpoint is discovered, not lost.
+    assert ui._discover_chat_models() == ["databricks-gpt-5-2", "databricks-gpt-5-5"]
+    assert calls["n"] == 2
+
+
 @pytest.mark.asyncio
 async def test_checkpoint_history_reads_messages_and_interrupts(monkeypatch):
     import agent.agent as agent_module

--- a/integrations/mason/templates/ui/agent-langgraph/ui/app.js
+++ b/integrations/mason/templates/ui/agent-langgraph/ui/app.js
@@ -14,6 +14,7 @@ const elements = {
   memoryMode: document.querySelector("#memory-mode-value"),
   memoryResults: document.querySelector("#memory-results"),
   memoryStatus: document.querySelector("#memory-status"),
+  modelSelect: document.querySelector("#model-select"),
   refreshMemory: document.querySelector("#refresh-memory"),
   newSession: document.querySelector("#new-session"),
   promptInput: document.querySelector("#prompt-input"),
@@ -44,6 +45,7 @@ const state = {
   instanceId: null,
   lastAssistantText: "",
   managedSessionId: "",
+  model: "",
   mode: "streaming",
   pendingInterrupt: null,
   sessionId: "",
@@ -76,6 +78,7 @@ function setBusy(busy, label = "Working") {
   elements.rejectAction.disabled = busy;
   elements.refreshMemory.disabled = busy || !state.config?.memory.enabled;
   elements.newSession.disabled = busy;
+  elements.modelSelect.disabled = busy || elements.modelSelect.options.length <= 1;
   elements.refreshSession.disabled = busy || !state.config?.session.history;
   elements.resumeSession.disabled = busy || !state.config?.session.durable;
   elements.rejectSession.disabled = busy || !state.config?.session.durable;
@@ -316,7 +319,9 @@ function invocationHeaders() {
 }
 
 function invocationPayload(payload) {
-  return { ...payload };
+  // Carry the picker's model so the runtime builds the agent on the selected endpoint. Omit it when
+  // unset so the agent falls back to its configured default.
+  return state.model ? { ...payload, model: state.model } : { ...payload };
 }
 
 async function jsonResponse(response) {
@@ -752,6 +757,21 @@ async function openSession(sessionId) {
   }
 }
 
+function renderModels(models) {
+  const available = models?.available?.length ? models.available : [models?.default].filter(Boolean);
+  state.model = available.includes(state.model) ? state.model : models?.default || available[0] || "";
+  elements.modelSelect.replaceChildren();
+  for (const name of available) {
+    const option = document.createElement("option");
+    option.value = name;
+    option.textContent = name;
+    option.selected = name === state.model;
+    elements.modelSelect.append(option);
+  }
+  // A single choice is informational, not a decision to make.
+  elements.modelSelect.disabled = state.busy || available.length <= 1;
+}
+
 async function loadConfig() {
   try {
     const response = await fetch("/api/demo/config", { cache: "no-store" });
@@ -759,6 +779,7 @@ async function loadConfig() {
     state.config = config;
     state.instanceId = config.instance_id;
     setSessionId(config.session_id);
+    renderModels(config.models);
     elements.viewerValue.textContent = config.viewer;
     elements.streamingMode.textContent = config.streaming.transport;
     elements.backgroundMode.textContent = config.background.durable ? "Durable run store" : "In-process run store";
@@ -848,6 +869,11 @@ document.querySelectorAll(".mode-button").forEach((button) => {
     state.mode = button.dataset.mode;
     document.querySelectorAll(".mode-button").forEach((item) => item.classList.toggle("active", item === button));
   });
+});
+
+elements.modelSelect.addEventListener("change", () => {
+  state.model = elements.modelSelect.value;
+  addEvent("model.selected", { model: state.model });
 });
 
 document.querySelectorAll("[data-prompt]").forEach((button) => {

--- a/integrations/mason/templates/ui/agent-langgraph/ui/index.html
+++ b/integrations/mason/templates/ui/agent-langgraph/ui/index.html
@@ -102,7 +102,15 @@
               <p class="eyebrow">Interactive client</p>
               <h2>LangGraph agent</h2>
             </div>
-            <span id="run-status" class="run-status">Ready</span>
+            <div class="chat-header-controls">
+              <label class="model-picker">
+                <span class="sr-only">Model</span>
+                <select id="model-select" aria-label="Model" disabled>
+                  <option>Loading models…</option>
+                </select>
+              </label>
+              <span id="run-status" class="run-status">Ready</span>
+            </div>
           </div>
 
           <div id="chat-log" class="chat-log" role="log" aria-live="polite" aria-busy="false">

--- a/integrations/mason/templates/ui/agent-langgraph/ui/styles.css
+++ b/integrations/mason/templates/ui/agent-langgraph/ui/styles.css
@@ -462,6 +462,34 @@ h2 {
   border-bottom: 1px solid var(--line);
 }
 
+.chat-header-controls {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.model-picker {
+  display: inline-flex;
+  align-items: center;
+}
+
+.model-picker select {
+  max-width: 220px;
+  padding: 5px 9px;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--surface-muted);
+  color: var(--ink);
+  font-size: 0.72rem;
+  font-weight: 650;
+  cursor: pointer;
+}
+
+.model-picker select:disabled {
+  cursor: default;
+  opacity: 0.7;
+}
+
 .run-status {
   min-height: 26px;
   padding: 4px 10px;

--- a/integrations/mason/templates/ui/agent-openai/CHAT_APP.md
+++ b/integrations/mason/templates/ui/agent-openai/CHAT_APP.md
@@ -17,6 +17,13 @@ The capability indicators are automatic. Streaming and background reflect the ru
 Session reflects transcript history; Memory requires `AGENT_MEMORY_STORE`. The transport selector is
 the only manual capability choice.
 
+The chat header's model picker lists the workspace's ready chat serving endpoints
+(`GET /api/demo/config` → `models`, discovered from `serving_endpoints.list()` and filtered to the
+`llm/v1/chat` task), with `agent.agent.MODEL` pinned as the default. Each request sends the selected
+endpoint as `model` in the invocation body; the agent is rebuilt per turn, so the picker changes the
+model for the next turn without a restart. Discovery is best-effort: if listing is unavailable (e.g.
+no permission), the picker falls back to just the default. Omitting `model` uses `MODEL`.
+
 The UI reads local history from the agent's in-process session (`SQLiteSession`) and managed history
 from Session Store items. The Databricks Apps `__Host-databricks-app-router` cookie is both the sticky
 routing key and the application session id; request bodies do not carry `session_id`. Local

--- a/integrations/mason/templates/ui/agent-openai/CHAT_APP.md
+++ b/integrations/mason/templates/ui/agent-openai/CHAT_APP.md
@@ -24,6 +24,11 @@ endpoint as `model` in the invocation body; the agent is rebuilt per turn, so th
 model for the next turn without a restart. Discovery is best-effort: if listing is unavailable (e.g.
 no permission), the picker falls back to just the default. Omitting `model` uses `MODEL`.
 
+A large workspace can expose thousands of endpoints, so the picker is capped (`_MODEL_LIMIT`, 20)
+and ranked — default first, then `databricks-*` foundation models, then other custom/external chat
+endpoints — so the cap keeps the canonical choices. The list call is unpaginated and occasionally
+fails on big workspaces, so it is retried a few times before falling back to the default.
+
 The UI reads local history from the agent's in-process session (`SQLiteSession`) and managed history
 from Session Store items. The Databricks Apps `__Host-databricks-app-router` cookie is both the sticky
 routing key and the application session id; request bodies do not carry `session_id`. Local

--- a/integrations/mason/templates/ui/agent-openai/runtime/ui.py
+++ b/integrations/mason/templates/ui/agent-openai/runtime/ui.py
@@ -84,6 +84,48 @@ def _is_deployed() -> bool:
     return bool(os.getenv("DATABRICKS_APP_NAME")) and not is_local
 
 
+# The task string the Model Serving API reports for chat/completions endpoints; only these can back
+# a conversational agent, so the picker filters the workspace's endpoints down to them.
+_CHAT_TASK = "llm/v1/chat"
+
+
+def _default_model() -> str:
+    """The agent's configured default endpoint (``agent.agent.MODEL``), imported lazily.
+
+    Imported inside the function, not at module load, so the light UI import path doesn't pull in the
+    agent stack (matching ``_local_history`` below).
+    """
+    from agent.agent import MODEL
+
+    return MODEL
+
+
+def _discover_chat_models() -> list[str]:
+    """List the workspace's ready chat serving endpoints, the agent's default pinned first.
+
+    Powers the chat UI's model picker. Best-effort: any failure (missing list permission, transient
+    API error) yields just the default so the picker still works. The default is always present and
+    first even if the listing omits it.
+    """
+    default = _default_model()
+    names: list[str] = []
+    try:
+        for endpoint in workspace_client().serving_endpoints.list():
+            if endpoint.task != _CHAT_TASK:
+                continue
+            state = getattr(endpoint.state, "ready", None)
+            if state is not None and getattr(state, "value", state) != "READY":
+                continue
+            if endpoint.name:
+                names.append(endpoint.name)
+    except Exception:
+        names = []
+    # Pin the configured default first and drop duplicates while preserving discovery order.
+    ordered = [default, *(n for n in names if n != default)]
+    seen: set[str] = set()
+    return [n for n in ordered if not (n in seen or seen.add(n))]
+
+
 class _ManagedStateClient:
     def __init__(self) -> None:
         self._workspace = workspace_client()
@@ -276,11 +318,14 @@ def install_ui(app: FastAPI) -> None:
         actor = _request_actor(request)
         memory_store = _memory_store()
         session_store = _session_store()
+        # Off-thread: serving_endpoints.list() is a blocking SDK call.
+        available_models = await asyncio.to_thread(_discover_chat_models)
         return {
             "session_id": request.state.session_id,
             "instance_id": _INSTANCE_ID,
             "viewer": actor if actor != "agent" else "Local developer",
             "deployed": _is_deployed(),
+            "models": {"default": _default_model(), "available": available_models},
             "streaming": {"enabled": True, "transport": "Server-sent events"},
             "background": {"enabled": True, "durable": False},
             "session": {

--- a/integrations/mason/templates/ui/agent-openai/runtime/ui.py
+++ b/integrations/mason/templates/ui/agent-openai/runtime/ui.py
@@ -87,6 +87,11 @@ def _is_deployed() -> bool:
 # The task string the Model Serving API reports for chat/completions endpoints; only these can back
 # a conversational agent, so the picker filters the workspace's endpoints down to them.
 _CHAT_TASK = "llm/v1/chat"
+# Cap the picker: a big workspace exposes thousands of endpoints, far too many for a dropdown.
+_MODEL_LIMIT = 20
+# The list API ignores page_size and returns every endpoint in one large, occasionally-failing
+# response; retry a few times before giving up so a transient error doesn't blank the picker.
+_LIST_ATTEMPTS = 3
 
 
 def _default_model() -> str:
@@ -100,30 +105,60 @@ def _default_model() -> str:
     return MODEL
 
 
-def _discover_chat_models() -> list[str]:
-    """List the workspace's ready chat serving endpoints, the agent's default pinned first.
+def _list_chat_endpoints() -> list[str]:
+    """Names of the workspace's ready chat serving endpoints, retrying the flaky list call.
 
-    Powers the chat UI's model picker. Best-effort: any failure (missing list permission, transient
-    API error) yields just the default so the picker still works. The default is always present and
-    first even if the listing omits it.
+    The `/api/2.0/serving-endpoints` list is unpaginated and can intermittently 500 on large
+    workspaces, so retry a few times. Raises the last error if every attempt fails.
     """
-    default = _default_model()
-    names: list[str] = []
-    try:
-        for endpoint in workspace_client().serving_endpoints.list():
-            if endpoint.task != _CHAT_TASK:
-                continue
-            state = getattr(endpoint.state, "ready", None)
-            if state is not None and getattr(state, "value", state) != "READY":
-                continue
-            if endpoint.name:
-                names.append(endpoint.name)
-    except Exception:
-        names = []
-    # Pin the configured default first and drop duplicates while preserving discovery order.
-    ordered = [default, *(n for n in names if n != default)]
+    import time
+
+    last_error: Exception | None = None
+    for attempt in range(_LIST_ATTEMPTS):
+        try:
+            names = []
+            for endpoint in workspace_client().serving_endpoints.list():
+                if endpoint.task != _CHAT_TASK:
+                    continue
+                state = getattr(endpoint.state, "ready", None)
+                if state is not None and getattr(state, "value", state) != "READY":
+                    continue
+                if endpoint.name:
+                    names.append(endpoint.name)
+            return names
+        except Exception as exc:  # noqa: BLE001 - retry any list failure, then surface the last one
+            last_error = exc
+            if attempt < _LIST_ATTEMPTS - 1:
+                time.sleep(0.5)
+    raise last_error if last_error else RuntimeError("serving-endpoints list returned nothing")
+
+
+def _rank_models(default: str, names: list[str]) -> list[str]:
+    """Order the picker so its capped slots stay useful, and drop duplicates.
+
+    The default is pinned first; then Databricks foundation models (``databricks-*``), which are the
+    canonical choices; then any other custom/external chat endpoints. Truncation therefore sheds the
+    least-canonical endpoints first, not an arbitrary alphabetical slice.
+    """
+    foundation = sorted(n for n in names if n.startswith("databricks-") and n != default)
+    other = sorted(n for n in names if not n.startswith("databricks-") and n != default)
+    ordered = [default, *foundation, *other]
     seen: set[str] = set()
     return [n for n in ordered if not (n in seen or seen.add(n))]
+
+
+def _discover_chat_models() -> list[str]:
+    """The chat serving endpoints for the picker: default first, foundation models next, capped.
+
+    Best-effort: if listing fails (missing permission, repeated transient errors), fall back to just
+    the default so the picker still works. The default is always present and first.
+    """
+    default = _default_model()
+    try:
+        names = _list_chat_endpoints()
+    except Exception:  # noqa: BLE001 - a broken listing must not break the whole config endpoint
+        names = []
+    return _rank_models(default, names)[:_MODEL_LIMIT]
 
 
 class _ManagedStateClient:

--- a/integrations/mason/templates/ui/agent-openai/tests/test_demo_ui.py
+++ b/integrations/mason/templates/ui/agent-openai/tests/test_demo_ui.py
@@ -87,6 +87,8 @@ def _client(monkeypatch, *, configured=False, history=False, session_id="routing
         monkeypatch.delenv("AGENT_SESSION_STORE", raising=False)
     if history:
         monkeypatch.setattr(ui, "_local_history", _session_history)
+    # Keep model discovery deterministic and offline (no serving_endpoints.list() call).
+    monkeypatch.setattr(ui, "_discover_chat_models", lambda: ["databricks-gpt-5-2"])
 
     async def invoke_handler(request):
         return {"output": [], "session_id": request["session_id"]}
@@ -113,11 +115,13 @@ def test_demo_ui_routes(monkeypatch):
     assert index.status_code == 200
     assert 'id="new-session"' in index.text
     assert 'id="session-list"' in index.text
+    assert 'id="model-select"' in index.text
     app_script = client.get("/ui-assets/app.js")
     assert app_script.status_code == 200
     assert "mason dev --memory <store-name>" in app_script.text
     assert "mason deploy <app-name> --source . --memory <store-name>" in app_script.text
     assert "refreshSessionView({ hydrateChat: true })" in app_script.text
+    assert "function renderModels(" in app_script.text
     assert 'fetch("/api/session/new"' in app_script.text
     assert "/api/demo/sessions/${encodeURIComponent(sessionId)}/open" in app_script.text
     assert "session_id: ensureSessionId()" not in app_script.text
@@ -128,6 +132,10 @@ def test_demo_ui_routes(monkeypatch):
     config = client.get("/api/demo/config").json()
     assert config["session_id"] == "routing-session"
     assert config["deployed"] is False
+    assert config["models"] == {
+        "default": "databricks-gpt-5-2",
+        "available": ["databricks-gpt-5-2"],
+    }
     assert config["streaming"]["enabled"] is True
     assert config["background"]["enabled"] is True
     assert config["memory"]["enabled"] is False
@@ -223,6 +231,42 @@ def test_chat_session_items_exclude_non_message_items():
         ],
         "next_page_token": "next",
     }
+
+
+def _endpoint(name, task="llm/v1/chat", ready="READY"):
+    state = type("State", (), {"ready": type("Ready", (), {"value": ready})()})()
+    return type("Endpoint", (), {"name": name, "task": task, "state": state})()
+
+
+def test_discover_chat_models_filters_pins_default_and_dedups(monkeypatch):
+    monkeypatch.setattr(ui, "_default_model", lambda: "databricks-gpt-5-2")
+    endpoints = [
+        _endpoint("databricks-claude-sonnet-4"),
+        _endpoint("an-embedding-model", task="llm/v1/embeddings"),  # dropped: wrong task
+        _endpoint("half-ready", ready="NOT_READY"),  # dropped: not ready
+        _endpoint("databricks-gpt-5-2"),  # the default, surfaced again by discovery
+    ]
+    fake_wc = type(
+        "WC", (), {"serving_endpoints": type("SE", (), {"list": lambda self: endpoints})()}
+    )()
+    monkeypatch.setattr(ui, "workspace_client", lambda: fake_wc)
+
+    # Default pinned first, chat endpoints only, no duplicate of the default.
+    assert ui._discover_chat_models() == ["databricks-gpt-5-2", "databricks-claude-sonnet-4"]
+
+
+def test_discover_chat_models_falls_back_to_default_on_error(monkeypatch):
+    monkeypatch.setattr(ui, "_default_model", lambda: "databricks-gpt-5-2")
+
+    def _boom():
+        raise PermissionError("no listing permission")
+
+    fake_wc = type(
+        "WC", (), {"serving_endpoints": type("SE", (), {"list": lambda self: _boom()})()}
+    )()
+    monkeypatch.setattr(ui, "workspace_client", lambda: fake_wc)
+
+    assert ui._discover_chat_models() == ["databricks-gpt-5-2"]
 
 
 @pytest.mark.asyncio

--- a/integrations/mason/templates/ui/agent-openai/tests/test_demo_ui.py
+++ b/integrations/mason/templates/ui/agent-openai/tests/test_demo_ui.py
@@ -269,6 +269,46 @@ def test_discover_chat_models_falls_back_to_default_on_error(monkeypatch):
     assert ui._discover_chat_models() == ["databricks-gpt-5-2"]
 
 
+def test_discover_chat_models_ranks_foundation_first_and_caps(monkeypatch):
+    monkeypatch.setattr(ui, "_default_model", lambda: "databricks-gpt-5-2")
+    # A big workspace: many custom endpoints plus a few foundation models. The cap must keep the
+    # default and the databricks-* foundation models, not an arbitrary alphabetical slice of customs.
+    endpoints = [_endpoint(f"zz-custom-{i:03d}") for i in range(30)]
+    endpoints += [_endpoint("databricks-gpt-5-5"), _endpoint("databricks-claude-sonnet-4")]
+    fake_wc = type(
+        "WC", (), {"serving_endpoints": type("SE", (), {"list": lambda self: endpoints})()}
+    )()
+    monkeypatch.setattr(ui, "workspace_client", lambda: fake_wc)
+
+    result = ui._discover_chat_models()
+    assert len(result) == 20  # capped
+    assert result[0] == "databricks-gpt-5-2"  # default pinned
+    # Foundation models win slots ahead of any custom endpoint.
+    assert result[1:3] == ["databricks-claude-sonnet-4", "databricks-gpt-5-5"]
+    assert all(name.startswith(("databricks-", "zz-custom-")) for name in result)
+
+
+def test_discover_chat_models_retries_transient_list_error(monkeypatch):
+    import time
+
+    monkeypatch.setattr(ui, "_default_model", lambda: "databricks-gpt-5-2")
+    monkeypatch.setattr(time, "sleep", lambda _s: None)  # don't actually wait between retries
+    calls = {"n": 0}
+
+    def _list(self):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise RuntimeError("transient 500")
+        return [_endpoint("databricks-gpt-5-5")]
+
+    fake_wc = type("WC", (), {"serving_endpoints": type("SE", (), {"list": _list})()})()
+    monkeypatch.setattr(ui, "workspace_client", lambda: fake_wc)
+
+    # First attempt fails, second succeeds -> the endpoint is discovered, not lost.
+    assert ui._discover_chat_models() == ["databricks-gpt-5-2", "databricks-gpt-5-5"]
+    assert calls["n"] == 2
+
+
 @pytest.mark.asyncio
 async def test_local_history_reads_messages_from_in_process_session(monkeypatch):
     import databricks_mason.openai.sessions as ss

--- a/integrations/mason/templates/ui/agent-openai/ui/app.js
+++ b/integrations/mason/templates/ui/agent-openai/ui/app.js
@@ -14,6 +14,7 @@ const elements = {
   memoryMode: document.querySelector("#memory-mode-value"),
   memoryResults: document.querySelector("#memory-results"),
   memoryStatus: document.querySelector("#memory-status"),
+  modelSelect: document.querySelector("#model-select"),
   refreshMemory: document.querySelector("#refresh-memory"),
   newSession: document.querySelector("#new-session"),
   promptInput: document.querySelector("#prompt-input"),
@@ -44,6 +45,7 @@ const state = {
   instanceId: null,
   lastAssistantText: "",
   managedSessionId: "",
+  model: "",
   mode: "streaming",
   pendingInterrupt: null,
   sessionId: "",
@@ -76,6 +78,7 @@ function setBusy(busy, label = "Working") {
   elements.rejectAction.disabled = busy;
   elements.refreshMemory.disabled = busy || !state.config?.memory.enabled;
   elements.newSession.disabled = busy;
+  elements.modelSelect.disabled = busy || elements.modelSelect.options.length <= 1;
   elements.refreshSession.disabled = busy || !state.config?.session.history;
   elements.resumeSession.disabled = busy || !state.config?.session.durable;
   elements.rejectSession.disabled = busy || !state.config?.session.durable;
@@ -316,7 +319,9 @@ function invocationHeaders() {
 }
 
 function invocationPayload(payload) {
-  return { ...payload };
+  // Carry the picker's model so the runtime builds the agent on the selected endpoint. Omit it when
+  // unset so the agent falls back to its configured default.
+  return state.model ? { ...payload, model: state.model } : { ...payload };
 }
 
 async function jsonResponse(response) {
@@ -716,6 +721,21 @@ async function openSession(sessionId) {
   }
 }
 
+function renderModels(models) {
+  const available = models?.available?.length ? models.available : [models?.default].filter(Boolean);
+  state.model = available.includes(state.model) ? state.model : models?.default || available[0] || "";
+  elements.modelSelect.replaceChildren();
+  for (const name of available) {
+    const option = document.createElement("option");
+    option.value = name;
+    option.textContent = name;
+    option.selected = name === state.model;
+    elements.modelSelect.append(option);
+  }
+  // A single choice is informational, not a decision to make.
+  elements.modelSelect.disabled = state.busy || available.length <= 1;
+}
+
 async function loadConfig() {
   try {
     const response = await fetch("/api/demo/config", { cache: "no-store" });
@@ -723,6 +743,7 @@ async function loadConfig() {
     state.config = config;
     state.instanceId = config.instance_id;
     setSessionId(config.session_id);
+    renderModels(config.models);
     elements.viewerValue.textContent = config.viewer;
     elements.streamingMode.textContent = config.streaming.transport;
     elements.backgroundMode.textContent = config.background.durable ? "Durable run store" : "In-process run store";
@@ -812,6 +833,11 @@ document.querySelectorAll(".mode-button").forEach((button) => {
     state.mode = button.dataset.mode;
     document.querySelectorAll(".mode-button").forEach((item) => item.classList.toggle("active", item === button));
   });
+});
+
+elements.modelSelect.addEventListener("change", () => {
+  state.model = elements.modelSelect.value;
+  addEvent("model.selected", { model: state.model });
 });
 
 document.querySelectorAll("[data-prompt]").forEach((button) => {

--- a/integrations/mason/templates/ui/agent-openai/ui/index.html
+++ b/integrations/mason/templates/ui/agent-openai/ui/index.html
@@ -102,7 +102,15 @@
               <p class="eyebrow">Interactive client</p>
               <h2>OpenAI agent</h2>
             </div>
-            <span id="run-status" class="run-status">Ready</span>
+            <div class="chat-header-controls">
+              <label class="model-picker">
+                <span class="sr-only">Model</span>
+                <select id="model-select" aria-label="Model" disabled>
+                  <option>Loading models…</option>
+                </select>
+              </label>
+              <span id="run-status" class="run-status">Ready</span>
+            </div>
           </div>
 
           <div id="chat-log" class="chat-log" role="log" aria-live="polite" aria-busy="false">

--- a/integrations/mason/templates/ui/agent-openai/ui/styles.css
+++ b/integrations/mason/templates/ui/agent-openai/ui/styles.css
@@ -462,6 +462,34 @@ h2 {
   border-bottom: 1px solid var(--line);
 }
 
+.chat-header-controls {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.model-picker {
+  display: inline-flex;
+  align-items: center;
+}
+
+.model-picker select {
+  max-width: 220px;
+  padding: 5px 9px;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--surface-muted);
+  color: var(--ink);
+  font-size: 0.72rem;
+  font-weight: 650;
+  cursor: pointer;
+}
+
+.model-picker select:disabled {
+  cursor: default;
+  opacity: 0.7;
+}
+
 .run-status {
   min-height: 26px;
   padding: 4px 10px;


### PR DESCRIPTION
Add a model dropdown to both chat-app templates (langgraph, openai). The config endpoint discovers the workspace's ready chat serving endpoints (llm/v1/chat) with the agent's MODEL pinned as default; the UI sends the choice as `model` in the invocation body, and the per-turn agent build honors it (falling back to MODEL). Discovery is best-effort — falls back to just the default if listing is unavailable.

<img width="785" height="790" alt="Screenshot 2026-09-03 at 2 13 35 PM" src="https://github.com/user-attachments/assets/e6b91e5b-f425-4ba4-b2cd-2735bc69499a" />
