### PR TITLE
[mason] Fix profile auth when profiles share a host

### DIFF
--- a/integrations/mason/pyproject.toml
+++ b/integrations/mason/pyproject.toml
@@ -9,7 +9,7 @@ readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
     "click>=8.1",
-    "databricks-sdk>=0.49",
+    "databricks-sdk>=0.94.0",
     "psycopg[binary]>=3.1",
     "PyYAML>=6.0",
     "rich>=13.7",

--- a/integrations/mason/tests/unit_tests/client_test.py
+++ b/integrations/mason/tests/unit_tests/client_test.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+import pathlib
+import subprocess
+import types
 from unittest import mock
 
 import pytest
@@ -149,6 +152,66 @@ def test_auth_error_hint_explains_profile_selection_and_login(_workspace_client)
     assert "`mason --profile <name> <command>`" in hint
     assert "`mason login --profile <name>`" in hint
     assert "`databricks auth login --profile <name>`" not in hint
+
+
+def test_profile_auth_is_forwarded_when_multiple_profiles_share_a_host(
+    tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+):
+    config_path = tmp_path / "databrickscfg"
+    config_path.write_text(
+        "[duplicate]\n"
+        "host = https://workspace.cloud.databricks.com\n"
+        "account_id = account-id\n"
+        "discovery_url = https://workspace.cloud.databricks.com/oidc/.well-known/oauth-authorization-server\n"
+        "auth_type = databricks-cli\n"
+        "\n"
+        "[selected]\n"
+        "host = https://workspace.cloud.databricks.com\n"
+        "account_id = account-id\n"
+        "discovery_url = https://workspace.cloud.databricks.com/oidc/.well-known/oauth-authorization-server\n"
+        "auth_type = databricks-cli\n"
+    )
+    for name in (
+        "DATABRICKS_AUTH_TYPE",
+        "DATABRICKS_CLIENT_ID",
+        "DATABRICKS_CLIENT_SECRET",
+        "DATABRICKS_CONFIG_PROFILE",
+        "DATABRICKS_HOST",
+        "DATABRICKS_TOKEN",
+    ):
+        monkeypatch.delenv(name, raising=False)
+    monkeypatch.setenv("DATABRICKS_CONFIG_FILE", str(config_path))
+    monkeypatch.setenv("DATABRICKS_CLI_PATH", "/fake/databricks")
+    monkeypatch.setenv("DATABRICKS_DISABLE_ASYNC_TOKEN_REFRESH", "true")
+
+    def run_cli(args: list[str], **_: object) -> subprocess.CompletedProcess[bytes]:
+        if args[1:] == ["version", "--output", "json"]:
+            stdout = b'{"Major": 0, "Minor": 300, "Patch": 0}'
+        else:
+            assert args[1:3] == ["auth", "token"]
+            assert "--host" not in args
+            assert args[args.index("--profile") + 1] == "selected"
+            stdout = (
+                b'{"access_token": "test-token", "token_type": "Bearer", '
+                b'"expiry": "2099-01-01T00:00:00Z"}'
+            )
+        return subprocess.CompletedProcess(args, 0, stdout=stdout, stderr=b"")
+
+    host_metadata = types.SimpleNamespace(
+        account_id=None,
+        workspace_id=None,
+        oidc_endpoint="",
+        cloud=None,
+        token_federation_default_oidc_audiences=[],
+    )
+    # Keep the test hermetic while exercising the SDK's real CLI command selection.
+    with (
+        mock.patch("databricks.sdk.config.get_host_metadata", return_value=host_metadata),
+        mock.patch("databricks.sdk.credentials_provider._run_subprocess", side_effect=run_cli),
+    ):
+        client = _workspace_client("selected")
+
+    assert client.config.profile == "selected"
 
 
 class _TransientError(RuntimeError):


### PR DESCRIPTION
## What did you change, and why?

Raise the Mason minimum `databricks-sdk` version from 0.49 to 0.94.0, the first release that forwards a configured profile to `databricks auth token` instead of resolving credentials only by host. This fixes `mason --profile ...` failing when multiple `.databrickscfg` profiles share the same workspace host.

Add a regression test with two same-host profiles that verifies the selected profile reaches the Databricks CLI without a `--host` fallback.

## How do you know it works?

- Lowest-direct/all-extras Python 3.10 suite with `databricks-sdk==0.94.0`: 271 passed
- Highest/all-extras Python 3.10 suite with `databricks-sdk==0.134.0`: 271 passed
- Targeted duplicate-host profile regression: passed
- Ruff lint and format checks passed in both dependency environments
- Highest/all-extras `ty check` passed
- Live read-only smoke test with same-host profiles: the selected profile authenticated and `mcp list` succeeded

### Before / after terminal behavior

Before (`databricks-sdk==0.93.0`, allowed by the old dependency floor):

```console
$ mason --profile <selected-profile> deploy <app-name> --session <session-store>
Error: Could not initialize Databricks auth: default auth: databricks-cli: cannot get access token: Error:
<selected-profile> and <other-profile> match <workspace-host> in
~/.databrickscfg. Use --profile to specify which profile to use. Config:
host=<workspace-host>, account_id=<account-id>, profile=<selected-profile>,
auth_type=databricks-cli
Select an existing profile with `mason --profile <name> <command>` or authenticate and save it with
`mason login --profile <name>`.
```

Mason accepts the outer `--profile`, but the older SDK drops it from the nested credential command:

```console
$ databricks auth token --host <workspace-host>
```

After (`databricks-sdk==0.94.0`, the new minimum), the selected profile reaches the nested CLI and the ambiguity is removed:

```console
$ databricks auth token --profile <selected-profile>
$ mason --profile <selected-profile> --output json mcp list >/dev/null && echo "Authenticated and listed MCP services."
Authenticated and listed MCP services.
```
