### PR TITLE
[mason] Fix agent-langgraph template dropping LangGraph/tool spans from traces

### DIFF
--- a/integrations/mason/templates/agent-langgraph/agent/agent.py
+++ b/integrations/mason/templates/agent-langgraph/agent/agent.py
@@ -10,12 +10,17 @@ from langchain.messages import AIMessageChunk
 from langgraph.types import Command
 
 from databricks_mason import (
-    configure_tracing,
     tag_session,
     workspace_client,
     workspace_headers,
 )
-from databricks_mason.langgraph import checkpointer, mcp_tools, memory_tools, thread_config
+from databricks_mason.langgraph import (
+    checkpointer,
+    configure_tracing,
+    mcp_tools,
+    memory_tools,
+    thread_config,
+)
 
 from agent.mcps import build_mcp_servers
 

--- a/integrations/mason/templates/agent-langgraph/tests/test_agent.py
+++ b/integrations/mason/templates/agent-langgraph/tests/test_agent.py
@@ -61,6 +61,32 @@ def test_configure_raises_clear_error_without_auth(monkeypatch):
         configure()
 
 
+def test_configure_tracing_enables_langchain_autolog(monkeypatch):
+    """`configure_tracing()` must turn on LangChain autologging when tracing is configured.
+
+    Regression: the agent has to import ``configure_tracing`` from ``databricks_mason.langgraph``
+    (which binds ``mlflow.langchain.autolog``), not the neutral top-level ``databricks_mason`` one.
+    With the neutral version, tracing switches on but no framework autolog is bound, so the only span
+    ever emitted is the runtime's per-request span - traces arrive with the whole LangGraph subtree
+    (model + tool calls) missing.
+    """
+    import mlflow
+    from mlflow.utils.autologging_utils import autologging_is_disabled
+
+    from agent.agent import configure_tracing
+
+    monkeypatch.setenv("MLFLOW_TRACKING_URI", "databricks")
+    monkeypatch.setenv("MLFLOW_EXPERIMENT_ID", "0")
+    mlflow.langchain.autolog(disable=True)  # start from a known-disabled state
+    try:
+        configure_tracing()
+        assert not autologging_is_disabled("langchain"), (
+            "configure_tracing() left LangChain autolog disabled - LangGraph/tool spans won't trace"
+        )
+    finally:
+        mlflow.langchain.autolog(disable=True)  # don't leak autolog state into other tests
+
+
 def test_chat_model_forwards_account_routing_header(monkeypatch):
     from agent.agent import _RoutedChatDatabricks
 


### PR DESCRIPTION
## Problem

The `agent-langgraph` template produces malformed MLflow traces: the trace shows only the runtime's per-request root span, with the entire LangGraph subtree - model calls, the `tools` node, and the individual tool spans - missing. Tool calls never appear grouped under the root span.

## Root cause

`agent/agent.py` imported `configure_tracing` from the top-level `databricks_mason`:

```python
from databricks_mason import configure_tracing, ...
```

That resolves to the framework-neutral `runtime.tracing.configure_tracing(autolog=None)`. With no `autolog` bound, it enables tracing (a destination + experiment are configured) but **never calls `mlflow.langchain.autolog()`**. `runtime.py` still opens its manual per-request span, so a trace is produced - but nothing emits the LangGraph/LangChain spans, leaving a single-span trace.

The sibling `agent-openai` template already imports `configure_tracing` from `databricks_mason.openai` (which binds `mlflow.openai.autolog`). This brings the langgraph template in line by importing from `databricks_mason.langgraph` (which binds `mlflow.langchain.autolog`).

## Fix

- Import `configure_tracing` from `databricks_mason.langgraph` instead of the neutral top-level one.
- Add a hermetic regression test asserting `configure_tracing()` enables LangChain autologging when tracing is configured. It fails on the old import and passes on the fix.

## Verification (end-to-end, live workspace)

Ran the actual template server against a live workspace with MLflow tracing to a real experiment and a real tool-calling model.

**Before:** trace had a single span:
```
stream_handler
```

**After:** full nested tree:
```
stream_handler
  └ LangGraph
      ├ model → _RoutedChatDatabricks
      ├ tools → get_current_time      ← tool call now under the root
      └ model → _RoutedChatDatabricks
```

Template test suite: 16 passed, 1 skipped (the live model test).

This pull request and its description were written by Isaac.