### PR TITLE
mason: prune dangling tool calls when replaying OpenAI session history

### DIFF
--- a/integrations/mason/src/databricks_mason/openai/sessions.py
+++ b/integrations/mason/src/databricks_mason/openai/sessions.py
@@ -38,7 +38,74 @@ _ORDER_BY = "create_time asc"
 
 # One in-process Session per session id, built lazily and shared — that's what makes multi-turn work
 # in-process (the durable store needs no cache; each call resolves the same REST-backed session).
-_local_sessions: dict[str, SQLiteSession] = {}
+_local_sessions: dict[str, _SanitizingSession] = {}
+
+
+def _prune_dangling_tool_calls(
+    items: list[TResponseInputItem],
+) -> list[TResponseInputItem]:
+    """Drop tool-call items that would replay with an unmatched ``call_id``.
+
+    When a run interrupts for human approval, the Agents SDK persists the ``function_call`` item
+    immediately but writes its matching ``function_call_output`` only once the run resumes. If that
+    resume never lands cleanly — the user declines, or the paused (in-process) ``RunState`` is lost to
+    a restart or another replica so the next prompt starts a fresh turn — the transcript keeps the
+    ``function_call`` with no output. Replaying that makes the Responses API reject the whole request
+    with BAD_REQUEST for the dangling ``call_id``. So keep a ``function_call`` only if its output was
+    also stored, and a ``function_call_output`` only if its call was — every other item passes
+    through untouched. (A plain tool exception does NOT trigger this: the SDK stores an error output
+    as a matched pair.)
+    """
+    call_ids = {
+        item["call_id"]
+        for item in items
+        if isinstance(item, dict) and item.get("type") == "function_call" and item.get("call_id")
+    }
+    output_ids = {
+        item["call_id"]
+        for item in items
+        if isinstance(item, dict)
+        and item.get("type") == "function_call_output"
+        and item.get("call_id")
+    }
+    kept: list[TResponseInputItem] = []
+    for item in items:
+        if isinstance(item, dict) and item.get("type") == "function_call":
+            if item.get("call_id") not in output_ids:
+                continue
+        elif isinstance(item, dict) and item.get("type") == "function_call_output":
+            if item.get("call_id") not in call_ids:
+                continue
+        kept.append(item)
+    return kept
+
+
+class _SanitizingSession(SessionABC):
+    """Wrap an Agents SDK ``Session`` and prune dangling tool calls when its history is replayed.
+
+    ``get_items`` is the only read the SDK makes when rebuilding a run's input, so pruning there keeps
+    a transcript left inconsistent by an earlier failed run (see ``_prune_dangling_tool_calls``) from
+    poisoning the next turn. Writes and rollback pass straight through to the wrapped session.
+    """
+
+    def __init__(self, inner: SessionABC) -> None:
+        self._inner = inner
+        self.session_id = getattr(inner, "session_id", None)
+
+    async def get_items(self, limit: int | None = None) -> list[TResponseInputItem]:
+        # Prune before applying `limit` so a dropped call/output can't leave a partial pair at the
+        # window edge, then take the last `limit` items in write order.
+        items = _prune_dangling_tool_calls(await self._inner.get_items())
+        return items[-limit:] if limit is not None else items
+
+    async def add_items(self, items: list[TResponseInputItem]) -> None:
+        await self._inner.add_items(items)
+
+    async def pop_item(self) -> TResponseInputItem | None:
+        return await self._inner.pop_item()
+
+    async def clear_session(self) -> None:
+        await self._inner.clear_session()
 
 
 def session_store(
@@ -56,10 +123,13 @@ def session_store(
 
     store = resolve_session_store(store)
     if store:
-        return DatabricksSessionStore(session_id, store, actor_id=actor or session_id)
+        durable = DatabricksSessionStore(session_id, store, actor_id=actor or session_id)
+        return _SanitizingSession(durable)
     cached = _local_sessions.get(session_id)
     if cached is None:
-        cached = SQLiteSession(session_id)  # ":memory:" — process-local, non-durable
+        # ":memory:" — process-local, non-durable; wrapped so a failed run's dangling tool call can't
+        # break the next turn within the process either.
+        cached = _SanitizingSession(SQLiteSession(session_id))
         _local_sessions[session_id] = cached
     return cached
 

--- a/integrations/mason/templates/agent-openai/tests/test_agent.py
+++ b/integrations/mason/templates/agent-openai/tests/test_agent.py
@@ -9,9 +9,9 @@ import os
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
-from agents import FunctionTool
 from agent.agent import _apply_decisions, _normalize_item, _serialize_events, _session_id
 from agent.tools import all_tools
+from agents import FunctionTool
 
 
 def test_tools_autoregister():
@@ -139,7 +139,11 @@ async def test_serialize_events_relays_interrupt_as_native_event():
         {
             "type": "interrupt",
             "id": "call-1",
-            "value": {"action_requests": [{"name": "send_message", "args": {"recipient": "x", "body": "y"}}]},
+            "value": {
+                "action_requests": [
+                    {"name": "send_message", "args": {"recipient": "x", "body": "y"}}
+                ]
+            },
         }
     ]
     # The paused run is stashed in-process, keyed by session id, for a later resume.
@@ -198,7 +202,10 @@ def test_session_store_selects_durable_store(monkeypatch):
     monkeypatch.setenv("AGENT_SESSION_STORE", "my-store")
     monkeypatch.setattr(ss, "SessionStoreClient", lambda *a, **k: _FakeStoreClient())
     store = ss.session_store("abc-123")
-    assert isinstance(store, ss.DatabricksSessionStore)
+    # Sessions are wrapped so a failed run's dangling tool call can't poison the next turn; the
+    # durable store is the wrapped inner.
+    assert isinstance(store, ss._SanitizingSession)
+    assert isinstance(store._inner, ss.DatabricksSessionStore)
 
 
 class _FakeStoreClient:
@@ -216,6 +223,97 @@ def test_session_id_is_required_from_runtime():
         _session_id({"input": [{"role": "user", "content": "hi"}]})
 
 
+def test_prune_dangling_tool_calls_drops_call_without_output():
+    import databricks_mason.openai.sessions as ss
+
+    items = [
+        {"role": "user", "content": "hi"},
+        {"type": "function_call", "call_id": "c1", "name": "t", "arguments": "{}"},
+        # no function_call_output for c1 — an approval interrupt persisted the call but the resume
+        # (which writes the output) never landed.
+    ]
+    assert ss._prune_dangling_tool_calls(items) == [{"role": "user", "content": "hi"}]
+
+
+def test_prune_dangling_tool_calls_keeps_matched_pair():
+    import databricks_mason.openai.sessions as ss
+
+    items = [
+        {"type": "function_call", "call_id": "c1", "name": "t", "arguments": "{}"},
+        {"type": "function_call_output", "call_id": "c1", "output": "ok"},
+    ]
+    assert ss._prune_dangling_tool_calls(items) == items
+
+
+def test_prune_dangling_tool_calls_drops_orphan_output():
+    import databricks_mason.openai.sessions as ss
+
+    items = [
+        {"role": "user", "content": "hi"},
+        {"type": "function_call_output", "call_id": "c1", "output": "ok"},  # no matching call
+    ]
+    assert ss._prune_dangling_tool_calls(items) == [{"role": "user", "content": "hi"}]
+
+
+@pytest.mark.asyncio
+async def test_sanitizing_session_prunes_on_get_items():
+    import databricks_mason.openai.sessions as ss
+
+    inner = ss.SQLiteSession("prune-test")
+    await inner.add_items(
+        [
+            {"role": "user", "content": "hi"},
+            {"type": "function_call", "call_id": "c1", "name": "t", "arguments": "{}"},
+        ]
+    )
+    session = ss._SanitizingSession(inner)
+    # The dangling function_call is gone, so replaying this history won't 400 on the next turn.
+    assert await session.get_items() == [{"role": "user", "content": "hi"}]
+
+
+@pytest.mark.asyncio
+async def test_hitl_interrupt_leaves_dangling_call_that_wrapper_prunes():
+    # End-to-end: an approval-gated tool interrupts the run, and the SDK persists the function_call
+    # with no output (the output is only written on resume). This is the real source of the dangling
+    # call_id — verify the raw session is left dangling and the wrapper prunes it on replay.
+    import json
+
+    from agents import Agent, Runner, function_tool
+    from agents.testing import ModelStep, ScriptedModel
+    from openai.types.responses import ResponseFunctionToolCall
+
+    import databricks_mason.openai.sessions as ss
+
+    @function_tool
+    def transfer(amount: str) -> str:
+        """Transfer money (needs approval)."""
+        return f"transferred {amount}"
+
+    transfer.needs_approval = True
+
+    inner = ss.SQLiteSession("hitl-e2e")
+    call = ResponseFunctionToolCall(
+        type="function_call",
+        call_id="call_hitl",
+        name="transfer",
+        arguments=json.dumps({"amount": "100"}),
+        id="fc_1",
+    )
+    agent = Agent(name="t", tools=[transfer], model=ScriptedModel([ModelStep(output=[call])]))
+    result = await Runner.run(agent, [{"role": "user", "content": "send 100"}], session=inner)
+    assert result.interruptions, "expected an approval interrupt"
+
+    # The raw session now holds a function_call with no matching output — the exact BAD_REQUEST cause.
+    raw = await inner.get_items()
+    raw_calls = {i.get("call_id") for i in raw if i.get("type") == "function_call"}
+    raw_outputs = {i.get("call_id") for i in raw if i.get("type") == "function_call_output"}
+    assert raw_calls - raw_outputs == {"call_hitl"}
+
+    # The wrapper drops it on replay, so the next turn's input is well-formed.
+    replayed = await ss._SanitizingSession(inner).get_items()
+    assert not any(i.get("type") == "function_call" for i in replayed)
+
+
 def _has_workspace_auth() -> bool:
     return bool(
         os.getenv("DATABRICKS_CONFIG_PROFILE")
@@ -229,9 +327,9 @@ def _has_workspace_auth() -> bool:
 )
 @pytest.mark.asyncio
 async def test_agent_responds_end_to_end():
+    from agent.agent import configure, create_agent
     from agents import Runner
 
-    from agent.agent import configure, create_agent
     from databricks_mason.openai import session_store
 
     configure()


### PR DESCRIPTION
A run that dies during or right after a tool call persists the `function_call` item without its matching `function_call_output`, so the next turn replays a dangling `call_id` and the Responses API rejects the whole request with BAD_REQUEST. Wrap every session (durable and in-memory) so `get_items` drops unpaired tool calls/outputs on replay; writes and rollback pass through unchanged.