### PR TITLE
mason: require mlflow>=3.10.1 for tracing (was 3.9.0)

### DIFF
--- a/integrations/mason/pyproject.toml
+++ b/integrations/mason/pyproject.toml
@@ -19,7 +19,7 @@ dependencies = [
 
 [project.optional-dependencies]
 tracing = [
-    "mlflow[databricks]>=3.9.0",
+    "mlflow[databricks]>=3.10.1",
 ]
 # The agent-side runtime helpers a deployed agent imports. Kept as extras so a plain
 # `pip install databricks-mason` (the CLI) stays light; each template depends on the extra for its

--- a/integrations/mason/src/databricks_mason/tracing.py
+++ b/integrations/mason/src/databricks_mason/tracing.py
@@ -46,6 +46,12 @@ TRACES_DEST_ENV = "MLFLOW_TRACING_DESTINATION"
 TRACES_EXPERIMENT_ENV = "MLFLOW_EXPERIMENT_NAME"
 
 
+# Installing the `tracing` extra (rather than a bare mlflow) is what actually resolves both the
+# missing- and too-old-mlflow cases: the extra carries the version floor `mason tracing` needs, so
+# a stale mlflow already in the venv gets upgraded to a compatible one.
+_INSTALL_HINT = "Install the tracing extra: pip install 'databricks-mason[tracing]'"
+
+
 def _mlflow():
     """Import mlflow lazily so the core CLI (and offline wheel) don't depend on it."""
     try:
@@ -55,7 +61,7 @@ def _mlflow():
     except ImportError as exc:
         raise AgentCliError(
             "MLflow is required for `mason tracing` setup/list/get.",
-            hint="Install it: pip install 'mlflow[databricks]>=3.10.1'",
+            hint=_INSTALL_HINT,
         ) from exc
 
 
@@ -77,7 +83,7 @@ def _uc_trace_symbols():
     except ImportError as exc:
         raise AgentCliError(
             "This MLflow version is too old for `mason tracing setup` (UC trace destinations).",
-            hint="Upgrade it: pip install 'mlflow[databricks]>=3.10.1'",
+            hint=_INSTALL_HINT,
         ) from exc
 
 

--- a/integrations/mason/src/databricks_mason/tracing.py
+++ b/integrations/mason/src/databricks_mason/tracing.py
@@ -6,7 +6,7 @@ read traces back, and `instrument` prints the wiring snippet (the "Starter code"
 `mason deploy --with-traces` injects the destination into a deployment's app.yaml, exactly as
 `--memory` / `--session` inject their stores.
 
-MLflow is an optional dependency: `setup`/`list`/`get` need `mlflow[databricks]>=3.9.0`
+MLflow is an optional dependency: `setup`/`list`/`get` need `mlflow[databricks]>=3.10.1`
 installed and lazily import it; `instrument` (and the deploy wiring) are pure and need nothing.
 """
 
@@ -55,7 +55,7 @@ def _mlflow():
     except ImportError as exc:
         raise AgentCliError(
             "MLflow is required for `mason tracing` setup/list/get.",
-            hint="Install it: pip install 'mlflow[databricks]>=3.9.0'",
+            hint="Install it: pip install 'mlflow[databricks]>=3.10.1'",
         ) from exc
 
 
@@ -77,7 +77,7 @@ def _uc_trace_symbols():
     except ImportError as exc:
         raise AgentCliError(
             "This MLflow version is too old for `mason tracing setup` (UC trace destinations).",
-            hint="Upgrade it: pip install 'mlflow[databricks]>=3.9.0'",
+            hint="Upgrade it: pip install 'mlflow[databricks]>=3.10.1'",
         ) from exc
 
 
@@ -355,7 +355,7 @@ def tracing_instrument(obj, destination, experiment) -> None:
     render.detail(
         _BREADCRUMB,
         dest,
-        {"Experiment": exp_name, "Destination": dest, "Requires": "mlflow[databricks]>=3.9.0"},
+        {"Experiment": exp_name, "Destination": dest, "Requires": "mlflow[databricks]>=3.10.1"},
         status="ACTIVE",
         snippets=[("python", "python", code)],
     )


### PR DESCRIPTION
mason tracing setup uses UC trace destinations (set_experiment_trace_location, UCSchemaLocation), which is why users hit 'This MLflow version is too old'. The tracing extra floored mlflow at >=3.9.0 while both runtime extras already require >=3.10.1 — bump tracing (and its install hints) to match.