### PR TITLE
[mason] deploy/dev read agent.toml store bindings

### DIFF
--- a/integrations/mason/README.md
+++ b/integrations/mason/README.md
@@ -86,12 +86,15 @@ mason [-p <profile>] [-o text|json]
   init         [--framework openai|langgraph] [--disable-chat-app]
                [--profile P] [--repo URL] [--ref REF] [directory]
   dev          [--source PATH] [--prepare-environment] [--app-port PORT]
-               [--memory/-m N] [--session/-s N]
-               [--with-traces C.S] [--no-create-stores]
+               [--with-traces C.S]
   memory
+    bind         STORE [--source PATH] [--no-create-stores]
+    unbind       [--source PATH]
     stores     create | list | get | update | delete
     entries    create | get | list | search | update | delete
   sessions     create | list | get | update | delete | fork
+    bind         STORE [--source PATH] [--no-create-stores]
+    unbind       [--source PATH]
     stores     create | list | get | update | delete
     items      list | append | pop | clear
   tracing
@@ -105,9 +108,7 @@ mason [-p <profile>] [-o text|json]
     add uc-function  FUNCTION [--name NAME] [--source PATH]
     add python       NAME [--source PATH]
     list             [--source PATH]
-  deploy       <name> --source PATH [--memory/-m N]
-               [--session/-s N] [--actor-id ID]
-               [--with-traces C.S] [--no-create-stores]
+  deploy       <name> --source PATH [--with-traces C.S]
   deployments  list | get | logs | start | stop | delete
 ```
 
@@ -193,16 +194,17 @@ The chat app includes synchronous, SSE streaming, background polling, Session St
 and HITL resume UI. The framework-specific overlay adds `ui/`, `runtime/ui.py`, the UI-enabled
 `runtime/main.py`, and UI tests.
 
-For the full deployed demo, connect both managed stores:
+For the full deployed demo, bind both managed stores, then deploy:
 
 ```sh
