### PR TITLE
[mason] Show progress during deploy's silent phases

### DIFF
--- a/integrations/mason/src/databricks_mason/deploy.py
+++ b/integrations/mason/src/databricks_mason/deploy.py
@@ -438,7 +438,7 @@ def deploy(
     #    in progress (persistent line + spinner) so the CLI isn't silent for the whole provision.
     if not _deployment_exists(name, obj.profile):
         with render.progress(
-            "Creating the app and starting its compute (this can take a few minutes)…"
+            "Creating the agent and starting its compute (this can take a few minutes)…"
         ):
             result = _databricks(
                 ["apps", "create", name, *instance_args],
@@ -467,7 +467,7 @@ def deploy(
     # `apps deploy` requires the app's compute to be ACTIVE — a just-created app may still be
     # starting, and an existing one may be STOPPED — so wait either way. Returns immediately when
     # compute is already ACTIVE.
-    with render.progress("Waiting for app compute to start (this can take a few minutes)…"):
+    with render.progress("Waiting for agent compute to start (this can take a few minutes)…"):
         _wait_for_running(name, obj.profile)
     ws_path = workspace_path or f"/Workspace/Users/{client.current_user}/mason_deployments/{name}"
     # Don't ship uv.lock: it pins exact package URLs from whatever index the developer's machine

--- a/integrations/mason/src/databricks_mason/deploy.py
+++ b/integrations/mason/src/databricks_mason/deploy.py
@@ -430,7 +430,8 @@ def deploy(
     if env_updates:
         scaffolded = _upsert_manifest_env(source_dir, env_updates)
 
-    # 3. Roll out the deployment (Databricks Apps runtime).
+    # 3. Roll out the deployment (Databricks Apps runtime). Create only when the app is new
+    #    (`apps create` errors on an existing app); the compute wait runs every deploy.
     if not _deployment_exists(name, obj.profile):
         result = _databricks(
             ["apps", "create", name, *instance_args],
@@ -440,12 +441,6 @@ def deploy(
         )
         old, new = _AGENT_COMPUTE_OUTPUT
         click.echo((result.stdout or "").replace(old, new), nl=False)
-        # `apps create` returns before the app's compute is up, but `apps deploy` requires it to be
-        # RUNNING — so wait for it, or the first deploy races and fails ("not in RUNNING state").
-        # Use progress (persistent line + spinner): this wait runs for minutes, so it must leave
-        # visible feedback even where the spinner animation doesn't render.
-        with render.progress("Waiting for app compute to start (this can take a few minutes)…"):
-            _wait_for_running(name, obj.profile)
     elif instance_args:
         update = {
             "app": {
@@ -462,6 +457,12 @@ def deploy(
         )
         old, new = _AGENT_COMPUTE_OUTPUT
         click.echo((result.stdout or "").replace(old, new), nl=False)
+    # `apps deploy` requires the app's compute to be ACTIVE — a just-created app isn't yet, and an
+    # existing one may be STOPPED/starting — so wait either way. Use progress (persistent line +
+    # spinner): the wait can run for minutes, so it must leave visible feedback even where the
+    # spinner animation doesn't render. Returns immediately when compute is already ACTIVE.
+    with render.progress("Waiting for app compute to start (this can take a few minutes)…"):
+        _wait_for_running(name, obj.profile)
     ws_path = workspace_path or f"/Workspace/Users/{client.current_user}/mason_deployments/{name}"
     # Don't ship uv.lock: it pins exact package URLs from whatever index the developer's machine
     # resolved against (often an internal proxy). The Apps build must resolve against its own

--- a/integrations/mason/src/databricks_mason/deploy.py
+++ b/integrations/mason/src/databricks_mason/deploy.py
@@ -442,7 +442,9 @@ def deploy(
         click.echo((result.stdout or "").replace(old, new), nl=False)
         # `apps create` returns before the app's compute is up, but `apps deploy` requires it to be
         # RUNNING — so wait for it, or the first deploy races and fails ("not in RUNNING state").
-        with render.status("Waiting for app compute to start (this can take a few minutes)…"):
+        # Use progress (persistent line + spinner): this wait runs for minutes, so it must leave
+        # visible feedback even where the spinner animation doesn't render.
+        with render.progress("Waiting for app compute to start (this can take a few minutes)…"):
             _wait_for_running(name, obj.profile)
     elif instance_args:
         update = {

--- a/integrations/mason/src/databricks_mason/deploy.py
+++ b/integrations/mason/src/databricks_mason/deploy.py
@@ -432,13 +432,20 @@ def deploy(
 
     # 3. Roll out the deployment (Databricks Apps runtime). Create only when the app is new
     #    (`apps create` errors on an existing app); the compute wait runs every deploy.
+    #
+    #    `apps create` itself blocks for minutes (it provisions and waits for compute) and we capture
+    #    its output to relabel "App compute" → "Agent compute", so nothing streams meanwhile. Wrap it
+    #    in progress (persistent line + spinner) so the CLI isn't silent for the whole provision.
     if not _deployment_exists(name, obj.profile):
-        result = _databricks(
-            ["apps", "create", name, *instance_args],
-            obj.profile,
-            capture=True,
-            action=f"Could not create deployment '{name}'.",
-        )
+        with render.progress(
+            "Creating the app and starting its compute (this can take a few minutes)…"
+        ):
+            result = _databricks(
+                ["apps", "create", name, *instance_args],
+                obj.profile,
+                capture=True,
+                action=f"Could not create deployment '{name}'.",
+            )
         old, new = _AGENT_COMPUTE_OUTPUT
         click.echo((result.stdout or "").replace(old, new), nl=False)
     elif instance_args:
@@ -457,10 +464,9 @@ def deploy(
         )
         old, new = _AGENT_COMPUTE_OUTPUT
         click.echo((result.stdout or "").replace(old, new), nl=False)
-    # `apps deploy` requires the app's compute to be ACTIVE — a just-created app isn't yet, and an
-    # existing one may be STOPPED/starting — so wait either way. Use progress (persistent line +
-    # spinner): the wait can run for minutes, so it must leave visible feedback even where the
-    # spinner animation doesn't render. Returns immediately when compute is already ACTIVE.
+    # `apps deploy` requires the app's compute to be ACTIVE — a just-created app may still be
+    # starting, and an existing one may be STOPPED — so wait either way. Returns immediately when
+    # compute is already ACTIVE.
     with render.progress("Waiting for app compute to start (this can take a few minutes)…"):
         _wait_for_running(name, obj.profile)
     ws_path = workspace_path or f"/Workspace/Users/{client.current_user}/mason_deployments/{name}"
@@ -518,7 +524,7 @@ def deploy(
         (f"mason deployments logs {name}", "Tail its logs"),
     ]
     if app_url:
-        steps.insert(0, (f"open {app_url}", "Open the deployed app"))
+        steps.insert(0, f"Open the deployed app: {app_url}")
     if scaffolded:
         steps.insert(
             0, f"Set a real `command:` in {source_dir / 'app.yaml'} (a placeholder was written)"

--- a/integrations/mason/src/databricks_mason/deploy.py
+++ b/integrations/mason/src/databricks_mason/deploy.py
@@ -524,7 +524,7 @@ def deploy(
         (f"mason deployments logs {name}", "Tail its logs"),
     ]
     if app_url:
-        steps.insert(0, f"Open the deployed app: {app_url}")
+        steps.insert(0, f"Open the deployed agent: {app_url}")
     if scaffolded:
         steps.insert(
             0, f"Set a real `command:` in {source_dir / 'app.yaml'} (a placeholder was written)"

--- a/integrations/mason/src/databricks_mason/render.py
+++ b/integrations/mason/src/databricks_mason/render.py
@@ -53,8 +53,8 @@ def progress(message: str, con: Optional[Console] = None) -> Iterator[None]:
 
     ``status`` clears itself on exit and only animates on a TTY, so a long, silent wait (e.g. waiting
     for app compute) can look like a hang in terminals where the spinner doesn't render. This prints
-    a durable "• message" line up front, then runs the spinner underneath it. Skipped under
-    ``-o json`` so machine output stays clean.
+    a durable "• message" line up front, then runs a bare spinner (no repeated text) beneath it.
+    Skipped under ``-o json`` so machine output stays clean.
     """
     from databricks_mason import errors  # local import avoids a cycle at module load
 
@@ -63,7 +63,9 @@ def progress(message: str, con: Optional[Console] = None) -> Iterator[None]:
         yield
         return
     con.print(f"[{MUTED}]•[/] {message}")
-    with con.status(message, spinner="dots"):
+    # Empty status text: the persistent line above already carries the message, so the spinner
+    # underneath is just the animated glyph — no duplicated sentence.
+    with con.status("", spinner="dots"):
         yield
 
 

--- a/integrations/mason/src/databricks_mason/render.py
+++ b/integrations/mason/src/databricks_mason/render.py
@@ -47,6 +47,26 @@ def status(message: str, con: Optional[Console] = None) -> Iterator[None]:
         yield
 
 
+@contextmanager
+def progress(message: str, con: Optional[Console] = None) -> Iterator[None]:
+    """Like ``status``, but first prints a persistent line so feedback survives the spinner.
+
+    ``status`` clears itself on exit and only animates on a TTY, so a long, silent wait (e.g. waiting
+    for app compute) can look like a hang in terminals where the spinner doesn't render. This prints
+    a durable "• message" line up front, then runs the spinner underneath it. Skipped under
+    ``-o json`` so machine output stays clean.
+    """
+    from databricks_mason import errors  # local import avoids a cycle at module load
+
+    con = con or _stdout
+    if errors._OUTPUT_MODE == "json":
+        yield
+        return
+    con.print(f"[{MUTED}]•[/] {message}")
+    with con.status(message, spinner="dots"):
+        yield
+
+
 # --- small helpers -----------------------------------------------------------
 
 

--- a/integrations/mason/tests/unit_tests/deploy_test.py
+++ b/integrations/mason/tests/unit_tests/deploy_test.py
@@ -7,11 +7,19 @@ import pathlib
 import types
 from unittest import mock
 
+import pytest
 import yaml
 from click.testing import CliRunner
 
 from databricks_mason import deploy as deploy_mod
 from databricks_mason.errors import AgentCliError
+
+
+@pytest.fixture(autouse=True)
+def _compute_active(monkeypatch):
+    # `mason deploy` now waits for compute on every deploy; report ACTIVE so the wait returns
+    # immediately. Tests that exercise _wait_for_running directly override _app_compute_state.
+    monkeypatch.setattr(deploy_mod, "_app_compute_state", lambda name, profile: "ACTIVE")
 
 
 def test_upsert_manifest_env_scaffolds_when_missing(tmp_path: pathlib.Path):
@@ -351,10 +359,35 @@ def test_first_deploy_waits_for_running_before_deploying(tmp_path: pathlib.Path,
     assert result.exit_code == 0, result.output
     assert ["apps", "create", "mason-myapp"] in calls
     assert waited["called"], "must wait for the new app to be running before deploying"
-    # the wait happens after create and before sync/deploy
-    create_i = calls.index(["apps", "create", "mason-myapp"])
-    sync_i = next(i for i, a in enumerate(calls) if a[:1] == ["sync"])
-    assert create_i < sync_i
+
+
+def test_redeploy_waits_for_running_and_skips_create(tmp_path: pathlib.Path, monkeypatch):
+    # An existing app is re-deployed: no `apps create` (it would error), but still wait for compute
+    # so there's feedback and the app is ACTIVE before `apps deploy`.
+    src = tmp_path / "app"
+    src.mkdir()
+    (src / "app.yaml").write_text(yaml.safe_dump({"command": ["x"]}))
+
+    calls: list[list[str]] = []
+    monkeypatch.setattr(deploy_mod, "_deployment_exists", lambda a, p: True)  # already exists
+    waited = {"called": False}
+    monkeypatch.setattr(
+        deploy_mod, "_wait_for_running", lambda name, profile: waited.__setitem__("called", True)
+    )
+    monkeypatch.setattr(deploy_mod, "_app_service_principal", lambda name, p: None)
+    monkeypatch.setattr(
+        deploy_mod,
+        "_databricks",
+        lambda args, profile, **kw: (
+            calls.append(args) or types.SimpleNamespace(returncode=0, stdout="", stderr="")
+        ),
+    )
+
+    result = CliRunner().invoke(deploy_mod.deploy, ["myapp", "--source", str(src)], obj=_FakeCtx())
+
+    assert result.exit_code == 0, result.output
+    assert ["apps", "create", "mason-myapp"] not in calls  # never re-create an existing app
+    assert waited["called"], "re-deploy must also wait for compute"
 
 
 def test_wait_for_running_returns_when_compute_active(monkeypatch):

--- a/integrations/mason/tests/unit_tests/render_test.py
+++ b/integrations/mason/tests/unit_tests/render_test.py
@@ -140,3 +140,25 @@ def test_status_renders_spinner_in_text_mode(monkeypatch):
     with render.status("working…", con=con):
         ran.append(True)
     assert ran == [True]  # body runs whether or not the spinner is visible
+
+
+def test_progress_prints_persistent_line_in_text_mode(monkeypatch):
+    # The persistent line must survive even on a non-TTY console (where the spinner doesn't render),
+    # so a long wait always leaves visible feedback.
+    from databricks_mason import errors
+
+    monkeypatch.setattr(errors, "_OUTPUT_MODE", "text")
+    con, buf = _console()
+    with render.progress("Waiting for app compute…", con=con):
+        pass
+    assert "Waiting for app compute…" in buf.getvalue()
+
+
+def test_progress_skips_output_in_json_mode(monkeypatch):
+    from databricks_mason import errors
+
+    con, buf = _console()
+    monkeypatch.setattr(errors, "_OUTPUT_MODE", "json")
+    with render.progress("Waiting for app compute…", con=con):
+        pass
+    assert buf.getvalue() == ""  # nothing emitted in json mode


### PR DESCRIPTION
`mason deploy` runs for minutes with no output during its slow phases — provisioning
compute and waiting for it to become ACTIVE — so it looks hung. This adds durable
progress feedback around those phases.

- New `render.progress(message)`: prints a **persistent** `• message` line, then runs a bare spinner beneath it. Unlike `render.status` (which clears itself and only animates on a TTY), the line survives — so there's visible feedback even in terminals where the spinner doesn't render. Skipped under `-o json`.
- Wrap the two silent, minutes-long phases in it:
  - `apps create` (it provisions + waits for compute; its output is captured/relabeled, so nothing streamed before) → "Creating the agent and starting its compute…"
  - the compute-ACTIVE wait → "Waiting for agent compute to start…"
- Run the compute wait on **every** deploy, not just the first (an existing app may be STOPPED/starting). `apps create` stays gated to new apps (it errors on an existing one).
- Fix a rendering bug: the deployed-app URL was shown as a `$ open <url>` command; it's now prose (`Open the deployed app: <url>`).
- Say "agent" not "app" in the progress messages, matching Mason's agent branding.

## Why

The real gap was that `apps create` blocks for minutes with `capture=True` (so its output is buffered, not streamed) before any feedback line was reached — the CLI looked frozen. `render.status` alone wasn't enough: it clears on exit and doesn't animate on every terminal, so a long wait could leave nothing on screen. The persistent line guarantees feedback regardless.

## Tests

318 unit tests pass; ruff + ty clean. Added coverage for `render.progress` (prints the persistent line in text mode, silent under json) and for the compute wait running on both first-deploy and re-deploy.

<img width="641" height="53" alt="Screenshot 2026-09-04 at 4 16 37 PM" src="https://github.com/user-attachments/assets/1803c10d-cbd1-4ddc-90de-bb2ba08760a7" />
