### PR TITLE
mason: show loading spinner for streaming responses

### DIFF
--- a/integrations/mason/templates/ui/agent-langgraph/tests/test_demo_ui.py
+++ b/integrations/mason/templates/ui/agent-langgraph/tests/test_demo_ui.py
@@ -121,6 +121,8 @@ def test_demo_ui_routes(monkeypatch):
     assert 'id="session-list"' in index.text
     app_script = client.get("/ui-assets/app.js")
     assert app_script.status_code == 200
+    assert "startDraft({ waiting: true })" in app_script.text
+    assert "Waiting for agent response." in app_script.text
     assert "mason dev --memory <store-name>" in app_script.text
     assert "mason deploy <app-name> --source . --memory <store-name>" in app_script.text
     assert "refreshSessionView({ hydrateChat: true })" in app_script.text
@@ -129,6 +131,9 @@ def test_demo_ui_routes(monkeypatch):
     assert "session_id: ensureSessionId()" not in app_script.text
     styles = client.get("/ui-assets/styles.css").text
     assert "@media (min-width: 1181px)" in styles
+    assert ".message.waiting .message-content::before" in styles
+    assert "@keyframes response-spin" in styles
+    assert "@media (prefers-reduced-motion: reduce)" in styles
     assert "scrollbar-gutter: stable" in styles
 
     config = client.get("/api/demo/config").json()

--- a/integrations/mason/templates/ui/agent-langgraph/ui/app.js
+++ b/integrations/mason/templates/ui/agent-langgraph/ui/app.js
@@ -222,10 +222,17 @@ function appendError(error) {
   addEvent("error", { message });
 }
 
