### PR TITLE
mason: don't leak the databricks apps CLI in error messages

### DIFF
--- a/integrations/mason/src/databricks_mason/deploy.py
+++ b/integrations/mason/src/databricks_mason/deploy.py
@@ -421,7 +421,12 @@ def deploy(
 
     # 3. Roll out the deployment (Databricks Apps runtime).
     if not _deployment_exists(name, obj.profile):
-        result = _databricks(["apps", "create", name], obj.profile, capture=True)
+        result = _databricks(
+            ["apps", "create", name],
+            obj.profile,
+            capture=True,
+            action=f"Could not create deployment '{name}'.",
+        )
         old, new = _AGENT_COMPUTE_OUTPUT
         click.echo((result.stdout or "").replace(old, new), nl=False)
         # `apps create` returns before the app's compute is up, but `apps deploy` requires it to be
@@ -431,8 +436,16 @@ def deploy(
     # Don't ship uv.lock: it pins exact package URLs from whatever index the developer's machine
     # resolved against (often an internal proxy). The Apps build must resolve against its own
     # configured index, so let it lock fresh in-sandbox instead of inheriting the local lock.
-    _databricks(["sync", str(source_dir), ws_path, "--exclude", "uv.lock"], obj.profile)
-    _databricks(["apps", "deploy", name, "--source-code-path", ws_path], obj.profile)
+    _databricks(
+        ["sync", str(source_dir), ws_path, "--exclude", "uv.lock"],
+        obj.profile,
+        action=f"Could not upload the agent source for '{name}'.",
+    )
+    _databricks(
+        ["apps", "deploy", name, "--source-code-path", ws_path],
+        obj.profile,
+        action=f"Could not deploy '{name}'.",
+    )
 
     # 4. Give the app's SP access to its stores (best-effort, two steps): bind each store's database
     #    as a `postgres` resource (CONNECT), then GRANT the SP read/write on its tables. Without
@@ -514,7 +527,12 @@ def _deployment_status(a: dict) -> Optional[str]:
 @click.pass_obj
 def deployments_list(obj) -> None:
     """List Mason agent deployments (apps named `mason-*`) in the workspace."""
-    result = _databricks(["apps", "list", "-o", "json"], obj.profile, capture=True)
+    result = _databricks(
+        ["apps", "list", "-o", "json"],
+        obj.profile,
+        capture=True,
+        action="Could not list agent deployments.",
+    )
     data = json.loads(result.stdout or "[]")
     items = data.get("apps", data) if isinstance(data, dict) else data
     items = [a for a in items if str(field(a, "name") or "").startswith(_DEPLOYMENT_PREFIX)]
@@ -542,7 +560,12 @@ def deployments_list(obj) -> None:
 def deployments_get(obj, name) -> None:
     """Get an agent deployment's details."""
     _validate_deployment_name(name)
-    result = _databricks(["apps", "get", name, "-o", "json"], obj.profile, capture=True)
+    result = _databricks(
+        ["apps", "get", name, "-o", "json"],
+        obj.profile,
+        capture=True,
+        action=f"Could not read deployment '{name}'.",
+    )
     data = json.loads(result.stdout or "{}")
     if obj.output == "json":
         render.emit_json(data)
@@ -568,7 +591,7 @@ def deployments_get(obj, name) -> None:
 def deployments_logs(obj, name) -> None:
     """Stream a deployment's logs."""
     _validate_deployment_name(name)
-    _databricks(["apps", "logs", name], obj.profile)
+    _databricks(["apps", "logs", name], obj.profile, action=f"Could not read logs for '{name}'.")
 
 
 @deployments.command("start")
@@ -577,7 +600,9 @@ def deployments_logs(obj, name) -> None:
 def deployments_start(obj, name) -> None:
     """Start a deployment."""
     _validate_deployment_name(name)
-    _databricks(["apps", "start", name], obj.profile)
+    _databricks(
+        ["apps", "start", name], obj.profile, action=f"Could not start deployment '{name}'."
+    )
     if obj.output == "json":
         render.emit_json({"started": name})
         return
@@ -592,7 +617,7 @@ def deployments_stop(obj, name, yes) -> None:
     """Stop a deployment."""
     _validate_deployment_name(name)
     _confirm_destroy(f"Stop deployment '{name}'", assume_yes=yes)
-    _databricks(["apps", "stop", name], obj.profile)
+    _databricks(["apps", "stop", name], obj.profile, action=f"Could not stop deployment '{name}'.")
     if obj.output == "json":
         render.emit_json({"stopped": name})
         return
@@ -607,7 +632,9 @@ def deployments_delete(obj, name, yes) -> None:
     """Delete a deployment."""
     _validate_deployment_name(name)
     _confirm_destroy(f"Delete deployment '{name}'", assume_yes=yes)
-    _databricks(["apps", "delete", name], obj.profile)
+    _databricks(
+        ["apps", "delete", name], obj.profile, action=f"Could not delete deployment '{name}'."
+    )
     if obj.output == "json":
         render.emit_json({"deleted": name})
         return

--- a/integrations/mason/src/databricks_mason/dev.py
+++ b/integrations/mason/src/databricks_mason/dev.py
@@ -147,7 +147,12 @@ def dev(
     _announce_local_url(source_dir, app_port or _DEFAULT_APP_PORT)
 
     # Run in the project dir so run-local finds the app; stream output (no capture).
-    _databricks(args, obj.profile, cwd=str(source_dir))
+    _databricks(
+        args,
+        obj.profile,
+        cwd=str(source_dir),
+        action="Could not start the agent locally.",
+    )
 
 
 def _announce_local_url(source_dir: pathlib.Path, port: int) -> None:

--- a/integrations/mason/src/databricks_mason/store_access.py
+++ b/integrations/mason/src/databricks_mason/store_access.py
@@ -32,14 +32,19 @@ def _databricks(
     capture: bool = False,
     check: bool = True,
     cwd: Optional[str] = None,
+    action: Optional[str] = None,
 ) -> subprocess.CompletedProcess:
     cmd = ["databricks", *args]
     if profile:
         cmd += ["--profile", profile]
     result = subprocess.run(cmd, text=True, capture_output=capture, cwd=cwd)
     if check and result.returncode != 0:
+        # Mason drives the `databricks apps` CLI as an implementation detail; surface a failure in
+        # Mason's own terms (`action`) rather than echoing the raw subcommand and --profile, which
+        # leaks the underlying tool at the customer. The captured stderr still rides along as the
+        # hint so debugging isn't lost.
         detail = (result.stderr or result.stdout or "").strip() if capture else None
-        raise AgentCliError(f"`{' '.join(cmd)}` failed (exit {result.returncode})", hint=detail)
+        raise AgentCliError(action or "A Databricks CLI command failed.", hint=detail)
     return result
 
 

--- a/integrations/mason/tests/unit_tests/deploy_test.py
+++ b/integrations/mason/tests/unit_tests/deploy_test.py
@@ -155,8 +155,13 @@ def test_deploy_renames_underlying_app_compute_output(tmp_path: pathlib.Path, mo
     assert result.exit_code == 0, result.output
     apps_calls = [call for call in calls if call[0][1] in ("create", "deploy")]
     assert [call[0][1] for call in apps_calls] == ["create", "deploy"]
-    assert apps_calls[0][1] == {"capture": True}
-    assert apps_calls[1][1] == {}
+    # create is still captured (to relabel its output); both carry an `action` so a failure is
+    # reported in Mason's terms instead of echoing the raw `databricks apps` command.
+    assert apps_calls[0][1] == {
+        "capture": True,
+        "action": "Could not create deployment 'mason-myapp'.",
+    }
+    assert apps_calls[1][1] == {"action": "Could not deploy 'mason-myapp'."}
     assert "Agent compute is starting" in result.output
     assert "App compute" not in result.output
     get_call = next(call for call in calls if call[0][:2] == ["apps", "get"])

--- a/integrations/mason/tests/unit_tests/store_access_test.py
+++ b/integrations/mason/tests/unit_tests/store_access_test.py
@@ -33,6 +33,40 @@ def test_memory_backend_targets_memory_entries():
     assert b.resource_name == "postgres-memory"  # distinct name so both stores coexist on one app
 
 
+def test_databricks_failure_hides_the_apps_subcommand(monkeypatch):
+    # Mason drives `databricks apps` as an implementation detail; a failure must be reported in
+    # Mason's terms (the `action`) and must NOT echo the raw subcommand or --profile at the customer.
+    def fake_run(cmd, **kw):
+        return types.SimpleNamespace(returncode=1, stdout="", stderr="boom from the CLI")
+
+    monkeypatch.setattr(sa.subprocess, "run", fake_run)
+    try:
+        sa._databricks(
+            ["apps", "run-local", "--prepare-environment"],
+            "e2-dogfood",
+            capture=True,
+            action="Could not start the agent locally.",
+        )
+        raise AssertionError("expected AgentCliError")
+    except sa.AgentCliError as exc:
+        assert exc.message == "Could not start the agent locally."
+        assert "apps" not in exc.message and "e2-dogfood" not in exc.message  # no leak
+        assert exc.hint == "boom from the CLI"  # underlying stderr preserved for debugging
+
+
+def test_databricks_failure_without_action_is_generic(monkeypatch):
+    # No action label: still no raw subcommand/profile echo — just a generic message.
+    def fake_run(cmd, **kw):
+        return types.SimpleNamespace(returncode=1, stdout="", stderr="err")
+
+    monkeypatch.setattr(sa.subprocess, "run", fake_run)
+    try:
+        sa._databricks(["apps", "deploy", "x"], "prof", capture=True)
+        raise AssertionError("expected AgentCliError")
+    except sa.AgentCliError as exc:
+        assert "apps" not in exc.message and "prof" not in exc.message
+
+
 def test_apply_postgres_resources_sends_all_backends_in_one_update(monkeypatch):
     captured = {}
 


### PR DESCRIPTION
Report failures from the underlying `databricks apps` CLI in Mason's own terms instead of echoing the raw subcommand and --profile, keeping Apps an implementation detail. The captured stderr is preserved as the error hint so debugging isn't lost.