### PR TITLE
mason: show a spinner during deploy's silent phases

### DIFF
--- a/integrations/mason/src/databricks_mason/deploy.py
+++ b/integrations/mason/src/databricks_mason/deploy.py
@@ -393,15 +393,16 @@ def deploy(
     client = obj.client()
 
     # 1. Provision / resolve stores and build the env to inject.
-    env_updates = resolve_store_env(
-        client,
-        app=name,
-        memory_store=memory_store,
-        session_store=session_store,
-        traces_destination=traces_destination,
-        traces_experiment=traces_experiment,
-        create_stores=not no_create_stores,
-    )
+    with render.status("Provisioning stores…"):
+        env_updates = resolve_store_env(
+            client,
+            app=name,
+            memory_store=memory_store,
+            session_store=session_store,
+            traces_destination=traces_destination,
+            traces_experiment=traces_experiment,
+            create_stores=not no_create_stores,
+        )
     provisioned: dict[str, Any] = {}
     if _MEMORY_ENV in env_updates:
         provisioned["Memory store"] = env_updates[_MEMORY_ENV]
@@ -426,7 +427,8 @@ def deploy(
         click.echo((result.stdout or "").replace(old, new), nl=False)
         # `apps create` returns before the app's compute is up, but `apps deploy` requires it to be
         # RUNNING — so wait for it, or the first deploy races and fails ("not in RUNNING state").
-        _wait_for_running(name, obj.profile)
+        with render.status("Waiting for agent compute to start…"):
+            _wait_for_running(name, obj.profile)
     ws_path = workspace_path or f"/Workspace/Users/{client.current_user}/mason_deployments/{name}"
     # Don't ship uv.lock: it pins exact package URLs from whatever index the developer's machine
     # resolved against (often an internal proxy). The Apps build must resolve against its own
@@ -440,14 +442,17 @@ def deploy(
     grants_stores = bool(session_store or memory_store)
     grant_error: Optional[str] = None
     if grants_stores:
-        sp = _app_service_principal(name, obj.profile)
-        if sp is None:
-            grant_error = "could not resolve the app's service principal."
-        else:
-            memory_database = _memory_store_database(client, memory_store) if memory_store else None
-            grant_error = _grant_store_access(
-                name, sp, client.current_user, session_store, memory_database, obj.profile
-            )
+        with render.status("Granting the agent access to its stores…"):
+            sp = _app_service_principal(name, obj.profile)
+            if sp is None:
+                grant_error = "could not resolve the app's service principal."
+            else:
+                memory_database = (
+                    _memory_store_database(client, memory_store) if memory_store else None
+                )
+                grant_error = _grant_store_access(
+                    name, sp, client.current_user, session_store, memory_database, obj.profile
+                )
 
     app_url = _app_url(name, obj.profile)
 

--- a/integrations/mason/src/databricks_mason/render.py
+++ b/integrations/mason/src/databricks_mason/render.py
@@ -34,9 +34,15 @@ def status(message: str, con: Optional[Console] = None) -> Iterator[None]:
     """Show an animated spinner with ``message`` while a slow call runs, then clear it.
 
     Wraps ``rich``'s console status; a no-op spinner (no TTY) still runs the body. Use around
-    network work like store provisioning so the CLI doesn't look hung.
+    network work like store provisioning so the CLI doesn't look hung. Under ``-o json`` the spinner
+    is skipped so no control characters leak into machine-readable output.
     """
+    from databricks_mason import errors  # local import avoids a cycle at module load
+
     con = con or _stdout
+    if errors._OUTPUT_MODE == "json":
+        yield
+        return
     with con.status(message, spinner="dots"):
         yield
 

--- a/integrations/mason/tests/unit_tests/render_test.py
+++ b/integrations/mason/tests/unit_tests/render_test.py
@@ -116,3 +116,27 @@ def test_detail_renders_breadcrumb_status_and_snippet():
     assert "Agent Memory" in out and "acme" in out
     assert "Active" in out
     assert "Starter code" in out
+
+
+def test_status_skips_spinner_in_json_mode(monkeypatch):
+    # Under -o json the spinner must not render, so no control chars pollute machine output.
+    from databricks_mason import errors
+
+    con, buf = _console()
+    monkeypatch.setattr(errors, "_OUTPUT_MODE", "json")
+    with render.status("working…", con=con):
+        pass
+    assert buf.getvalue() == ""  # nothing emitted in json mode
+
+
+def test_status_renders_spinner_in_text_mode(monkeypatch):
+    from databricks_mason import errors
+
+    # A TTY-backed console renders the spinner; a plain StringIO console is not a terminal, so
+    # assert the body still runs and the call is a no-op-safe context manager.
+    monkeypatch.setattr(errors, "_OUTPUT_MODE", "text")
+    con, buf = _console()
+    ran = []
+    with render.status("working…", con=con):
+        ran.append(True)
+    assert ran == [True]  # body runs whether or not the spinner is visible


### PR DESCRIPTION
mason deploy ran silently through store provisioning, the wait for agent compute, and the store-access grants — the friction-log "runs ~15s without any feedback" gaps. Wrap each in the existing render.status spinner (skipped under -o json so machine output stays clean). The sync / apps deploy steps still stream the CLI's own output as before.