-function startDraft() {
+function startDraft({ waiting = false } = {}) {
   if (state.draft) return state.draft;
   const draft = appendMessage("assistant", "", "Agent · streaming");
   draft.wrapper.classList.add("streaming");
+  if (waiting) {
+    draft.wrapper.classList.add("waiting");
+    const loadingLabel = document.createElement("span");
+    loadingLabel.className = "sr-only";
+    loadingLabel.textContent = "Waiting for agent response.";
+    draft.text.append(loadingLabel);
+  }
   state.draft = draft;
   state.draftText = "";
   return draft;
@@ -235,6 +242,7 @@ function appendDelta(content) {
   const text = extractText(content);
   if (!text) return;
   const draft = startDraft();
+  draft.wrapper.classList.remove("waiting");
   state.draftText += text;
   state.lastAssistantText = state.draftText;
   draft.text.textContent = state.draftText;
@@ -243,12 +251,18 @@ function appendDelta(content) {
 
 function finishDraft(finalText = "") {
   if (!state.draft) return false;
+  if (state.draft.wrapper.classList.contains("waiting") && !finalText && !state.draftText) {
+    state.draft.wrapper.remove();
+    state.draft = null;
+    state.draftText = "";
+    return true;
+  }
   if (finalText) {
     state.draftText = finalText;
     state.lastAssistantText = finalText;
     state.draft.text.textContent = finalText;
   }
-  state.draft.wrapper.classList.remove("streaming");
+  state.draft.wrapper.classList.remove("streaming", "waiting");
   state.draft.wrapper.querySelector(".message-meta").textContent = "Agent";
   state.draft = null;
   return true;
@@ -267,7 +281,8 @@ function handleAgentMessage(message) {
   if (role === "user") return;
   if (role === "assistant") {
     const text = extractText(message?.content);
-    if (finishDraft(text)) return;
+    if (text && finishDraft(text)) return;
+    if (!text && message?.tool_calls?.length) finishDraft();
     if (text) {
       state.lastAssistantText = text;
       appendMessage("assistant", text, "Agent");
@@ -638,6 +653,7 @@ async function sendText(text, mode = state.mode) {
   if (!content || state.busy) return "";
   appendMessage("user", content, "You");
   setBusy(true, mode === "background" ? "Starting background run" : mode === "streaming" ? "Streaming" : "Running");
+  if (mode === "streaming") startDraft({ waiting: true });
   try {
     await dispatch({ input: [{ role: "user", content }] }, mode);
     const items = [{ role: "user", content, transport: mode, instance_id: state.instanceId }];
@@ -672,6 +688,7 @@ async function resume(decision) {
       : { resume: { decisions: [{ type: "reject", message: "Rejected from the Mason demo UI." }] } };
   appendMessage("system", decision === "approve" ? "Approved pending tool call." : "Rejected pending tool call.", "Human decision");
   setBusy(true, "Resuming");
+  startDraft({ waiting: true });
   try {
     await dispatch(payload, "streaming");
     const items = [

--- a/integrations/mason/templates/ui/agent-langgraph/ui/styles.css
+++ b/integrations/mason/templates/ui/agent-langgraph/ui/styles.css
@@ -665,7 +665,7 @@ h2 {
   color: var(--danger);
 }
 
-.message.streaming .message-content::after {
+.message.streaming:not(.waiting) .message-content::after {
   content: "";
   display: inline-block;
   width: 7px;
@@ -674,6 +674,25 @@ h2 {
   background: var(--accent);
   vertical-align: -2px;
   animation: blink 0.8s infinite;
+}
+
+.message.waiting .message-content {
+  min-width: 48px;
+  min-height: 40px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.message.waiting .message-content::before {
+  width: 14px;
+  height: 14px;
+  flex: 0 0 auto;
+  border: 2px solid var(--line-strong);
+  border-top-color: var(--accent);
+  border-radius: 50%;
+  content: "";
+  animation: response-spin 0.8s linear infinite;
 }
 
 .approval-panel {
@@ -996,6 +1015,16 @@ h2 {
 @keyframes blink {
   0%, 45% { opacity: 1; }
   46%, 100% { opacity: 0; }
+}
+
+@keyframes response-spin {
+  to { transform: rotate(360deg); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .message.waiting .message-content::before {
+    animation: none;
+  }
 }
 
 @media (min-width: 1181px) {

--- a/integrations/mason/templates/ui/agent-openai/tests/test_demo_ui.py
+++ b/integrations/mason/templates/ui/agent-openai/tests/test_demo_ui.py
@@ -115,6 +115,8 @@ def test_demo_ui_routes(monkeypatch):
     assert 'id="session-list"' in index.text
     app_script = client.get("/ui-assets/app.js")
     assert app_script.status_code == 200
+    assert "startDraft({ waiting: true })" in app_script.text
+    assert "Waiting for agent response." in app_script.text
     assert "mason dev --memory <store-name>" in app_script.text
     assert "mason deploy <app-name> --source . --memory <store-name>" in app_script.text
     assert "refreshSessionView({ hydrateChat: true })" in app_script.text
@@ -123,6 +125,9 @@ def test_demo_ui_routes(monkeypatch):
     assert "session_id: ensureSessionId()" not in app_script.text
     styles = client.get("/ui-assets/styles.css").text
     assert "@media (min-width: 1181px)" in styles
+    assert ".message.waiting .message-content::before" in styles
+    assert "@keyframes response-spin" in styles
+    assert "@media (prefers-reduced-motion: reduce)" in styles
     assert "scrollbar-gutter: stable" in styles
 
     config = client.get("/api/demo/config").json()

--- a/integrations/mason/templates/ui/agent-openai/ui/app.js
+++ b/integrations/mason/templates/ui/agent-openai/ui/app.js
@@ -222,10 +222,17 @@ function appendError(error) {
   addEvent("error", { message });
 }
 
-function startDraft() {
+function startDraft({ waiting = false } = {}) {
   if (state.draft) return state.draft;
   const draft = appendMessage("assistant", "", "Agent · streaming");
   draft.wrapper.classList.add("streaming");
+  if (waiting) {
+    draft.wrapper.classList.add("waiting");
+    const loadingLabel = document.createElement("span");
+    loadingLabel.className = "sr-only";
+    loadingLabel.textContent = "Waiting for agent response.";
+    draft.text.append(loadingLabel);
+  }
   state.draft = draft;
   state.draftText = "";
   return draft;
@@ -235,6 +242,7 @@ function appendDelta(content) {
   const text = extractText(content);
   if (!text) return;
   const draft = startDraft();
+  draft.wrapper.classList.remove("waiting");
   state.draftText += text;
   state.lastAssistantText = state.draftText;
   draft.text.textContent = state.draftText;
@@ -243,12 +251,18 @@ function appendDelta(content) {
 
 function finishDraft(finalText = "") {
   if (!state.draft) return false;
+  if (state.draft.wrapper.classList.contains("waiting") && !finalText && !state.draftText) {
+    state.draft.wrapper.remove();
+    state.draft = null;
+    state.draftText = "";
+    return true;
+  }
   if (finalText) {
     state.draftText = finalText;
     state.lastAssistantText = finalText;
     state.draft.text.textContent = finalText;
   }
-  state.draft.wrapper.classList.remove("streaming");
+  state.draft.wrapper.classList.remove("streaming", "waiting");
   state.draft.wrapper.querySelector(".message-meta").textContent = "Agent";
   state.draft = null;
   return true;
@@ -267,7 +281,8 @@ function handleAgentMessage(message) {
   if (role === "user") return;
   if (role === "assistant") {
     const text = extractText(message?.content);
-    if (finishDraft(text)) return;
+    if (text && finishDraft(text)) return;
+    if (!text && message?.tool_calls?.length) finishDraft();
     if (text) {
       state.lastAssistantText = text;
       appendMessage("assistant", text, "Agent");
@@ -620,6 +635,7 @@ async function sendText(text, mode = state.mode) {
   if (!content || state.busy) return "";
   appendMessage("user", content, "You");
   setBusy(true, mode === "background" ? "Starting background run" : mode === "streaming" ? "Streaming" : "Running");
+  if (mode === "streaming") startDraft({ waiting: true });
   try {
     await dispatch({ input: [{ role: "user", content }] }, mode);
     // The agent persists the turn to its own Session; refresh the panel to show it (no client write).
@@ -646,6 +662,7 @@ async function resume(decision) {
       : { resume: { decisions: [{ type: "reject", message: "Rejected from the Mason demo UI." }] } };
   appendMessage("system", decision === "approve" ? "Approved pending tool call." : "Rejected pending tool call.", "Human decision");
   setBusy(true, "Resuming");
+  startDraft({ waiting: true });
   try {
     await dispatch(payload, "streaming");
     // The agent persists the resumed turn to its own Session; refresh the panel (no client write).

--- a/integrations/mason/templates/ui/agent-openai/ui/styles.css
+++ b/integrations/mason/templates/ui/agent-openai/ui/styles.css
@@ -665,7 +665,7 @@ h2 {
   color: var(--danger);
 }
 
-.message.streaming .message-content::after {
+.message.streaming:not(.waiting) .message-content::after {
   content: "";
   display: inline-block;
   width: 7px;
@@ -674,6 +674,25 @@ h2 {
   background: var(--accent);
   vertical-align: -2px;
   animation: blink 0.8s infinite;
+}
+
+.message.waiting .message-content {
+  min-width: 48px;
+  min-height: 40px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.message.waiting .message-content::before {
+  width: 14px;
+  height: 14px;
+  flex: 0 0 auto;
+  border: 2px solid var(--line-strong);
+  border-top-color: var(--accent);
+  border-radius: 50%;
+  content: "";
+  animation: response-spin 0.8s linear infinite;
 }
 
 .approval-panel {
@@ -996,6 +1015,16 @@ h2 {
 @keyframes blink {
   0%, 45% { opacity: 1; }
   46%, 100% { opacity: 0; }
+}
+
+@keyframes response-spin {
+  to { transform: rotate(360deg); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .message.waiting .message-content::before {
+    animation: none;
+  }
 }
 
 @media (min-width: 1181px) {


### PR DESCRIPTION
## Summary

- show an assistant loading bubble as soon as a generated chat UI starts a streaming request
- replace the spinner with the first streamed token and remove it on empty completion, interruption, or error
- keep the LangGraph and OpenAI templates aligned, including accessible text and reduced-motion behavior

## Testing

- `node --check` for both generated UI scripts
- `pytest tests/unit_tests/init_test.py -q` (27 passed)
- `git diff --check`

The generated template route test was not run locally because the reused FastAPI/TestClient environment hangs on `GET /` before reaching the new static-asset assertions.