-mason --profile <profile> deploy mason-agent-demo --source . \
-  --session mason-demo-sessions \
-  --memory mason-demo-memory \
-  --actor-id alice
+mason sessions bind mason-demo-sessions
+mason memory bind mason-demo-memory
+mason --profile <profile> deploy mason-agent-demo --source .
 ```
 
-(Missing stores are created automatically; pass `--no-create-stores` to require they already exist.)
+(Binding creates a missing store automatically; pass `--no-create-stores` to require it already
+exists. The agent reads the bound stores from `agent.toml` at runtime; `deploy` grants the app's
+service principal access to them.)
 
 The Databricks Apps `__Host-databricks-app-router` cookie is both the sticky routing key and the
 application session id. The browser sends it automatically; API clients must reuse it as a cookie.

--- a/integrations/mason/src/databricks_mason/agent_project.py
+++ b/integrations/mason/src/databricks_mason/agent_project.py
@@ -201,6 +201,14 @@ def _store_name_from_manifest(value: object, table: str) -> str | None:
     return _required_string(cast(Mapping[str, Any], value).get("name"), f"[{table}] name")
 
 
+def _store_id_from_manifest(value: object) -> str | None:
+    """Read the optional bare store ``id`` from a ``[memory_store]`` table, or None if absent."""
+    if not isinstance(value, Mapping):
+        return None
+    store_id = cast(Mapping[str, Any], value).get("id")
+    return store_id if isinstance(store_id, str) and store_id else None
+
+
 def _scope_from_manifest(value: object) -> Scope:
     if not isinstance(value, Mapping):
         raise AgentCliError("Sandbox downscope entries must be TOML tables.")
@@ -287,15 +295,18 @@ class AgentProject:
         tools: list[ToolSpec],
         memory_store: str | None = None,
         session_store: str | None = None,
+        memory_store_id: str | None = None,
     ) -> None:
         self.root = root
         self.path = root / "agent.toml"
         self._document = document
         self.framework = framework
         self.tools = tools
-        # Managed store bindings declared in agent.toml; None = unbound.
+        # Managed store bindings declared in agent.toml; None = unbound. memory_store_id is the bare
+        # store id the runtime needs for the entries API (the display name can't be used there).
         self.memory_store = memory_store
         self.session_store = session_store
+        self.memory_store_id = memory_store_id
 
     @classmethod
     def load(cls, root: pathlib.Path | str) -> "AgentProject":
@@ -332,10 +343,19 @@ class AgentProject:
         memory_store = _store_name_from_manifest(
             document.get(MEMORY_STORE_TABLE), MEMORY_STORE_TABLE
         )
+        memory_store_id = _store_id_from_manifest(document.get(MEMORY_STORE_TABLE))
         session_store = _store_name_from_manifest(
             document.get(SESSION_STORE_TABLE), SESSION_STORE_TABLE
         )
-        return cls(project_root, document, framework, tools, memory_store, session_store)
+        return cls(
+            project_root,
+            document,
+            framework,
+            tools,
+            memory_store,
+            session_store,
+            memory_store_id,
+        )
 
     @classmethod
     def create(cls, root: pathlib.Path | str, *, framework: str) -> "AgentProject":
@@ -388,9 +408,14 @@ class AgentProject:
         del self.tools[index]
         return True
 
-    def bind_memory_store(self, name: str) -> bool:
-        """Declare the memory store binding in agent.toml. Returns True if it changed."""
-        return self._set_store(MEMORY_STORE_TABLE, name)
+    def bind_memory_store(self, name: str, store_id: str | None = None) -> bool:
+        """Declare the memory store binding in agent.toml. Returns True if it changed.
+
+        ``store_id`` is the bare store id (``memory-stores/<id>`` minus the prefix). The runtime needs
+        the id, not the display name, to build the entries API path, so we record it alongside the
+        name to keep resolution a pure agent.toml read.
+        """
+        return self._set_store(MEMORY_STORE_TABLE, name, store_id)
 
     def bind_session_store(self, name: str) -> bool:
         """Declare the session store binding in agent.toml. Returns True if it changed."""
@@ -404,18 +429,26 @@ class AgentProject:
         """Remove the session store binding from agent.toml. Returns True if it was present."""
         return self._clear_store(SESSION_STORE_TABLE)
 
-    def _set_store(self, table: str, name: str) -> bool:
+    def _set_store(self, table: str, name: str, store_id: str | None = None) -> bool:
         name = _required_string(name, f"[{table}] name")
-        if getattr(self, table) == name:
+        if getattr(self, table) == name and getattr(self, f"{table}_id", None) == store_id:
             return False
         existing = self._document.get(table)
         if isinstance(existing, Mapping):
             existing["name"] = name
+            if store_id:
+                existing["id"] = store_id
+            elif "id" in existing:
+                del existing["id"]
         else:
             store_table = tomlkit.table()
             store_table.add("name", name)
+            if store_id:
+                store_table.add("id", store_id)
             self._document.append(table, store_table)
         setattr(self, table, name)
+        if hasattr(self, f"{table}_id"):
+            setattr(self, f"{table}_id", store_id)
         return True
 
     def _clear_store(self, table: str) -> bool:
@@ -424,6 +457,8 @@ class AgentProject:
         if table in self._document:
             del self._document[table]
         setattr(self, table, None)
+        if hasattr(self, f"{table}_id"):
+            setattr(self, f"{table}_id", None)
         return True
 
     def write(self) -> pathlib.Path:

--- a/integrations/mason/src/databricks_mason/deploy.py
+++ b/integrations/mason/src/databricks_mason/deploy.py
@@ -1,8 +1,9 @@
 """`mason deploy` and the `mason deployments` group — manage agent deployments.
 
-`mason deploy` is the integrated entry point: it can provision a memory store and a
-session store for the agent, inject their identifiers into the deployment's `app.yaml`
-env, then roll out the deployment. `mason deployments` covers the lifecycle verbs
+`mason deploy` is the integrated entry point: it provisions the memory/session stores
+bound in `agent.toml`, grants the app's service principal access to them, then rolls out
+the deployment. The stores are read from `agent.toml` at runtime, so they are not written
+into `app.yaml`. `mason deployments` covers the lifecycle verbs
 (`list`/`get`/`logs`/`start`/`stop`/`delete`).
 
 Deployments run on the Databricks Apps runtime, which this module drives via the
@@ -24,9 +25,6 @@ from databricks_mason.errors import AgentCliError
 from databricks_mason.render import field
 from databricks_mason.store_access import _databricks, apply_postgres_resources, grant_tables
 from databricks_mason.tracing import TRACES_DEST_ENV, TRACES_EXPERIMENT_ENV, default_experiment
-
-_MEMORY_ENV = "AGENT_MEMORY_STORE"
-_SESSION_ENV = "AGENT_SESSION_STORE"
 
 # TEMPORARY: the Apps build environment currently can't reach the internal pypi proxy, so builds
 # time out installing dependencies. Point the build at public PyPI (sanctioned interim workaround)
@@ -222,7 +220,26 @@ def _memory_store_database(client, memory_store: str) -> Optional[str]:
     return memory_store_access.database_from_backend_id(backend_id) if backend_id else None
 
 
-def resolve_store_env(
+def store_bindings(source: pathlib.Path) -> tuple[Optional[str], Optional[str]]:
+    """The (memory, session) stores bound in agent.toml via `mason memory/sessions bind`.
+
+    agent.toml is the single source of truth for an agent's stores. Both `mason dev` and `mason
+    deploy` resolve through here so the store env AND the deploy-time access grant honor the same
+    bindings. Missing/invalid agent.toml is ignored (no stores), so this never blocks a run.
+    """
+    try:
+        from databricks_mason.agent_project import AgentProject
+
+        project = AgentProject.load(source)
+    except AgentCliError:
+        return None, None
+    # str(): agent.toml bindings come back as tomlkit strings, which don't serialize to app.yaml.
+    memory = str(project.memory_store) if project.memory_store else None
+    session = str(project.session_store) if project.session_store else None
+    return memory, session
+
+
+def validate_stores_and_trace_env(
     client,
     *,
     app: Optional[str],
@@ -230,45 +247,30 @@ def resolve_store_env(
     session_store: Optional[str],
     traces_destination: Optional[str],
     traces_experiment: Optional[str],
-    create_stores: bool,
 ) -> dict[str, str]:
-    """Resolve store/trace references to the AGENT_*/MLFLOW_* env vars that wire them in.
+    """Validate the agent's bound stores exist and build the MLFLOW_* trace env to wire in.
 
-    Shared by `mason deploy` and `mason dev` so both wire an agent's stores into app.yaml the same
-    way. With `create_stores` (the default), missing stores are created (idempotent); when it is off
-    they must already exist. The memory store resolves to its bare id (the runtime re-adds the
-    `memory-stores/` prefix when building the entries URL); the session store and trace destination
-    are used verbatim.
+    Shared by `mason deploy` and `mason dev`. Stores are created by `mason memory/sessions bind` and
+    read from agent.toml at runtime, so this neither creates them nor writes them to app.yaml — it
+    only checks a bound store still exists (a typo or unbound clone fails here, not at runtime) and
+    returns the trace env.
     """
-    env: dict[str, str] = {}
-    if memory_store:
-        # Resolve by display name (what users pass) in both cases: get_memory_store looks up by
-        # resource id, so it can't resolve a display name on the non-create path.
-        if create_stores:
-            store = _ensure_memory_store(client, memory_store)
-        else:
-            store = _resolve_memory_store(client, memory_store)
-            if store is None:
-                raise AgentCliError(
-                    f"Memory store '{memory_store}' does not exist "
-                    "(drop --no-create-stores to create it)."
-                )
-        store_name = field(store, "name") or memory_store
-        env[_MEMORY_ENV] = store_name.split("/", 1)[-1]
+    if memory_store and _resolve_memory_store(client, memory_store) is None:
+        # Resolve by display name: get_memory_store looks up by resource id, not the bound name.
+        raise AgentCliError(
+            f"Memory store '{memory_store}' does not exist.",
+            hint=f"Run `mason memory bind {memory_store}` to create and bind it.",
+        )
     if session_store:
-        if create_stores:
-            _ensure_session_store(client, session_store)
-        else:
-            # Validate existence up front so a typo fails at deploy time, not at runtime.
-            try:
-                client.get_session_store(session_store)
-            except AgentCliError as exc:
-                raise AgentCliError(
-                    f"Session store '{session_store}' does not exist "
-                    "(drop --no-create-stores to create it).",
-                    error_code=exc.error_code,
-                ) from exc
-        env[_SESSION_ENV] = session_store
+        try:
+            client.get_session_store(session_store)
+        except AgentCliError as exc:
+            raise AgentCliError(
+                f"Session store '{session_store}' does not exist.",
+                hint=f"Run `mason sessions bind {session_store}` to create and bind it.",
+                error_code=exc.error_code,
+            ) from exc
+    env: dict[str, str] = {}
     if traces_destination:
         env[TRACES_DEST_ENV] = traces_destination
         # The agent enables tracing only when BOTH a destination and an experiment are set, so
@@ -327,20 +329,6 @@ def _grant_store_access(
     "current directory.",
 )
 @click.option(
-    "--memory",
-    "-m",
-    "memory_store",
-    default=None,
-    help="Memory store display name to wire in via AGENT_MEMORY_STORE.",
-)
-@click.option(
-    "--session",
-    "-s",
-    "session_store",
-    default=None,
-    help="Session store name to wire in via AGENT_SESSION_STORE.",
-)
-@click.option(
     "--with-traces",
     "traces_destination",
     default=None,
@@ -351,12 +339,6 @@ def _grant_store_access(
     "--traces-experiment",
     default=None,
     help="MLflow experiment path to wire in via MLFLOW_EXPERIMENT_NAME.",
-)
-@click.option(
-    "--no-create-stores",
-    is_flag=True,
-    help="Require referenced stores to already exist. By default missing stores are created "
-    "(idempotent).",
 )
 @click.option(
     "--pip-index-url",
@@ -374,15 +356,12 @@ def deploy(
     obj,
     name,
     source,
-    memory_store,
-    session_store,
     traces_destination,
     traces_experiment,
-    no_create_stores,
     pip_index_url,
     workspace_path,
 ) -> None:
-    """Deploy an agent: provision its stores, wire them in, and roll out the deployment.
+    """Deploy an agent: validate its bound stores, wire in tracing, and roll out the deployment.
 
     The app is named `mason-<name>` (Mason adds the prefix if absent); use that full name with the
     other `mason deployments` verbs. `deployments list` shows only apps carrying this prefix.
@@ -392,21 +371,24 @@ def deploy(
     source_dir = pathlib.Path(source)
     client = obj.client()
 
-    # 1. Provision / resolve stores and build the env to inject.
-    env_updates = resolve_store_env(
-        client,
-        app=name,
-        memory_store=memory_store,
-        session_store=session_store,
-        traces_destination=traces_destination,
-        traces_experiment=traces_experiment,
-        create_stores=not no_create_stores,
-    )
+    # 1. Validate the agent's bound stores (`mason memory/sessions bind` creates them) and build any
+    #    trace env. Stores are read from agent.toml at runtime, not wired into app.yaml; the bindings
+    #    also drive the store access grant (step 4).
+    memory_store, session_store = store_bindings(source_dir)
+    with render.status("Checking stores…"):
+        env_updates = validate_stores_and_trace_env(
+            client,
+            app=name,
+            memory_store=memory_store,
+            session_store=session_store,
+            traces_destination=traces_destination,
+            traces_experiment=traces_experiment,
+        )
     provisioned: dict[str, Any] = {}
-    if _MEMORY_ENV in env_updates:
-        provisioned["Memory store"] = env_updates[_MEMORY_ENV]
-    if _SESSION_ENV in env_updates:
-        provisioned["Session store"] = env_updates[_SESSION_ENV]
+    if memory_store:
+        provisioned["Memory store"] = memory_store
+    if session_store:
+        provisioned["Session store"] = session_store
     if traces_destination:
         provisioned["Traces"] = traces_destination
     if pip_index_url:
@@ -414,7 +396,7 @@ def deploy(
             env_updates[env] = pip_index_url
         provisioned["Package index"] = pip_index_url
 
-    # 2. Patch the app.yaml manifest with the store identifiers.
+    # 2. Patch the app.yaml manifest with any trace/index env (stores are read from agent.toml).
     scaffolded = False
     if env_updates:
         scaffolded = _upsert_manifest_env(source_dir, env_updates)
@@ -426,7 +408,8 @@ def deploy(
         click.echo((result.stdout or "").replace(old, new), nl=False)
         # `apps create` returns before the app's compute is up, but `apps deploy` requires it to be
         # RUNNING — so wait for it, or the first deploy races and fails ("not in RUNNING state").
-        _wait_for_running(name, obj.profile)
+        with render.status("Waiting for app compute to start (this can take a few minutes)…"):
+            _wait_for_running(name, obj.profile)
     ws_path = workspace_path or f"/Workspace/Users/{client.current_user}/mason_deployments/{name}"
     # Don't ship uv.lock: it pins exact package URLs from whatever index the developer's machine
     # resolved against (often an internal proxy). The Apps build must resolve against its own
@@ -440,14 +423,17 @@ def deploy(
     grants_stores = bool(session_store or memory_store)
     grant_error: Optional[str] = None
     if grants_stores:
-        sp = _app_service_principal(name, obj.profile)
-        if sp is None:
-            grant_error = "could not resolve the app's service principal."
-        else:
-            memory_database = _memory_store_database(client, memory_store) if memory_store else None
-            grant_error = _grant_store_access(
-                name, sp, client.current_user, session_store, memory_database, obj.profile
-            )
+        with render.status("Granting the app access to its stores…"):
+            sp = _app_service_principal(name, obj.profile)
+            if sp is None:
+                grant_error = "could not resolve the app's service principal."
+            else:
+                memory_database = (
+                    _memory_store_database(client, memory_store) if memory_store else None
+                )
+                grant_error = _grant_store_access(
+                    name, sp, client.current_user, session_store, memory_database, obj.profile
+                )
 
     app_url = _app_url(name, obj.profile)
 

--- a/integrations/mason/src/databricks_mason/dev.py
+++ b/integrations/mason/src/databricks_mason/dev.py
@@ -16,7 +16,11 @@ import click
 import yaml
 
 from databricks_mason import render
-from databricks_mason.deploy import _upsert_manifest_env, resolve_store_env
+from databricks_mason.deploy import (
+    _upsert_manifest_env,
+    store_bindings,
+    validate_stores_and_trace_env,
+)
 from databricks_mason.errors import AgentCliError
 from databricks_mason.store_access import _databricks
 
@@ -45,20 +49,6 @@ _BUILD_INDEX_ENVS = frozenset({"PIP_INDEX_URL", "UV_INDEX_URL", "UV_DEFAULT_INDE
 )
 @click.option("--app-port", type=int, default=None, help="Port to run the app on (default 8000).")
 @click.option(
-    "--memory",
-    "-m",
-    "memory_store",
-    default=None,
-    help="Memory store display name to wire in via AGENT_MEMORY_STORE (same as `mason deploy`).",
-)
-@click.option(
-    "--session",
-    "-s",
-    "session_store",
-    default=None,
-    help="Session store name to wire in via AGENT_SESSION_STORE (same as `mason deploy`).",
-)
-@click.option(
     "--with-traces",
     "traces_destination",
     default=None,
@@ -69,23 +59,14 @@ _BUILD_INDEX_ENVS = frozenset({"PIP_INDEX_URL", "UV_INDEX_URL", "UV_DEFAULT_INDE
     default=None,
     help="MLflow experiment path to wire in via MLFLOW_EXPERIMENT_NAME.",
 )
-@click.option(
-    "--no-create-stores",
-    is_flag=True,
-    help="Require referenced stores to already exist. By default missing stores are created "
-    "(idempotent).",
-)
 @click.pass_obj
 def dev(
     obj,
     source: str,
     prepare_environment: Optional[bool],
     app_port: Optional[int],
-    memory_store: Optional[str],
-    session_store: Optional[str],
     traces_destination: Optional[str],
     traces_experiment: Optional[str],
-    no_create_stores: bool,
 ) -> None:
     """Run a scaffolded agent locally from its app.yaml (wraps `databricks apps run-local`).
 
@@ -94,11 +75,10 @@ def dev(
     ``mason deploy``. The environment is built on first run and reused after; pass
     ``--prepare-environment`` to force a rebuild (e.g. after changing dependencies).
 
-    The ``--memory`` / ``--session`` / ``--with-traces`` flags wire an agent's stores/traces
-    into ``app.yaml`` before running, exactly as ``mason deploy`` does — so you can iterate locally
-    against a real store without hand-editing env.
-    Locally the store owner (you) already has access, so no service-principal grant is needed here;
-    that grant happens at ``mason deploy`` time.
+    Stores bound with ``mason memory/sessions bind`` are provisioned here and read from agent.toml at
+    runtime (not written to app.yaml); the ``--with-traces`` flag wires tracing env into app.yaml,
+    exactly as ``mason deploy`` does. Locally the store owner (you) already has access, so no
+    service-principal grant is needed here; that grant happens at ``mason deploy`` time.
     """
     source_dir = pathlib.Path(source)
     app_yaml = source_dir / "app.yaml"
@@ -108,19 +88,22 @@ def dev(
             hint="Run from a scaffolded project, or pass --source <dir> (see `mason init`).",
         )
 
-    # Wire any requested stores/traces into app.yaml first, so run-local reads the updated env.
+    # Validate the agent.toml store bindings exist and wire any traces into app.yaml. The stores are
+    # read from agent.toml at runtime, so they aren't written to app.yaml — set them (and create them)
+    # with `mason memory/sessions bind`.
+    memory_store, session_store = store_bindings(source_dir)
     if memory_store or session_store or traces_destination or traces_experiment:
         # The agent name defaults to the project dir name, so a per-app trace experiment here matches
         # what `mason deploy <that-name>` derives.
-        env_updates = resolve_store_env(
-            obj.client(),
-            app=source_dir.resolve().name,
-            memory_store=memory_store,
-            session_store=session_store,
-            traces_destination=traces_destination,
-            traces_experiment=traces_experiment,
-            create_stores=not no_create_stores,
-        )
+        with render.status("Checking stores…"):
+            env_updates = validate_stores_and_trace_env(
+                obj.client(),
+                app=source_dir.resolve().name,
+                memory_store=memory_store,
+                session_store=session_store,
+                traces_destination=traces_destination,
+                traces_experiment=traces_experiment,
+            )
         if env_updates:
             _upsert_manifest_env(source_dir, env_updates)
 
@@ -161,7 +144,7 @@ def _announce_local_url(source_dir: pathlib.Path, port: int) -> None:
             next_steps=[
                 f"Open {base} to chat with your agent",
                 ("mason tools add mcp <service>", "Give the agent a tool"),
-                ("mason dev -m <store> -s <store>", "Attach a memory / session store"),
+                ("mason memory bind <store>", "Attach a memory / session store"),
                 (f"mason deploy {deploy_name}", "Deploy it to Databricks"),
             ],
         )

--- a/integrations/mason/src/databricks_mason/dev.py
+++ b/integrations/mason/src/databricks_mason/dev.py
@@ -75,7 +75,7 @@ def dev(
     ``mason deploy``. The environment is built on first run and reused after; pass
     ``--prepare-environment`` to force a rebuild (e.g. after changing dependencies).
 
-    Stores bound with ``mason memory/sessions bind`` are provisioned here and read from agent.toml at
+    Stores bound with ``mason memory/sessions bind`` are validated here and read from agent.toml at
     runtime (not written to app.yaml); the ``--with-traces`` flag wires tracing env into app.yaml,
     exactly as ``mason deploy`` does. Locally the store owner (you) already has access, so no
     service-principal grant is needed here; that grant happens at ``mason deploy`` time.

--- a/integrations/mason/src/databricks_mason/help.py
+++ b/integrations/mason/src/databricks_mason/help.py
@@ -27,7 +27,7 @@ _EXAMPLES: dict[CommandPath, tuple[Example, ...]] = {
     ("dev",): (("mason dev", "run the agent locally with a chat UI"),),
     ("memory",): (
         ("mason memory stores create --display-name agent-memory", "create a memory store"),
-        ("mason deploy <agent> --memory agent-memory", "wire it into a deployment"),
+        ("mason memory bind agent-memory", "bind it to the agent (wired in on dev/deploy)"),
     ),
     ("memory", "bind"): (
         ("mason memory bind agent-memory --source .", "declare a memory store in agent.toml"),

--- a/integrations/mason/src/databricks_mason/memory.py
+++ b/integrations/mason/src/databricks_mason/memory.py
@@ -94,8 +94,8 @@ def _source_option(function):
 def memory_bind(obj, store: str, source: pathlib.Path, no_create_stores: bool) -> None:
     """Bind memory STORE to the agent, declaring it in agent.toml (creating it if it doesn't exist).
 
-    `mason dev` / `mason deploy` sync the bound store into the deployment's app.yaml env and grant the
-    app access. Pass --no-create-stores to require the store to already exist.
+    The agent reads the store from agent.toml at runtime; `mason deploy` grants the deployed app's
+    service principal access to it. Pass --no-create-stores to require the store to already exist.
     """
     from databricks_mason.agent_project import AgentProject
     from databricks_mason.deploy import _ensure_memory_store, _resolve_memory_store
@@ -103,17 +103,19 @@ def memory_bind(obj, store: str, source: pathlib.Path, no_create_stores: bool) -
     client = obj.client()
     if no_create_stores:
         with render.status(f"Resolving memory store '{store}'…"):
-            exists = _resolve_memory_store(client, store) is not None
-        if not exists:
+            resolved = _resolve_memory_store(client, store)
+        if resolved is None:
             raise AgentCliError(
                 f"Memory store '{store}' does not exist (drop --no-create-stores to create it)."
             )
     else:
         with render.status(f"Provisioning memory store '{store}'…"):
-            _ensure_memory_store(client, store)
+            resolved = _ensure_memory_store(client, store)
 
+    # Record the bare store id: the runtime needs it (not the display name) for the entries API.
+    store_id = (field(resolved, "name") or "").split("/", 1)[-1] or None
     project = AgentProject.load(source)
-    project.bind_memory_store(store)
+    project.bind_memory_store(store, store_id)
     project.write()
     if obj.output == "json":
         render.emit_json({"memory_store": store, "manifest": str(project.path)})
@@ -121,7 +123,10 @@ def memory_bind(obj, store: str, source: pathlib.Path, no_create_stores: bool) -
     render.success(
         f"Bound memory store '{store}'",
         fields={"agent.toml": str(project.path)},
-        next_steps=["mason dev", "mason deploy <name>"],
+        next_steps=[
+            ("mason dev", "Re-run to pick up the store locally"),
+            ("mason deploy <name>", "Redeploy to grant the app access"),
+        ],
     )
 
 
@@ -229,8 +234,8 @@ def stores_create(obj, display_name, description) -> None:
             ),
             (f"mason memory stores get {store_id}", "View this store's details"),
             (
-                f"mason deploy <agent> --memory {display_name}",
-                "Wire this store into a deployment",
+                f"mason memory bind {display_name}",
+                "Bind this store to the agent (wired in on dev/deploy)",
             ),
         ],
     )

--- a/integrations/mason/src/databricks_mason/render.py
+++ b/integrations/mason/src/databricks_mason/render.py
@@ -34,9 +34,15 @@ def status(message: str, con: Optional[Console] = None) -> Iterator[None]:
     """Show an animated spinner with ``message`` while a slow call runs, then clear it.
 
     Wraps ``rich``'s console status; a no-op spinner (no TTY) still runs the body. Use around
-    network work like store provisioning so the CLI doesn't look hung.
+    network work like store provisioning so the CLI doesn't look hung. Under ``-o json`` the spinner
+    is skipped so no control characters leak into machine-readable output.
     """
+    from databricks_mason import errors  # local import avoids a cycle at module load
+
     con = con or _stdout
+    if errors._OUTPUT_MODE == "json":
+        yield
+        return
     with con.status(message, spinner="dots"):
         yield
 

--- a/integrations/mason/src/databricks_mason/runtime/tool_manifest.py
+++ b/integrations/mason/src/databricks_mason/runtime/tool_manifest.py
@@ -142,13 +142,14 @@ def load_tools(*, expected_framework: str) -> tuple[ToolRecord, ...]:
     return tools
 
 
-def store_binding(table: str) -> str | None:
-    """The store ``name`` declared in agent.toml's ``[memory_store]`` / ``[session_store]``, or None.
+def store_binding(table: str, prefer: str = "name") -> str | None:
+    """The store binding declared in agent.toml's ``[memory_store]`` / ``[session_store]``, or None.
 
     Read at runtime so `mason memory/sessions bind` (which writes these tables) takes effect without
-    any env plumbing. Returns None when the project has no agent.toml, no such table, or no name — the
-    adapters treat that as "unbound" and fall back to their default. Never raises: a malformed or
-    missing manifest just means "no binding here".
+    any env plumbing. With ``prefer="id"`` the table's ``id`` is returned when present, falling back
+    to ``name``; otherwise the ``name`` is returned. Returns None when the project has no agent.toml,
+    no such table, or no value — the adapters treat that as "unbound" and fall back to their default.
+    Never raises: a malformed or missing manifest just means "no binding here".
     """
     try:
         path = project_root() / "agent.toml"
@@ -157,20 +158,32 @@ def store_binding(table: str) -> str | None:
     except (RuntimeError, OSError, tomllib.TOMLDecodeError):
         return None
     section = document.get(table)
-    if isinstance(section, dict):
-        name = section.get("name")
-        if isinstance(name, str) and name:
-            return name
+    if not isinstance(section, dict):
+        return None
+    keys = ("id", "name") if prefer == "id" else ("name",)
+    for key in keys:
+        value = section.get(key)
+        if isinstance(value, str) and value:
+            return value
     return None
 
 
 def resolve_memory_store(explicit: str | None = None) -> str | None:
-    """The memory store name: ``explicit`` arg → ``AGENT_MEMORY_STORE`` env → agent.toml binding.
+    """The memory store id: ``explicit`` arg → ``AGENT_MEMORY_STORE`` env → agent.toml ``[memory_store]``.
 
     The one place the store-resolution precedence lives, shared by the framework adapters and the
     chat-app UI so they always agree on which store is in effect. None means "no memory store".
+
+    The entries API is keyed by store id, not display name, so the binding's ``id`` is preferred
+    (`mason memory bind` records it); the display ``name`` is only a fallback for a hand-written
+    binding without an id.
     """
-    return explicit or os.getenv(MEMORY_STORE_ENV) or store_binding(MEMORY_STORE_TABLE)
+    if explicit:
+        return explicit
+    env = os.getenv(MEMORY_STORE_ENV)
+    if env:
+        return env
+    return store_binding(MEMORY_STORE_TABLE, prefer="id")
 
 
 def resolve_session_store(explicit: str | None = None) -> str | None:

--- a/integrations/mason/src/databricks_mason/runtime/tool_manifest.py
+++ b/integrations/mason/src/databricks_mason/runtime/tool_manifest.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import os
 import pathlib
 from dataclasses import dataclass
-from typing import Any, cast
+from typing import Any, Literal, cast
 
 try:
     import tomllib  # ty: ignore[unresolved-import]
@@ -142,7 +142,7 @@ def load_tools(*, expected_framework: str) -> tuple[ToolRecord, ...]:
     return tools
 
 
-def store_binding(table: str, prefer: str = "name") -> str | None:
+def store_binding(table: str, prefer: Literal["name", "id"] = "name") -> str | None:
     """The store binding declared in agent.toml's ``[memory_store]`` / ``[session_store]``, or None.
 
     Read at runtime so `mason memory/sessions bind` (which writes these tables) takes effect without

--- a/integrations/mason/src/databricks_mason/sessions.py
+++ b/integrations/mason/src/databricks_mason/sessions.py
@@ -63,8 +63,8 @@ def _source_option(function):
 def sessions_bind(obj, store: str, source: pathlib.Path, no_create_stores: bool) -> None:
     """Bind session STORE to the agent, declaring it in agent.toml (creating it if it doesn't exist).
 
-    `mason dev` / `mason deploy` sync the bound store into the deployment's app.yaml env and grant the
-    app access. Pass --no-create-stores to require the store to already exist.
+    The agent reads the store from agent.toml at runtime; `mason deploy` grants the deployed app's
+    service principal access to it. Pass --no-create-stores to require the store to already exist.
     """
     from databricks_mason.agent_project import AgentProject
     from databricks_mason.deploy import _ensure_session_store
@@ -92,7 +92,10 @@ def sessions_bind(obj, store: str, source: pathlib.Path, no_create_stores: bool)
     render.success(
         f"Bound session store '{store}'",
         fields={"agent.toml": str(project.path)},
-        next_steps=["mason dev", "mason deploy <name>"],
+        next_steps=[
+            ("mason dev", "Re-run to pick up the store locally"),
+            ("mason deploy <name>", "Redeploy to grant the app access"),
+        ],
     )
 
 
@@ -161,7 +164,10 @@ def stores_create(obj, name, description, metadata) -> None:
                 "Start a session for an actor",
             ),
             (f"mason sessions stores get {name}", "View this store's details"),
-            (f"mason deploy <agent> --session {name}", "Wire this store into a deployment"),
+            (
+                f"mason sessions bind {name}",
+                "Bind this store to the agent (wired in on dev/deploy)",
+            ),
         ],
     )
 

--- a/integrations/mason/templates/agent-langgraph/README.md
+++ b/integrations/mason/templates/agent-langgraph/README.md
@@ -212,11 +212,11 @@ curl -s -b "$COOKIE_JAR" -X POST "$BASE/invocations" -H "Content-Type: applicati
 - **Require approval for a tool:** add its name to `REQUIRE_APPROVAL` in `agent/agent.py` (see the
   human-in-the-loop section above); empty the dict to disable gating.
 - **Add an MCP server:** append a `DatabricksMCPServer` to `build_mcp_servers()` in `agent/mcps.py`.
-- **Make state durable:** set `AGENT_SESSION_STORE` (see "Enable durable state" below); the
+- **Make state durable:** run `mason sessions bind <store>` (see "Enable durable state" below); the
   checkpointer lives in `databricks_mason/langgraph/session_store.py`.
-- **Add long-term memory:** set `AGENT_MEMORY_STORE` to a managed memory store ID; `create_agent_graph()`
+- **Add long-term memory:** run `mason memory bind <store>`; `create_agent_graph()`
   then includes the `remember`/`recall` tools from `databricks_mason/langgraph/memory.py` (persist/search facts across
-  conversations). Unset → the model isn't offered them.
+  conversations). Unbound → the model isn't offered them.
 - **Change the HTTP surface:** `runtime/runtime.py` — routes, SSE framing, background wiring (the run
   store itself is `databricks_mason/runtime/background.py`).
 
@@ -270,7 +270,8 @@ each trace with the session id. Otherwise it disables tracing outright, so the p
 By default the agent uses an in-process LangGraph checkpointer (`InMemorySaver`) — multi-turn and
 human-in-the-loop pauses work within a running process but do not survive restarts or span replicas.
 
-Set **`AGENT_SESSION_STORE`** to a managed [Session Store](../../README.md) name and
+Bind a managed [Session Store](../../README.md) with **`mason sessions bind <store>`** (recorded in
+`agent.toml`; `AGENT_SESSION_STORE` still overrides it if set) and
 `databricks_mason/langgraph/session_store.py` returns a `DatabricksSessionStoreSaver` instead. It's a LangGraph
 `BaseCheckpointSaver` that serializes each checkpoint into ordered **session items** and stores them
 through the managed Session Store **REST API** — no database the app connects to directly. Full graph

--- a/integrations/mason/templates/agent-langgraph/app.yaml
+++ b/integrations/mason/templates/agent-langgraph/app.yaml
@@ -2,8 +2,7 @@ command: ["uv", "run", "start-server"]
 # databricks apps listen by default on port 8000
 #
 # No env vars are required by default: the app runs the lean backend (in-process checkpointer,
-# tracing off). To enable tracing, long-term memory, or durable state, add the matching entries
-# below (literal values):
+# tracing off). To enable tracing, add the matching env entries below (literal values):
 #
 # env:
 #   # Tracing (set a destination + an experiment). Destination: MLFLOW_TRACKING_URI or
@@ -12,11 +11,3 @@ command: ["uv", "run", "start-server"]
 #     value: "databricks"
 #   - name: MLFLOW_EXPERIMENT_ID
 #     value: "<experiment-id>"
-#   # Long-term memory tools: a managed memory store ID (registers remember/recall). Memory is
-#   # partitioned per signed-in user automatically (see agent/agent.py `_actor`).
-#   - name: AGENT_MEMORY_STORE
-#     value: "<memory-store-id>"
-#   # Durable state: a managed Session Store name → checkpoints persisted via its REST API
-#   # (durable multi-turn + HITL pauses, no DB connection). Access uses the app's service principal.
-#   - name: AGENT_SESSION_STORE
-#     value: "<session-store-name>"

--- a/integrations/mason/templates/agent-openai/README.md
+++ b/integrations/mason/templates/agent-openai/README.md
@@ -211,11 +211,11 @@ curl -s -b "$COOKIE_JAR" -X POST "$BASE/invocations" -H "Content-Type: applicati
   `REQUIRE_APPROVAL` in `agent/agent.py` (see the human-in-the-loop section above); empty the set to
   disable gating.
 - **Add an MCP server:** append an `McpServer` to `build_mcp_servers()` in `agent/mcps.py`.
-- **Make history durable:** set `AGENT_SESSION_STORE` (see "Enable durable state" below); the session
+- **Make history durable:** run `mason sessions bind <store>` (see "Enable durable state" below); the session
   store lives in `databricks_mason/openai/sessions.py`.
-- **Add long-term memory:** set `AGENT_MEMORY_STORE` to a managed memory store ID; `create_agent()`
+- **Add long-term memory:** run `mason memory bind <store>`; `create_agent()`
   then includes the `remember`/`recall` tools from `databricks_mason/openai/memory.py` (persist/search
-  facts across conversations). Unset → the model isn't offered them.
+  facts across conversations). Unbound → the model isn't offered them.
 - **Change the HTTP surface:** `runtime/runtime.py` — routes, SSE framing, background wiring (the run
   store itself is `databricks_mason/runtime/background.py`).
 
@@ -269,7 +269,8 @@ each trace with the session id. Otherwise it disables tracing outright, so the p
 By default the agent uses an in-process session (`SQLiteSession` backed by `:memory:`) — multi-turn
 history works within a running process but does not survive restarts or span replicas.
 
-Set **`AGENT_SESSION_STORE`** to a managed [Session Store](../../README.md) name and
+Bind a managed [Session Store](../../README.md) with **`mason sessions bind <store>`** (recorded in
+`agent.toml`; `AGENT_SESSION_STORE` still overrides it if set) and
 `databricks_mason/openai/sessions.py` returns a `DatabricksSessionStore` instead. It's an Agents
 SDK `Session` that stores each Responses item as an ordered **session item** through the managed
 Session Store **REST API** — no database the app connects to directly. The conversation transcript is

--- a/integrations/mason/templates/agent-openai/app.yaml
+++ b/integrations/mason/templates/agent-openai/app.yaml
@@ -2,8 +2,7 @@ command: ["uv", "run", "start-server"]
 # databricks apps listen by default on port 8000
 #
 # No env vars are required by default: the app runs the lean backend (in-process session, tracing
-# off). To enable tracing, long-term memory, or durable state, add the matching entries below
-# (literal values):
+# off). To enable tracing, add the matching env entries below (literal values):
 #
 # env:
 #   # Tracing (set a destination + an experiment). Destination: MLFLOW_TRACKING_URI or
@@ -12,11 +11,3 @@ command: ["uv", "run", "start-server"]
 #     value: "databricks"
 #   - name: MLFLOW_EXPERIMENT_ID
 #     value: "<experiment-id>"
-#   # Long-term memory tools: a managed memory store ID (registers remember/recall). Memory is
-#   # partitioned per signed-in user automatically (see agent/agent.py `_actor`).
-#   - name: AGENT_MEMORY_STORE
-#     value: "<memory-store-id>"
-#   # Durable state: a managed Session Store name → transcript persisted via its REST API
-#   # (durable multi-turn history, no DB connection). Access uses the app's service principal.
-#   - name: AGENT_SESSION_STORE
-#     value: "<session-store-name>"

--- a/integrations/mason/templates/ui/agent-langgraph/tests/test_demo_ui.py
+++ b/integrations/mason/templates/ui/agent-langgraph/tests/test_demo_ui.py
@@ -121,8 +121,7 @@ def test_demo_ui_routes(monkeypatch):
     assert 'id="session-list"' in index.text
     app_script = client.get("/ui-assets/app.js")
     assert app_script.status_code == 200
-    assert "mason dev --memory <store-name>" in app_script.text
-    assert "mason deploy <app-name> --source . --memory <store-name>" in app_script.text
+    assert "mason memory bind <store-name>" in app_script.text
     assert "refreshSessionView({ hydrateChat: true })" in app_script.text
     assert 'fetch("/api/session/new"' in app_script.text
     assert "/api/demo/sessions/${encodeURIComponent(sessionId)}/open" in app_script.text

--- a/integrations/mason/templates/ui/agent-langgraph/ui/app.js
+++ b/integrations/mason/templates/ui/agent-langgraph/ui/app.js
@@ -784,7 +784,7 @@ async function loadConfig() {
       config.session.managed
         ? `Connected to Session Store "${config.session.store}" for actor ${config.session.actor}. State is durable and shareable.`
         : "Session state is kept in process and resets when the app restarts.",
-      config.session.managed ? null : "mason deploy <deployment-name> --session <store-name>",
+      config.session.managed ? null : "mason sessions bind <store-name>",
     );
     setCapability(
       elements.memoryStatus,
@@ -792,7 +792,7 @@ async function loadConfig() {
       config.memory.enabled
         ? `Connected to ${config.memory.store} for actor ${config.memory.actor}.`
         : "No long-term memory is connected.",
-      config.memory.enabled ? null : "mason deploy <deployment-name> --memory <store-name>",
+      config.memory.enabled ? null : "mason memory bind <store-name>",
     );
     elements.refreshMemory.disabled = state.busy || !config.memory.enabled;
     elements.newSession.disabled = state.busy;
@@ -801,9 +801,7 @@ async function loadConfig() {
     elements.rejectSession.disabled = state.busy || !config.session.durable;
     elements.memoryHelp.textContent = config.memory.enabled
       ? `${config.memory.store} · actor ${config.memory.actor}`
-      : config.deployed
-        ? "Run from the project directory: mason deploy <app-name> --source . --memory <store-name>. Mason creates the store if needed."
-        : "Run from the project directory: mason dev --memory <store-name>. Mason creates the store if needed.";
+      : "Run from the project directory: mason memory bind <store-name>. Mason creates the store if needed.";
     elements.sessionStoreLabel.textContent = config.session.managed
       ? `${config.session.store} · actor ${config.session.actor} · the Apps routing cookie keys transcript and checkpoint state.`
       : config.session.history

--- a/integrations/mason/templates/ui/agent-langgraph/ui/index.html
+++ b/integrations/mason/templates/ui/agent-langgraph/ui/index.html
@@ -153,7 +153,7 @@
               <div><p class="eyebrow">Cross-session</p><h2>Long-term memory</h2></div>
               <button id="refresh-memory" class="icon-button" type="button" aria-label="Refresh memory entries">↻</button>
             </div>
-            <p id="memory-help" class="supporting-text">Run from the project directory: mason dev --memory &lt;store-name&gt;</p>
+            <p id="memory-help" class="supporting-text">Run from the project directory: mason memory bind &lt;store-name&gt;</p>
             <div id="memory-results" class="state-list" aria-live="polite">
               <div class="state-empty">Memory entries appear here.</div>
             </div>

--- a/integrations/mason/templates/ui/agent-openai/tests/test_demo_ui.py
+++ b/integrations/mason/templates/ui/agent-openai/tests/test_demo_ui.py
@@ -115,8 +115,7 @@ def test_demo_ui_routes(monkeypatch):
     assert 'id="session-list"' in index.text
     app_script = client.get("/ui-assets/app.js")
     assert app_script.status_code == 200
-    assert "mason dev --memory <store-name>" in app_script.text
-    assert "mason deploy <app-name> --source . --memory <store-name>" in app_script.text
+    assert "mason memory bind <store-name>" in app_script.text
     assert "refreshSessionView({ hydrateChat: true })" in app_script.text
     assert 'fetch("/api/session/new"' in app_script.text
     assert "/api/demo/sessions/${encodeURIComponent(sessionId)}/open" in app_script.text

--- a/integrations/mason/templates/ui/agent-openai/ui/app.js
+++ b/integrations/mason/templates/ui/agent-openai/ui/app.js
@@ -748,7 +748,7 @@ async function loadConfig() {
       config.session.managed
         ? `Connected to Session Store "${config.session.store}" for actor ${config.session.actor}. State is durable and shareable.`
         : "Session state is kept in process and resets when the app restarts.",
-      config.session.managed ? null : "mason deploy <deployment-name> --session <store-name>",
+      config.session.managed ? null : "mason sessions bind <store-name>",
     );
     setCapability(
       elements.memoryStatus,
@@ -756,7 +756,7 @@ async function loadConfig() {
       config.memory.enabled
         ? `Connected to ${config.memory.store} for actor ${config.memory.actor}.`
         : "No long-term memory is connected.",
-      config.memory.enabled ? null : "mason deploy <deployment-name> --memory <store-name>",
+      config.memory.enabled ? null : "mason memory bind <store-name>",
     );
     elements.refreshMemory.disabled = state.busy || !config.memory.enabled;
     elements.newSession.disabled = state.busy;
@@ -765,9 +765,7 @@ async function loadConfig() {
     elements.rejectSession.disabled = state.busy || !config.session.durable;
     elements.memoryHelp.textContent = config.memory.enabled
       ? `${config.memory.store} · actor ${config.memory.actor}`
-      : config.deployed
-        ? "Run from the project directory: mason deploy <app-name> --source . --memory <store-name>. Mason creates the store if needed."
-        : "Run from the project directory: mason dev --memory <store-name>. Mason creates the store if needed.";
+      : "Run from the project directory: mason memory bind <store-name>. Mason creates the store if needed.";
     elements.sessionStoreLabel.textContent = config.session.managed
       ? `${config.session.store} · actor ${config.session.actor} · the Apps routing cookie keys the session transcript.`
       : config.session.history

--- a/integrations/mason/templates/ui/agent-openai/ui/index.html
+++ b/integrations/mason/templates/ui/agent-openai/ui/index.html
@@ -153,7 +153,7 @@
               <div><p class="eyebrow">Cross-session</p><h2>Long-term memory</h2></div>
               <button id="refresh-memory" class="icon-button" type="button" aria-label="Refresh memory entries">↻</button>
             </div>
-            <p id="memory-help" class="supporting-text">Run from the project directory: mason dev --memory &lt;store-name&gt;</p>
+            <p id="memory-help" class="supporting-text">Run from the project directory: mason memory bind &lt;store-name&gt;</p>
             <div id="memory-results" class="state-list" aria-live="polite">
               <div class="state-empty">Memory entries appear here.</div>
             </div>

--- a/integrations/mason/tests/unit_tests/agent_project_test.py
+++ b/integrations/mason/tests/unit_tests/agent_project_test.py
@@ -136,6 +136,26 @@ def test_rebinding_replaces_the_store_name(tmp_path: pathlib.Path):
     assert AgentProject.load(tmp_path).memory_store == "second"
 
 
+def test_bind_memory_store_records_id(tmp_path: pathlib.Path):
+    # The runtime needs the store id (not the display name) for the entries API, so bind writes both.
+    _write_manifest(tmp_path)
+    project = AgentProject.load(tmp_path)
+    assert project.bind_memory_store("mem", "mem-id-123") is True
+    project.write()
+
+    reloaded = AgentProject.load(tmp_path)
+    assert reloaded.memory_store == "mem"
+    assert reloaded.memory_store_id == "mem-id-123"
+    assert 'id = "mem-id-123"' in (tmp_path / "agent.toml").read_text(encoding="utf-8")
+
+    # Unbinding clears both name and id.
+    assert reloaded.unbind_memory_store() is True
+    reloaded.write()
+    final = AgentProject.load(tmp_path)
+    assert final.memory_store is None
+    assert final.memory_store_id is None
+
+
 def test_load_rejects_store_table_without_name(tmp_path: pathlib.Path):
     _write_manifest(
         tmp_path,

--- a/integrations/mason/tests/unit_tests/cli_test.py
+++ b/integrations/mason/tests/unit_tests/cli_test.py
@@ -105,7 +105,7 @@ def test_help_examples_recommend_the_default_happy_path():
         ("dev",): ("mason dev",),
         ("memory",): (
             "mason memory stores create --display-name agent-memory",
-            "mason deploy <agent> --memory agent-memory",
+            "mason memory bind agent-memory",
         ),
         ("deploy",): ("mason deploy my-agent",),
     }

--- a/integrations/mason/tests/unit_tests/deploy_bugfix_test.py
+++ b/integrations/mason/tests/unit_tests/deploy_bugfix_test.py
@@ -92,8 +92,9 @@ def test_delete_proceeds_with_yes(monkeypatch):
     monkeypatch.setattr(
         deploy_mod,
         "_databricks",
-        lambda args, profile, **k: called.append(args)
-        or types.SimpleNamespace(returncode=0, stdout="", stderr=""),
+        lambda args, profile, **k: (
+            called.append(args) or types.SimpleNamespace(returncode=0, stdout="", stderr="")
+        ),
     )
     result = CliRunner().invoke(deploy_mod.deployments_delete, ["myapp", "--yes"], obj=_Ctx())
     assert result.exit_code == 0, result.output
@@ -103,20 +104,19 @@ def test_delete_proceeds_with_yes(monkeypatch):
 # --- ML-69248: session store pre-validation ----------------------------------
 
 
-def test_resolve_store_env_validates_session_store_on_non_create_path():
+def test_validate_stores_raises_when_session_store_missing():
     client = mock.Mock()
     client.get_session_store.side_effect = AgentCliError(
         "session store not found", error_code="NOT_FOUND"
     )
     with pytest.raises(AgentCliError) as exc:
-        deploy_mod.resolve_store_env(
+        deploy_mod.validate_stores_and_trace_env(
             client,
             app="a",
             memory_store=None,
             session_store="ghost",
             traces_destination=None,
             traces_experiment=None,
-            create_stores=False,
         )
     assert "does not exist" in str(exc.value)
     client.get_session_store.assert_called_once_with("ghost")

--- a/integrations/mason/tests/unit_tests/deploy_test.py
+++ b/integrations/mason/tests/unit_tests/deploy_test.py
@@ -1,4 +1,4 @@
-"""Unit tests for the deploy wrapper: app.yaml env injection, store reuse, deploy argv."""
+"""Unit tests for the deploy wrapper: trace env injection, store validation, deploy argv."""
 
 from __future__ import annotations
 
@@ -81,7 +81,6 @@ class _FakeClient:
         }
 
     def create_memory_store(self, display_name, *, retry_transient=False):
-        # Create-if-not-exists is the deploy default; return the same id resolution would find.
         return {"name": "memory-stores/mem-id-123", "display_name": display_name}
 
     def get_session_store(self, name):
@@ -103,19 +102,21 @@ def test_deploy_drives_sync_and_apps_deploy(tmp_path: pathlib.Path, monkeypatch)
     src = tmp_path / "app"
     src.mkdir()
     (src / "app.yaml").write_text(yaml.safe_dump({"command": ["x"]}))
+    _agent_toml(src, memory="mem")
 
     calls: list[list[str]] = []
     monkeypatch.setattr(deploy_mod, "_deployment_exists", lambda a, p: True)
     monkeypatch.setattr(
         deploy_mod,
         "_databricks",
-        lambda args, profile, **kw: calls.append(args)
-        or types.SimpleNamespace(returncode=0, stdout="", stderr=""),
+        lambda args, profile, **kw: (
+            calls.append(args) or types.SimpleNamespace(returncode=0, stdout="", stderr="")
+        ),
     )
 
     result = CliRunner().invoke(
         deploy_mod.deploy,
-        ["myapp", "--source", str(src), "--memory", "mem"],
+        ["myapp", "--source", str(src)],
         obj=_FakeCtx(),
     )
 
@@ -125,10 +126,10 @@ def test_deploy_drives_sync_and_apps_deploy(tmp_path: pathlib.Path, monkeypatch)
     # uv.lock is excluded so the build resolves fresh against its own index (not the dev machine's).
     assert ["sync", str(src), ws, "--exclude", "uv.lock"] in calls
     assert ["apps", "deploy", "mason-myapp", "--source-code-path", ws] in calls
-    env = {e["name"]: e["value"] for e in yaml.safe_load((src / "app.yaml").read_text())["env"]}
-    # Display name "mem" resolves to store id memory-stores/mem-id-123; the runtime re-adds the
-    # `memory-stores/` prefix, so the env var must carry the bare id.
-    assert env["AGENT_MEMORY_STORE"] == "mem-id-123"
+    # Stores are read from agent.toml at runtime, so deploy does NOT write store env into app.yaml.
+    env_entries = yaml.safe_load((src / "app.yaml").read_text()).get("env") or []
+    env = {e["name"]: e["value"] for e in env_entries}
+    assert "AGENT_MEMORY_STORE" not in env
 
 
 def test_deploy_renames_underlying_app_compute_output(tmp_path: pathlib.Path, monkeypatch):
@@ -142,11 +143,13 @@ def test_deploy_renames_underlying_app_compute_output(tmp_path: pathlib.Path, mo
     monkeypatch.setattr(
         deploy_mod,
         "_databricks",
-        lambda args, profile, **kwargs: calls.append((args, kwargs))
-        or types.SimpleNamespace(
-            returncode=0,
-            stdout="App compute is starting\n" if args[:2] == ["apps", "create"] else "",
-            stderr="",
+        lambda args, profile, **kwargs: (
+            calls.append((args, kwargs))
+            or types.SimpleNamespace(
+                returncode=0,
+                stdout="App compute is starting\n" if args[:2] == ["apps", "create"] else "",
+                stderr="",
+            )
         ),
     )
 
@@ -199,8 +202,9 @@ def test_deploy_sync_keeps_directly_edited_agent_manifest(tmp_path: pathlib.Path
     monkeypatch.setattr(
         deploy_mod,
         "_databricks",
-        lambda args, profile, **kw: calls.append(args)
-        or types.SimpleNamespace(returncode=0, stdout="", stderr=""),
+        lambda args, profile, **kw: (
+            calls.append(args) or types.SimpleNamespace(returncode=0, stdout="", stderr="")
+        ),
     )
 
     result = CliRunner().invoke(deploy_mod.deploy, ["myapp", "--source", str(src)], obj=_FakeCtx())
@@ -235,8 +239,9 @@ def test_first_deploy_waits_for_running_before_deploying(tmp_path: pathlib.Path,
     monkeypatch.setattr(
         deploy_mod,
         "_databricks",
-        lambda args, profile, **kw: calls.append(args)
-        or types.SimpleNamespace(returncode=0, stdout="", stderr=""),
+        lambda args, profile, **kw: (
+            calls.append(args) or types.SimpleNamespace(returncode=0, stdout="", stderr="")
+        ),
     )
 
     result = CliRunner().invoke(deploy_mod.deploy, ["myapp", "--source", str(src)], obj=_FakeCtx())
@@ -265,10 +270,12 @@ def test_wait_for_running_times_out(monkeypatch):
         pass
 
 
-def test_deploy_injects_store_env_without_actor(tmp_path: pathlib.Path, monkeypatch):
+def test_deploy_does_not_write_store_env_to_app_yaml(tmp_path: pathlib.Path, monkeypatch):
+    # Stores are read from agent.toml at runtime, so deploy writes no AGENT_*_STORE (nor actor) env.
     src = tmp_path / "app"
     src.mkdir()
     (src / "app.yaml").write_text(yaml.safe_dump({"command": ["x"]}))
+    _agent_toml(src, memory="mem", session="sessions")
 
     monkeypatch.setattr(deploy_mod, "_deployment_exists", lambda a, p: True)
     monkeypatch.setattr(
@@ -279,18 +286,15 @@ def test_deploy_injects_store_env_without_actor(tmp_path: pathlib.Path, monkeypa
 
     result = CliRunner().invoke(
         deploy_mod.deploy,
-        ["myapp", "--source", str(src), "--memory", "mem", "--session", "sessions"],
+        ["myapp", "--source", str(src)],
         obj=_FakeCtx(),
     )
 
     assert result.exit_code == 0, result.output
-    env = {
-        entry["name"]: entry["value"]
-        for entry in yaml.safe_load((src / "app.yaml").read_text())["env"]
-    }
-    assert env["AGENT_MEMORY_STORE"]  # resolved memory store id
-    assert env["AGENT_SESSION_STORE"] == "sessions"
-    # The actor is derived per request from the signed-in user, not injected at deploy time.
+    env_entries = yaml.safe_load((src / "app.yaml").read_text()).get("env") or []
+    env = {entry["name"]: entry["value"] for entry in env_entries}
+    assert "AGENT_MEMORY_STORE" not in env
+    assert "AGENT_SESSION_STORE" not in env
     assert "AGENT_MEMORY_ACTOR_ID" not in env
     assert "AGENT_SESSION_ACTOR_ID" not in env
 
@@ -384,13 +388,12 @@ def test_memory_store_database_resolves_by_display_name():
     assert deploy_mod._memory_store_database(_Client(), "mem") == "memory-uuidx"
 
 
-def test_deploy_no_create_stores_resolves_memory_by_display_name(
-    tmp_path: pathlib.Path, monkeypatch
-):
-    # --no-create-stores path must resolve by display name (list+match), not get_memory_store (by id).
+def test_deploy_validates_bound_memory_store_by_display_name(tmp_path: pathlib.Path, monkeypatch):
+    # Deploy resolves the bound memory store by display name (list+match), not get_memory_store (by id).
     src = tmp_path / "app"
     src.mkdir()
     (src / "app.yaml").write_text(yaml.safe_dump({"command": ["x"]}))
+    _agent_toml(src, memory="mem")
     monkeypatch.setattr(deploy_mod, "_deployment_exists", lambda a, p: True)
     monkeypatch.setattr(deploy_mod, "_app_service_principal", lambda name, p: None)
     monkeypatch.setattr(
@@ -398,95 +401,57 @@ def test_deploy_no_create_stores_resolves_memory_by_display_name(
         "_databricks",
         lambda args, profile, **kw: types.SimpleNamespace(returncode=0, stdout="", stderr=""),
     )
-    result = CliRunner().invoke(
-        deploy_mod.deploy,
-        ["myapp", "--source", str(src), "--memory", "mem", "--no-create-stores"],
-        obj=_FakeCtx(),
-    )
+    # _FakeClient resolves display name "mem" via list+match; deploy succeeds.
+    result = CliRunner().invoke(deploy_mod.deploy, ["myapp", "--source", str(src)], obj=_FakeCtx())
     assert result.exit_code == 0, result.output
-    env = {e["name"]: e["value"] for e in yaml.safe_load((src / "app.yaml").read_text())["env"]}
-    assert env["AGENT_MEMORY_STORE"] == "mem-id-123"  # resolved by display name, bare id
 
 
-def test_deploy_creates_missing_stores_by_default(tmp_path: pathlib.Path, monkeypatch):
-    # Create-if-not-exists is now the default (no flag): a referenced store is created via the API.
-    created: list[str] = []
+def test_deploy_errors_when_bound_store_missing(tmp_path: pathlib.Path, monkeypatch):
+    # Stores are created by `mason ... bind`, not deploy; a bound-but-missing store fails with a hint.
     src = tmp_path / "app"
     src.mkdir()
     (src / "app.yaml").write_text(yaml.safe_dump({"command": ["x"]}))
+    _agent_toml(src, memory="ghost")
     monkeypatch.setattr(deploy_mod, "_deployment_exists", lambda a, p: True)
-    monkeypatch.setattr(deploy_mod, "_app_service_principal", lambda name, p: None)
-    monkeypatch.setattr(
-        deploy_mod,
-        "_databricks",
-        lambda args, profile, **kw: types.SimpleNamespace(returncode=0, stdout="", stderr=""),
-    )
 
-    class _CreatingClient(_FakeClient):
-        def create_memory_store(self, display_name, *, retry_transient=False):
-            created.append(display_name)
-            return {"name": "memory-stores/mem-id-123", "display_name": display_name}
+    class _EmptyClient(_FakeClient):
+        def list_memory_stores(self, page_size=None, page_token=None):
+            return {"managed_memory_stores": [], "next_page_token": ""}
 
     class _Ctx(_FakeCtx):
         def client(self):
-            return _CreatingClient()
+            return _EmptyClient()
 
-    result = CliRunner().invoke(
-        deploy_mod.deploy, ["myapp", "--source", str(src), "--memory", "new-mem"], obj=_Ctx()
-    )
-    assert result.exit_code == 0, result.output
-    assert created == ["new-mem"]  # created without any --create-stores flag
-
-
-def test_deploy_accepts_short_store_flags(tmp_path: pathlib.Path, monkeypatch):
-    # -m / -s are the short forms of --memory / --session.
-    src = tmp_path / "app"
-    src.mkdir()
-    (src / "app.yaml").write_text(yaml.safe_dump({"command": ["x"]}))
-    monkeypatch.setattr(deploy_mod, "_deployment_exists", lambda a, p: True)
-    monkeypatch.setattr(deploy_mod, "_app_service_principal", lambda name, p: None)
-    monkeypatch.setattr(
-        deploy_mod,
-        "_databricks",
-        lambda args, profile, **kw: types.SimpleNamespace(returncode=0, stdout="", stderr=""),
-    )
-    result = CliRunner().invoke(
-        deploy_mod.deploy,
-        ["myapp", "--source", str(src), "-m", "mem", "-s", "s"],
-        obj=_FakeCtx(),
-    )
-    assert result.exit_code == 0, result.output
-    env = {e["name"]: e["value"] for e in yaml.safe_load((src / "app.yaml").read_text())["env"]}
-    assert env["AGENT_MEMORY_STORE"] == "mem-id-123"
-    assert env["AGENT_SESSION_STORE"] == "s"
+    result = CliRunner().invoke(deploy_mod.deploy, ["myapp", "--source", str(src)], obj=_Ctx())
+    assert result.exit_code != 0
+    assert "does not exist" in result.output
+    assert "mason memory bind ghost" in result.output
 
 
 def test_with_traces_defaults_the_experiment_per_app():
     # --with-traces alone must still set the experiment, or the agent ships tracing half-configured
     # (destination set, experiment missing) and silently disables it. The default is per-app, so
     # each agent's traces are isolated instead of piling into one shared experiment.
-    env = deploy_mod.resolve_store_env(
+    env = deploy_mod.validate_stores_and_trace_env(
         _FakeClient(),
         app="my-agent",
         memory_store=None,
         session_store=None,
         traces_destination="cat.schema",
         traces_experiment=None,
-        create_stores=False,
     )
     assert env["MLFLOW_TRACING_DESTINATION"] == "cat.schema"
     assert env["MLFLOW_EXPERIMENT_NAME"] == "/Users/me@example.com/mason-traces/my-agent"
 
 
 def test_with_traces_explicit_experiment_wins_over_per_app():
-    env = deploy_mod.resolve_store_env(
+    env = deploy_mod.validate_stores_and_trace_env(
         _FakeClient(),
         app="my-agent",
         memory_store=None,
         session_store=None,
         traces_destination="cat.schema",
         traces_experiment="/Shared/custom",
-        create_stores=False,
     )
     assert env["MLFLOW_EXPERIMENT_NAME"] == "/Shared/custom"
 
@@ -545,3 +510,61 @@ def test_lifecycle_commands_honor_json_output(monkeypatch):
         result = CliRunner().invoke(command, args, obj=_JsonCtx())
         assert result.exit_code == 0, result.output
         assert json.loads(result.output) == {key: "myapp"}
+
+
+def _agent_toml(source: pathlib.Path, *, memory=None, session=None) -> None:
+    text = 'schema_version = 1\n\n[agent]\nframework = "openai"\n'
+    if memory:
+        text += f'\n[memory_store]\nname = "{memory}"\n'
+    if session:
+        text += f'\n[session_store]\nname = "{session}"\n'
+    (source / "agent.toml").write_text(text, encoding="utf-8")
+
+
+def test_store_bindings_reads_agent_toml(tmp_path: pathlib.Path):
+    _agent_toml(tmp_path, memory="bound-mem", session="bound-sess")
+    assert deploy_mod.store_bindings(tmp_path) == ("bound-mem", "bound-sess")
+
+
+def test_store_bindings_none_when_unbound(tmp_path: pathlib.Path):
+    _agent_toml(tmp_path)  # scaffold with no store tables
+    assert deploy_mod.store_bindings(tmp_path) == (None, None)
+
+
+def test_store_bindings_ignores_missing_manifest(tmp_path: pathlib.Path):
+    # No agent.toml -> no stores, never raises (so deploy/dev aren't blocked).
+    assert deploy_mod.store_bindings(tmp_path) == (None, None)
+
+
+def test_deploy_grants_bound_store(tmp_path: pathlib.Path, monkeypatch):
+    # `mason sessions bind` then plain `mason deploy`: the binding must drive both the
+    # app.yaml env AND the SP access grant, or the deployed app can't reach its durable store.
+    src = tmp_path / "app"
+    src.mkdir()
+    (src / "app.yaml").write_text(yaml.safe_dump({"command": ["x"]}))
+    _agent_toml(src, session="bound-sess")
+
+    monkeypatch.setattr(deploy_mod, "_deployment_exists", lambda a, p: True)
+    monkeypatch.setattr(
+        deploy_mod,
+        "_databricks",
+        lambda args, profile, **kw: types.SimpleNamespace(returncode=0, stdout="", stderr=""),
+    )
+    monkeypatch.setattr(deploy_mod, "_app_service_principal", lambda name, profile: "sp-123")
+    grant_args: dict = {}
+    monkeypatch.setattr(
+        deploy_mod,
+        "_grant_store_access",
+        lambda name, sp, user, session_store, memory_database, profile: (
+            grant_args.update(sp=sp, session_store=session_store, memory_database=memory_database)
+            or None
+        ),
+    )
+
+    result = CliRunner().invoke(deploy_mod.deploy, ["myapp", "--source", str(src)], obj=_FakeCtx())
+
+    assert result.exit_code == 0, result.output
+    # The grant fired for the bound session store, resolved from agent.toml — no store env in app.yaml.
+    assert grant_args == {"sp": "sp-123", "session_store": "bound-sess", "memory_database": None}
+    env_entries = yaml.safe_load((src / "app.yaml").read_text()).get("env") or []
+    assert "AGENT_SESSION_STORE" not in {e["name"] for e in env_entries}

--- a/integrations/mason/tests/unit_tests/dev_test.py
+++ b/integrations/mason/tests/unit_tests/dev_test.py
@@ -106,43 +106,40 @@ def test_dev_no_entry_point_when_no_index_override(tmp_path: pathlib.Path):
     assert not (tmp_path / ".mason-dev.app.yaml").exists()
 
 
-def test_dev_with_flags_wires_app_yaml_before_running(tmp_path: pathlib.Path):
+def test_dev_validates_bound_stores_without_writing_store_env(tmp_path: pathlib.Path):
     import yaml
 
     (tmp_path / "app.yaml").write_text(yaml.safe_dump({"command": ["x"]}))
+    (tmp_path / "agent.toml").write_text(
+        'schema_version = 1\n\n[agent]\nframework = "openai"\n'
+        '\n[memory_store]\nname = "m"\n\n[session_store]\nname = "s"\n',
+        encoding="utf-8",
+    )
     (tmp_path / ".venv").mkdir()
     with (
         mock.patch.object(dev_mod, "_databricks") as db,
-        mock.patch.object(
-            dev_mod,
-            "resolve_store_env",
-            return_value={"AGENT_SESSION_STORE": "s", "AGENT_MEMORY_STORE": "abc"},
-        ) as resolve,
+        mock.patch.object(dev_mod, "validate_stores_and_trace_env", return_value={}) as validate,
     ):
-        result = CliRunner().invoke(
-            dev_mod.dev,
-            ["--source", str(tmp_path), "--session", "s", "--memory", "m"],
-            obj=_Ctx(),
-        )
+        result = CliRunner().invoke(dev_mod.dev, ["--source", str(tmp_path)], obj=_Ctx())
     assert result.exit_code == 0, result.output
-    resolve.assert_called_once()  # same resolution path as deploy
-    env = {
-        e["name"]: e["value"] for e in yaml.safe_load((tmp_path / "app.yaml").read_text())["env"]
-    }
-    assert env == {"AGENT_SESSION_STORE": "s", "AGENT_MEMORY_STORE": "abc"}  # patched before run
+    validate.assert_called_once()  # bound stores are validated, same path as deploy
+    # Stores are read from agent.toml at runtime, so no store env is written into app.yaml.
+    env_entries = yaml.safe_load((tmp_path / "app.yaml").read_text()).get("env") or []
+    assert {e["name"] for e in env_entries} == set()
     assert db.call_args.args[0][:2] == ["apps", "run-local"]
 
 
-def test_dev_without_flags_does_not_touch_app_yaml(tmp_path: pathlib.Path):
+def test_dev_without_bindings_does_not_validate(tmp_path: pathlib.Path):
+    # No agent.toml store bindings (and no --with-* traces) -> nothing to validate.
     (tmp_path / "app.yaml").write_text("command: []\n")
     (tmp_path / ".venv").mkdir()
     with (
         mock.patch.object(dev_mod, "_databricks"),
-        mock.patch.object(dev_mod, "resolve_store_env") as resolve,
+        mock.patch.object(dev_mod, "validate_stores_and_trace_env") as validate,
     ):
         result = CliRunner().invoke(dev_mod.dev, ["--source", str(tmp_path)], obj=_Ctx())
     assert result.exit_code == 0, result.output
-    resolve.assert_not_called()  # no --with-* -> no store resolution, app.yaml untouched
+    validate.assert_not_called()
 
 
 def test_dev_requires_app_yaml(tmp_path: pathlib.Path):

--- a/integrations/mason/tests/unit_tests/memory_test.py
+++ b/integrations/mason/tests/unit_tests/memory_test.py
@@ -64,13 +64,13 @@ def test_store_get_renders_timestamps_from_create_time():
     assert "2026" in result.output
 
 
-def test_store_create_suggests_deploying_with_memory():
+def test_store_create_suggests_binding_the_store():
     store = {"name": "memory-stores/abc123", "display_name": "demo"}
     result = CliRunner().invoke(
         stores, ["create", "--display-name", "demo"], obj=_Ctx(_Client(store=store))
     )
     assert result.exit_code == 0, result.output
-    assert "mason deploy <agent> --memory demo" in result.output
+    assert "mason memory bind demo" in result.output
 
 
 def test_store_list_renders_timestamps_from_create_time():
@@ -104,7 +104,8 @@ def _bind_ctx(tmp_path):
 
         def create_memory_store(self, display_name, description=None, *, retry_transient=False):
             self.created.append(display_name)
-            return {"name": f"memory-stores/{display_name}", "display_name": display_name}
+            # The API returns an id distinct from the display name, as the real one does.
+            return {"name": "memory-stores/mem-id-123", "display_name": display_name}
 
         def list_memory_stores(self, page_size=None, page_token=None):
             return {"managed_memory_stores": []}
@@ -123,7 +124,9 @@ def test_memory_bind_writes_agent_toml_and_creates_store(tmp_path):
 
     assert result.exit_code == 0, result.output
     assert ctx.client().created == ["agent-mem"]  # created by default
-    assert AgentProject.load(tmp_path).memory_store == "agent-mem"
+    project = AgentProject.load(tmp_path)
+    assert project.memory_store == "agent-mem"
+    assert project.memory_store_id == "mem-id-123"  # bare id recorded for the runtime
 
 
 def test_memory_unbind_clears_agent_toml(tmp_path):

--- a/integrations/mason/tests/unit_tests/render_test.py
+++ b/integrations/mason/tests/unit_tests/render_test.py
@@ -116,3 +116,27 @@ def test_detail_renders_breadcrumb_status_and_snippet():
     assert "Agent Memory" in out and "acme" in out
     assert "Active" in out
     assert "Starter code" in out
+
+
+def test_status_skips_spinner_in_json_mode(monkeypatch):
+    # Under -o json the spinner must not render, so no control chars pollute machine output.
+    from databricks_mason import errors
+
+    con, buf = _console()
+    monkeypatch.setattr(errors, "_OUTPUT_MODE", "json")
+    with render.status("working…", con=con):
+        pass
+    assert buf.getvalue() == ""  # nothing emitted in json mode
+
+
+def test_status_renders_spinner_in_text_mode(monkeypatch):
+    from databricks_mason import errors
+
+    # A TTY-backed console renders the spinner; a plain StringIO console is not a terminal, so
+    # assert the body still runs and the call is a no-op-safe context manager.
+    monkeypatch.setattr(errors, "_OUTPUT_MODE", "text")
+    con, buf = _console()
+    ran = []
+    with render.status("working…", con=con):
+        ran.append(True)
+    assert ran == [True]  # body runs whether or not the spinner is visible

--- a/integrations/mason/tests/unit_tests/store_binding_test.py
+++ b/integrations/mason/tests/unit_tests/store_binding_test.py
@@ -4,7 +4,11 @@ from __future__ import annotations
 
 import pathlib
 
-from databricks_mason.runtime.tool_manifest import store_binding
+from databricks_mason.runtime.tool_manifest import (
+    resolve_memory_store,
+    resolve_session_store,
+    store_binding,
+)
 
 
 def _write(root: pathlib.Path, body: str) -> None:
@@ -35,3 +39,42 @@ def test_store_binding_none_when_no_manifest(tmp_path: pathlib.Path, monkeypatch
     # No agent.toml anywhere and no MASON_PROJECT_ROOT with one → never raises, just None.
     monkeypatch.setenv("MASON_PROJECT_ROOT", str(tmp_path))
     assert store_binding("session_store") is None
+
+
+def test_store_binding_prefers_id_when_requested(tmp_path: pathlib.Path, monkeypatch):
+    _write(
+        tmp_path,
+        'schema_version = 1\n\n[agent]\nframework = "openai"\n'
+        '\n[memory_store]\nname = "mem"\nid = "mem-id-123"\n',
+    )
+    monkeypatch.setenv("MASON_PROJECT_ROOT", str(tmp_path))
+
+    assert store_binding("memory_store", prefer="id") == "mem-id-123"
+    assert store_binding("memory_store") == "mem"  # default still returns the display name
+
+
+def test_resolve_memory_store_returns_bound_id(tmp_path: pathlib.Path, monkeypatch):
+    # The entries API is keyed by id, so the runtime resolves the memory store to its bound id.
+    _write(
+        tmp_path,
+        'schema_version = 1\n\n[agent]\nframework = "openai"\n'
+        '\n[memory_store]\nname = "mem"\nid = "mem-id-123"\n\n[session_store]\nname = "sess"\n',
+    )
+    monkeypatch.setenv("MASON_PROJECT_ROOT", str(tmp_path))
+    monkeypatch.delenv("AGENT_MEMORY_STORE", raising=False)
+    monkeypatch.delenv("AGENT_SESSION_STORE", raising=False)
+
+    assert resolve_memory_store() == "mem-id-123"
+    assert resolve_session_store() == "sess"  # sessions use the name verbatim
+
+
+def test_resolve_memory_store_falls_back_to_name_without_id(tmp_path: pathlib.Path, monkeypatch):
+    # A hand-written binding with only a name still resolves (to the name) rather than None.
+    _write(
+        tmp_path,
+        'schema_version = 1\n\n[agent]\nframework = "openai"\n\n[memory_store]\nname = "mem"\n',
+    )
+    monkeypatch.setenv("MASON_PROJECT_ROOT", str(tmp_path))
+    monkeypatch.delenv("AGENT_MEMORY_STORE", raising=False)
+
+    assert resolve_memory_store() == "mem"


### PR DESCRIPTION
###  What

  Make `agent.toml` the single source of truth for an agent's memory and session stores, end to end.

  - Stores are declared only via `mason memory bind` / `mason sessions bind`. Binding creates the store (idempotent) and records it in `agent.toml` — memory also records the store id, which the entries API is keyed by.
  - The runtime resolves stores straight from agent.toml (`resolve_memory_store` / `resolve_session_store`); precedence is explicit arg → `AGENT_*_STORE` env → `agent.toml` binding.
  - `mason deploy / mason dev` drop the --memory/-m and --session/-s flags.
  - Stores are no longer written into `app.yaml` env — the runtime reads `agent.toml` at request time, so there's nothing to sync.
  - `mason deploy / mason dev` now only validate the bound stores exist (erroring toward bind if not) and, for deploy, grant the app's service principal access. Store creation lives in bind alone; `--no-create-stores` is removed from deploy/dev (it stays on bind).
  - Adds a spinner over deploy/dev's previously silent phases (app-compute wait, store checks, access grant).

### Why

`mason memory/sessions bind` wrote the store into agent.toml, but `mason deploy` keyed both env-wiring and the SP access grant off the -s/-m flags — bool(`session_store` or `memory_store`). So bind + deploy (no flags) deployed an app whose service principal was never granted store access, and every runtime store call failed with `PERMISSION_DENIED`. The app was effectively broken unless you re-passed the store as a flag on deploy, duplicating what bind already recorded.

Routing everything through agent.toml fixes that and removes the `app.yaml`-vs-`agent.toml` split-brain: one place declares stores (bind), one place reads them (the runtime), and deploy just validates + grants.

### Tests

277 unit tests pass; ruff + ty clean. Coverage added/updated for:
- `mason memory bind` records the store id; resolve_memory_store returns the id (falling back to the display name for a hand-written binding).
- `store_binding(prefer="id")` and the resolver precedence.
- `mason deploy / mason dev` write no store env into app.yaml.
- `mason deploy errors` (pointing at bind) when a bound store doesn't exist.
