### PR TITLE
[mason] tracing: managed MLflow tracing, on by default, experiment_id-centric

### DIFF
--- a/integrations/mason/src/databricks_mason/agent_project.py
+++ b/integrations/mason/src/databricks_mason/agent_project.py
@@ -17,7 +17,7 @@ from tomlkit.exceptions import ParseError
 from databricks_mason.errors import AgentCliError
 from databricks_mason.runtime.tool_manifest import MEMORY_STORE_TABLE, SESSION_STORE_TABLE
 
-# The tracing binding (`mason tracing configure` / `disable`). Tracing is on by default (a per-app
+# The tracing binding (`mason tracing configure` / `disable`). Tracing is on by default (a per-project
 # MLflow experiment); this table only records an explicit experiment override or a disable.
 TRACING_TABLE = "tracing"
 
@@ -329,7 +329,7 @@ class AgentProject:
         # The deployment's base name (`mason deploy` prefixes it with `mason-`); None until named.
         self.deployment_name = deployment_name
         self.durability_enabled = durability_enabled
-        # Tracing config: an explicit experiment id override (None = default per-app experiment), and
+        # Tracing config: an explicit experiment id override (None = default per-project experiment), and
         # whether tracing is disabled (tracing is on by default; this flag turns it off).
         self.trace_experiment_id = trace_experiment_id
         self.trace_disabled = trace_disabled
@@ -505,7 +505,7 @@ class AgentProject:
     def configure_tracing(self, experiment_id: str | None) -> bool:
         """Enable tracing and (optionally) pin an explicit experiment id. Returns True if changed.
 
-        ``experiment_id=None`` means "use the default per-app experiment": any prior override is
+        ``experiment_id=None`` means "use the default per-project experiment": any prior override is
         cleared. Enabling always clears a previous ``disabled`` flag (tracing is on by default, so an
         absent ``[tracing]`` table is the enabled default).
         """

--- a/integrations/mason/src/databricks_mason/agent_project.py
+++ b/integrations/mason/src/databricks_mason/agent_project.py
@@ -17,6 +17,10 @@ from tomlkit.exceptions import ParseError
 from databricks_mason.errors import AgentCliError
 from databricks_mason.runtime.tool_manifest import MEMORY_STORE_TABLE, SESSION_STORE_TABLE
 
+# The tracing binding (`mason tracing configure` / `disable`). Tracing is on by default (a per-app
+# MLflow experiment); this table only records an explicit experiment override or a disable.
+TRACING_TABLE = "tracing"
+
 _SCHEMA_VERSION = 1
 _SUPPORTED_FRAMEWORKS = {"langgraph", "openai"}
 _SUPPORTED_SCOPE_KINDS = {"table", "volume", "workspace"}
@@ -296,6 +300,8 @@ class AgentProject:
         memory_store: str | None = None,
         session_store: str | None = None,
         memory_store_id: str | None = None,
+        trace_experiment_id: str | None = None,
+        trace_disabled: bool = False,
     ) -> None:
         self.root = root
         self.path = root / "agent.toml"
@@ -307,6 +313,10 @@ class AgentProject:
         self.memory_store = memory_store
         self.session_store = session_store
         self.memory_store_id = memory_store_id
+        # Tracing config: an explicit experiment id override (None = default per-app experiment), and
+        # whether tracing is disabled (tracing is on by default; this flag turns it off).
+        self.trace_experiment_id = trace_experiment_id
+        self.trace_disabled = trace_disabled
 
     @classmethod
     def load(cls, root: pathlib.Path | str) -> "AgentProject":
@@ -347,6 +357,15 @@ class AgentProject:
         session_store = _store_name_from_manifest(
             document.get(SESSION_STORE_TABLE), SESSION_STORE_TABLE
         )
+        tracing_table = document.get(TRACING_TABLE)
+        trace_experiment_id: str | None = None
+        trace_disabled = False
+        if isinstance(tracing_table, Mapping):
+            raw_experiment = tracing_table.get("experiment_id")
+            trace_experiment_id = (
+                str(raw_experiment) if isinstance(raw_experiment, str) and raw_experiment else None
+            )
+            trace_disabled = bool(tracing_table.get("disabled"))
         return cls(
             project_root,
             document,
@@ -355,6 +374,8 @@ class AgentProject:
             memory_store,
             session_store,
             memory_store_id,
+            trace_experiment_id,
+            trace_disabled,
         )
 
     @classmethod
@@ -428,6 +449,41 @@ class AgentProject:
     def unbind_session_store(self) -> bool:
         """Remove the session store binding from agent.toml. Returns True if it was present."""
         return self._clear_store(SESSION_STORE_TABLE)
+
+    def configure_tracing(self, experiment_id: str | None) -> bool:
+        """Enable tracing and (optionally) pin an explicit experiment id. Returns True if changed.
+
+        ``experiment_id=None`` means "use the default per-app experiment": any prior override is
+        cleared. Enabling always clears a previous ``disabled`` flag (tracing is on by default, so an
+        absent ``[tracing]`` table is the enabled default).
+        """
+        if self.trace_experiment_id == experiment_id and not self.trace_disabled:
+            return False
+        table = self._document.get(TRACING_TABLE)
+        if not isinstance(table, Mapping):
+            table = tomlkit.table()
+            self._document.append(TRACING_TABLE, table)
+        if "disabled" in table:
+            del table["disabled"]
+        if experiment_id:
+            table["experiment_id"] = experiment_id
+        elif "experiment_id" in table:
+            del table["experiment_id"]
+        self.trace_experiment_id = experiment_id
+        self.trace_disabled = False
+        return True
+
+    def disable_tracing(self) -> bool:
+        """Turn tracing off (records ``[tracing] disabled = true``). Returns True if changed."""
+        if self.trace_disabled:
+            return False
+        table = self._document.get(TRACING_TABLE)
+        if not isinstance(table, Mapping):
+            table = tomlkit.table()
+            self._document.append(TRACING_TABLE, table)
+        table["disabled"] = True
+        self.trace_disabled = True
+        return True
 
     def _set_store(self, table: str, name: str, store_id: str | None = None) -> bool:
         name = _required_string(name, f"[{table}] name")

--- a/integrations/mason/src/databricks_mason/deploy.py
+++ b/integrations/mason/src/databricks_mason/deploy.py
@@ -41,8 +41,8 @@ from databricks_mason.store_access import (
 from databricks_mason.tracing import (
     TRACES_EXPERIMENT_ID_ENV,
     TRACES_TRACKING_URI_ENV,
-    default_experiment,
-    ensure_experiment,
+    create_experiment_idempotent,
+    default_experiment_name,
     experiment_url,
 )
 
@@ -321,7 +321,7 @@ def validate_stores(client, *, memory_store: Optional[str], session_store: Optio
             ) from exc
 
 
-def resolve_trace_experiment(
+def resolve_trace_experiment_id(
     source: pathlib.Path, project_name: str, client, profile
 ) -> Optional[str]:
     """The MLflow experiment id an agent traces to, or None when tracing is disabled.
@@ -349,8 +349,8 @@ def resolve_trace_experiment(
     pinned = project.trace_experiment_id if project is not None else None
     if pinned:
         return pinned
-    experiment_id = ensure_experiment(
-        profile, client, default_experiment(client.current_user, project_name)
+    experiment_id = create_experiment_idempotent(
+        profile, client, default_experiment_name(client.current_user, project_name)
     )
     # Pin the resolved default so subsequent runs reuse it by id (removes the special-cased "recompute
     # the default" path). No agent.toml (raw dir) just means nowhere to pin — still trace this run.
@@ -496,7 +496,7 @@ def deploy(
     trace_experiment_id: Optional[str] = None
     trace_setup_error: Optional[str] = None
     try:
-        trace_experiment_id = resolve_trace_experiment(
+        trace_experiment_id = resolve_trace_experiment_id(
             source_dir, source_dir.resolve().name, client, obj.profile
         )
     except Exception as exc:  # noqa: BLE001 - tracing is best-effort; never block a deploy

--- a/integrations/mason/src/databricks_mason/deploy.py
+++ b/integrations/mason/src/databricks_mason/deploy.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 import json
 import pathlib
 import time
-from dataclasses import replace
+from dataclasses import dataclass, replace
 from typing import Any, Optional
 
 import click
@@ -343,9 +343,27 @@ def resolve_trace_experiment(source: pathlib.Path, app: str, client, profile) ->
     return ensure_experiment(profile, client, default_experiment(client.current_user, app))
 
 
-def trace_env(experiment_id: str) -> dict[str, str]:
-    """The env that binds a dev/deployed agent to an experiment: the workspace + the experiment id."""
-    return {TRACES_TRACKING_URI_ENV: "databricks", TRACES_EXPERIMENT_ID_ENV: experiment_id}
+@dataclass(frozen=True)
+class MlflowTracingConfig:
+    """The MLflow config that binds a dev/deployed agent to its experiment.
+
+    The agent enables tracing when it sees both a destination (the workspace tracking uri) and an
+    experiment id; ``env`` renders them as the two env vars wired into app.yaml.
+    """
+
+    experiment_id: str
+    tracking_uri: str = "databricks"
+
+    def env(self) -> dict[str, str]:
+        return {
+            TRACES_TRACKING_URI_ENV: self.tracking_uri,
+            TRACES_EXPERIMENT_ID_ENV: self.experiment_id,
+        }
+
+
+def mlflow_tracing_config(experiment_id: str) -> MlflowTracingConfig:
+    """The tracing config binding a dev/deployed agent to ``experiment_id``."""
+    return MlflowTracingConfig(experiment_id=experiment_id)
 
 
 def _grant_store_access(
@@ -473,7 +491,7 @@ def deploy(
     if session_store:
         provisioned["Session store"] = session_store
     if trace_experiment_id:
-        env_updates.update(trace_env(trace_experiment_id))
+        env_updates.update(mlflow_tracing_config(trace_experiment_id).env())
         provisioned["Traces"] = (
             experiment_url(client.host, trace_experiment_id) or trace_experiment_id
         )

--- a/integrations/mason/src/databricks_mason/deploy.py
+++ b/integrations/mason/src/databricks_mason/deploy.py
@@ -23,8 +23,19 @@ import yaml
 from databricks_mason import memory_store_access, render, session_store_access, timefmt
 from databricks_mason.errors import AgentCliError
 from databricks_mason.render import field
-from databricks_mason.store_access import _databricks, apply_postgres_resources, grant_tables
-from databricks_mason.tracing import TRACES_DEST_ENV, TRACES_EXPERIMENT_ENV, default_experiment
+from databricks_mason.store_access import (
+    _databricks,
+    apply_experiment_resource,
+    apply_postgres_resources,
+    grant_tables,
+)
+from databricks_mason.tracing import (
+    TRACES_EXPERIMENT_ID_ENV,
+    TRACES_TRACKING_URI_ENV,
+    default_experiment,
+    ensure_experiment,
+    experiment_url,
+)
 
 # TEMPORARY: the Apps build environment currently can't reach the internal pypi proxy, so builds
 # time out installing dependencies. Point the build at public PyPI (sanctioned interim workaround)
@@ -251,21 +262,12 @@ def store_bindings(source: pathlib.Path) -> tuple[Optional[str], Optional[str]]:
     return memory, session
 
 
-def validate_stores_and_trace_env(
-    client,
-    *,
-    app: Optional[str],
-    memory_store: Optional[str],
-    session_store: Optional[str],
-    traces_destination: Optional[str],
-    traces_experiment: Optional[str],
-) -> dict[str, str]:
-    """Validate the agent's bound stores exist and build the MLFLOW_* trace env to wire in.
+def validate_stores(client, *, memory_store: Optional[str], session_store: Optional[str]) -> None:
+    """Validate the agent's bound stores exist. Shared by `mason deploy` and `mason dev`.
 
-    Shared by `mason deploy` and `mason dev`. Stores are created by `mason memory/sessions bind` and
-    read from agent.toml at runtime, so this neither creates them nor writes them to app.yaml — it
-    only checks a bound store still exists (a typo or unbound clone fails here, not at runtime) and
-    returns the trace env.
+    Stores are created by `mason memory/sessions bind` and read from agent.toml at runtime, so this
+    neither creates them nor writes them to app.yaml — it only checks a bound store still exists (a
+    typo or unbound clone fails here, not at runtime).
     """
     if memory_store and _resolve_memory_store(client, memory_store) is None:
         # Resolve by display name: get_memory_store looks up by resource id, not the bound name.
@@ -282,18 +284,33 @@ def validate_stores_and_trace_env(
                 hint=f"Run `mason sessions bind {session_store}` to create and bind it.",
                 error_code=exc.error_code,
             ) from exc
-    env: dict[str, str] = {}
-    if traces_destination:
-        env[TRACES_DEST_ENV] = traces_destination
-        # The agent enables tracing only when BOTH a destination and an experiment are set, so
-        # default the experiment to this agent's per-app path (matching `mason tracing setup --app`),
-        # otherwise --with-traces alone would ship a half-config that silently disables tracing.
-        env[TRACES_EXPERIMENT_ENV] = traces_experiment or default_experiment(
-            client.current_user, app
-        )
-    elif traces_experiment:
-        env[TRACES_EXPERIMENT_ENV] = traces_experiment
-    return env
+
+
+def resolve_trace_experiment(source: pathlib.Path, app: str, client, profile) -> Optional[str]:
+    """The MLflow experiment id an agent traces to, or None when tracing is disabled.
+
+    Tracing is on by default: unless `mason tracing disable` was run, this returns the project's
+    pinned experiment id (`mason tracing configure --experiment`), else creates-and-returns a per-app
+    experiment (`/Users/<you>/mason-traces/<app>`). Shared by `mason dev` and `mason deploy` so both
+    trace to the same experiment for a given agent.
+    """
+    from databricks_mason.agent_project import AgentProject  # noqa: PLC0415 - avoid import cycle
+
+    try:
+        project = AgentProject.load(source)
+    except AgentCliError:
+        project = None
+    if project is not None and project.trace_disabled:
+        return None
+    pinned = project.trace_experiment_id if project is not None else None
+    if pinned:
+        return pinned
+    return ensure_experiment(profile, client, default_experiment(client.current_user, app))
+
+
+def trace_env(experiment_id: str) -> dict[str, str]:
+    """The env that binds a dev/deployed agent to an experiment: the workspace + the experiment id."""
+    return {TRACES_TRACKING_URI_ENV: "databricks", TRACES_EXPERIMENT_ID_ENV: experiment_id}
 
 
 def _grant_store_access(
@@ -341,18 +358,6 @@ def _grant_store_access(
     "current directory.",
 )
 @click.option(
-    "--with-traces",
-    "traces_destination",
-    default=None,
-    help="UC trace destination 'catalog.schema' to wire in via MLFLOW_TRACING_DESTINATION "
-    "(link it first with `mason tracing setup`).",
-)
-@click.option(
-    "--traces-experiment",
-    default=None,
-    help="MLflow experiment path to wire in via MLFLOW_EXPERIMENT_NAME.",
-)
-@click.option(
     "--pip-index-url",
     default=_DEFAULT_PIP_INDEX_URL,
     show_default=True,
@@ -374,8 +379,6 @@ def deploy(
     obj,
     name,
     source,
-    traces_destination,
-    traces_experiment,
     pip_index_url,
     workspace_path,
     instances,
@@ -398,26 +401,34 @@ def deploy(
     source_dir = pathlib.Path(source)
     client = obj.client()
 
-    # 1. Validate the agent's bound stores (`mason memory/sessions bind` creates them) and build any
-    #    trace env. Stores are read from agent.toml at runtime, not wired into app.yaml; the bindings
-    #    also drive the store access grant (step 4).
+    # 1. Validate the agent's bound stores (`mason memory/sessions bind` creates them). Stores are
+    #    read from agent.toml at runtime, not wired into app.yaml; the bindings also drive the store
+    #    access grant (step 4).
     memory_store, session_store = store_bindings(source_dir)
     with render.status("Checking stores…"):
-        env_updates = validate_stores_and_trace_env(
-            client,
-            app=name,
-            memory_store=memory_store,
-            session_store=session_store,
-            traces_destination=traces_destination,
-            traces_experiment=traces_experiment,
-        )
+        validate_stores(client, memory_store=memory_store, session_store=session_store)
+
+    # 2. Provision tracing (on by default): resolve/create the agent's MLflow experiment and wire the
+    #    two env vars the runtime reads. Keyed on the app name, matching `mason dev`. The app's SP is
+    #    granted write access to it in step 5 (an experiment app resource). Best-effort: if it can't
+    #    be set up (e.g. no mlflow installed), the deploy still proceeds without tracing.
+    trace_experiment_id: Optional[str] = None
+    trace_setup_error: Optional[str] = None
+    try:
+        trace_experiment_id = resolve_trace_experiment(source_dir, name, client, obj.profile)
+    except AgentCliError as exc:
+        trace_setup_error = str(exc)
+    env_updates: dict[str, str] = {}
     provisioned: dict[str, Any] = {}
     if memory_store:
         provisioned["Memory store"] = memory_store
     if session_store:
         provisioned["Session store"] = session_store
-    if traces_destination:
-        provisioned["Traces"] = traces_destination
+    if trace_experiment_id:
+        env_updates.update(trace_env(trace_experiment_id))
+        provisioned["Traces"] = (
+            experiment_url(client.host, trace_experiment_id) or trace_experiment_id
+        )
     if pip_index_url:
         for env in _PIP_INDEX_ENVS:
             env_updates[env] = pip_index_url
@@ -425,12 +436,12 @@ def deploy(
     if instances is not None:
         provisioned["Instances"] = str(instances)
 
-    # 2. Patch the app.yaml manifest with any trace/index env (stores are read from agent.toml).
+    # 3. Patch the app.yaml manifest with any trace/index env (stores are read from agent.toml).
     scaffolded = False
     if env_updates:
         scaffolded = _upsert_manifest_env(source_dir, env_updates)
 
-    # 3. Roll out the deployment (Databricks Apps runtime). Create only when the app is new
+    # 4. Roll out the deployment (Databricks Apps runtime). Create only when the app is new
     #    (`apps create` errors on an existing app); the compute wait runs every deploy.
     #
     #    `apps create` itself blocks for minutes (it provisions and waits for compute) and we capture
@@ -484,9 +495,10 @@ def deploy(
         action=f"Could not deploy '{name}'.",
     )
 
-    # 4. Give the app's SP access to its stores (best-effort, two steps): bind each store's database
-    #    as a `postgres` resource (CONNECT), then GRANT the SP read/write on its tables. Without
-    #    both, the app runs but the durable store path fails (can't connect, or can't read tables).
+    # 5. Grant the app's service principal what it needs to run (best-effort):
+    #    - stores: bind each store DB as a `postgres` resource (CONNECT) + GRANT read/write on tables;
+    #    - tracing: bind the experiment as an `experiment` resource (CAN_EDIT) so it can write traces.
+    #    The experiment resource is the platform-managed grant — no manual SQL grant needed.
     grants_stores = bool(session_store or memory_store)
     grant_error: Optional[str] = None
     if grants_stores:
@@ -501,6 +513,10 @@ def deploy(
                 grant_error = _grant_store_access(
                     name, sp, client.current_user, session_store, memory_database, obj.profile
                 )
+    trace_grant_error: Optional[str] = None
+    if trace_experiment_id:
+        with render.status("Granting the app access to its trace experiment…"):
+            trace_grant_error = apply_experiment_resource(name, trace_experiment_id, obj.profile)
 
     app_url = _app_url(name, obj.profile)
 
@@ -511,6 +527,12 @@ def deploy(
                 "url": app_url,
                 "workspace_path": ws_path,
                 "env": env_updates,
+                "trace_experiment_id": trace_experiment_id,
+                "trace_setup_error": trace_setup_error,
+                "trace_grant": None
+                if not trace_experiment_id
+                else ("granted" if trace_grant_error is None else "failed"),
+                "trace_grant_error": trace_grant_error,
                 "store_grant": "skipped"
                 if not grants_stores
                 else ("granted" if grant_error is None else "failed"),
@@ -536,8 +558,18 @@ def deploy(
             "be applied automatically (it requires store ownership). "
             f"Cause: {grant_error}",
         )
+    if trace_setup_error is not None:
+        steps.insert(0, f"Tracing wasn't set up (deployed without it). Cause: {trace_setup_error}")
+    if trace_experiment_id and trace_grant_error is not None:
+        steps.insert(
+            0,
+            "The app's service principal needs write access to its trace experiment; that grant "
+            f"couldn't be applied automatically. Cause: {trace_grant_error}",
+        )
     if grants_stores and grant_error is None:
         provisioned["Store access"] = "granted to app service principal"
+    if trace_experiment_id and trace_grant_error is None:
+        provisioned["Trace access"] = "granted to app service principal"
     fields = {"URL": app_url} if app_url else {}
     fields.update({"Workspace path": ws_path, **provisioned})
     render.success(

--- a/integrations/mason/src/databricks_mason/deploy.py
+++ b/integrations/mason/src/databricks_mason/deploy.py
@@ -324,10 +324,16 @@ def validate_stores(client, *, memory_store: Optional[str], session_store: Optio
 def resolve_trace_experiment(source: pathlib.Path, app: str, client, profile) -> Optional[str]:
     """The MLflow experiment id an agent traces to, or None when tracing is disabled.
 
-    Tracing is on by default: unless `mason tracing disable` was run, this returns the project's
-    pinned experiment id (`mason tracing configure --experiment`), else creates-and-returns a per-app
-    experiment (`/Users/<you>/mason-traces/<app>`). Shared by `mason dev` and `mason deploy` so both
-    trace to the same experiment for a given agent.
+    Tracing is on by default. Resolution:
+
+    - `mason tracing disable` was run -> None (tracing off).
+    - a pinned experiment id (`mason tracing configure --experiment`) -> that id.
+    - otherwise -> create the per-app experiment (`/Users/<you>/mason-traces/<app>`), pin its id into
+      agent.toml, and return it. Pinning on first run means later `mason dev` / `mason deploy` reuse
+      the same experiment by id rather than re-deriving the default each time — there is no separate
+      "default" state once tracing has run once.
+
+    Shared by `mason dev` and `mason deploy` so both trace to the same experiment for a given agent.
     """
     from databricks_mason.agent_project import AgentProject  # noqa: PLC0415 - avoid import cycle
 
@@ -340,7 +346,12 @@ def resolve_trace_experiment(source: pathlib.Path, app: str, client, profile) ->
     pinned = project.trace_experiment_id if project is not None else None
     if pinned:
         return pinned
-    return ensure_experiment(profile, client, default_experiment(client.current_user, app))
+    experiment_id = ensure_experiment(profile, client, default_experiment(client.current_user, app))
+    # Pin the resolved default so subsequent runs reuse it by id (removes the special-cased "recompute
+    # the default" path). No agent.toml (raw dir) just means nowhere to pin — still trace this run.
+    if project is not None and project.configure_tracing(experiment_id):
+        project.write()
+    return experiment_id
 
 
 @dataclass(frozen=True)
@@ -473,7 +484,8 @@ def deploy(
     # 2. Provision tracing (on by default): resolve/create the agent's MLflow experiment and wire the
     #    two env vars the runtime reads. Keyed on the source dir name (NOT the mason-prefixed
     #    deployment name), matching `mason dev`, so dev and deploy trace to the same per-agent
-    #    experiment. The app's SP is granted write access to it in step 5 (an experiment app
+    #    experiment. On first run the resolved default experiment id is pinned into agent.toml, so
+    #    later runs reuse it. The app's SP is granted write access to it in step 5 (an experiment app
     #    resource). Best-effort: if it can't be set up (no mlflow, offline, permission), the deploy
     #    still proceeds without tracing.
     trace_experiment_id: Optional[str] = None

--- a/integrations/mason/src/databricks_mason/deploy.py
+++ b/integrations/mason/src/databricks_mason/deploy.py
@@ -411,14 +411,18 @@ def deploy(
         validate_stores(client, memory_store=memory_store, session_store=session_store)
 
     # 2. Provision tracing (on by default): resolve/create the agent's MLflow experiment and wire the
-    #    two env vars the runtime reads. Keyed on the app name, matching `mason dev`. The app's SP is
-    #    granted write access to it in step 5 (an experiment app resource). Best-effort: if it can't
-    #    be set up (e.g. no mlflow installed), the deploy still proceeds without tracing.
+    #    two env vars the runtime reads. Keyed on the source dir name (NOT the mason-prefixed
+    #    deployment name), matching `mason dev`, so dev and deploy trace to the same per-agent
+    #    experiment. The app's SP is granted write access to it in step 5 (an experiment app
+    #    resource). Best-effort: if it can't be set up (no mlflow, offline, permission), the deploy
+    #    still proceeds without tracing.
     trace_experiment_id: Optional[str] = None
     trace_setup_error: Optional[str] = None
     try:
-        trace_experiment_id = resolve_trace_experiment(source_dir, name, client, obj.profile)
-    except AgentCliError as exc:
+        trace_experiment_id = resolve_trace_experiment(
+            source_dir, source_dir.resolve().name, client, obj.profile
+        )
+    except Exception as exc:  # noqa: BLE001 - tracing is best-effort; never block a deploy
         trace_setup_error = str(exc)
     env_updates: dict[str, str] = {}
     provisioned: dict[str, Any] = {}

--- a/integrations/mason/src/databricks_mason/deploy.py
+++ b/integrations/mason/src/databricks_mason/deploy.py
@@ -321,19 +321,22 @@ def validate_stores(client, *, memory_store: Optional[str], session_store: Optio
             ) from exc
 
 
-def resolve_trace_experiment(source: pathlib.Path, app: str, client, profile) -> Optional[str]:
+def resolve_trace_experiment(
+    source: pathlib.Path, project_name: str, client, profile
+) -> Optional[str]:
     """The MLflow experiment id an agent traces to, or None when tracing is disabled.
 
-    Tracing is on by default. Resolution:
+    ``project_name`` is the Mason project name (the source directory's basename), not the deployed
+    app name. Tracing is on by default. Resolution:
 
     - `mason tracing disable` was run -> None (tracing off).
     - a pinned experiment id (`mason tracing configure --experiment`) -> that id.
-    - otherwise -> create the per-app experiment (`/Users/<you>/mason-traces/<app>`), pin its id into
-      agent.toml, and return it. Pinning on first run means later `mason dev` / `mason deploy` reuse
-      the same experiment by id rather than re-deriving the default each time — there is no separate
-      "default" state once tracing has run once.
+    - otherwise -> create the per-project experiment (`/Users/<you>/mason-traces/<project>`), pin its
+      id into agent.toml, and return it. Pinning on first run means later `mason dev` / `mason deploy`
+      reuse the same experiment by id rather than re-deriving the default each time — there is no
+      separate "default" state once tracing has run once.
 
-    Shared by `mason dev` and `mason deploy` so both trace to the same experiment for a given agent.
+    Shared by `mason dev` and `mason deploy` so both trace to the same experiment for a given project.
     """
     from databricks_mason.agent_project import AgentProject  # noqa: PLC0415 - avoid import cycle
 
@@ -346,7 +349,9 @@ def resolve_trace_experiment(source: pathlib.Path, app: str, client, profile) ->
     pinned = project.trace_experiment_id if project is not None else None
     if pinned:
         return pinned
-    experiment_id = ensure_experiment(profile, client, default_experiment(client.current_user, app))
+    experiment_id = ensure_experiment(
+        profile, client, default_experiment(client.current_user, project_name)
+    )
     # Pin the resolved default so subsequent runs reuse it by id (removes the special-cased "recompute
     # the default" path). No agent.toml (raw dir) just means nowhere to pin — still trace this run.
     if project is not None and project.configure_tracing(experiment_id):
@@ -483,7 +488,7 @@ def deploy(
 
     # 2. Provision tracing (on by default): resolve/create the agent's MLflow experiment and wire the
     #    two env vars the runtime reads. Keyed on the source dir name (NOT the mason-prefixed
-    #    deployment name), matching `mason dev`, so dev and deploy trace to the same per-agent
+    #    deployment name), matching `mason dev`, so dev and deploy trace to the same per-project
     #    experiment. On first run the resolved default experiment id is pinned into agent.toml, so
     #    later runs reuse it. The app's SP is granted write access to it in step 5 (an experiment app
     #    resource). Best-effort: if it can't be set up (no mlflow, offline, permission), the deploy

--- a/integrations/mason/src/databricks_mason/dev.py
+++ b/integrations/mason/src/databricks_mason/dev.py
@@ -67,7 +67,7 @@ def dev(
     ``--prepare-environment`` to force a rebuild (e.g. after changing dependencies).
 
     Tracing is on by default: dev sends the agent's traces to the default mason experiment based on
-    the agent name (the same one ``mason deploy`` uses), created and pinned into agent.toml on first
+    the project name (the same one ``mason deploy`` uses), created and pinned into agent.toml on first
     run — configure or turn it off with ``mason tracing configure`` / ``disable``. Stores bound with ``mason memory/sessions
     bind`` are validated here and read from agent.toml at runtime. Locally you already have access, so
     no service-principal grant is needed; that grant happens at ``mason deploy`` time.
@@ -82,7 +82,7 @@ def dev(
 
     # Validate the agent.toml store bindings and wire tracing into app.yaml. Stores are read from
     # agent.toml at runtime (not written here); tracing is on by default, so resolve/create the
-    # per-app experiment and wire its env. Tracing is best-effort locally — if it can't be set up
+    # per-project experiment and wire its env. Tracing is best-effort locally — if it can't be set up
     # (e.g. no mlflow installed, or offline), dev still runs the agent, just without traces.
     memory_store, session_store = store_bindings(source_dir)
     env_updates: dict[str, str] = {}

--- a/integrations/mason/src/databricks_mason/dev.py
+++ b/integrations/mason/src/databricks_mason/dev.py
@@ -19,9 +19,9 @@ from databricks_mason import render
 from databricks_mason.agent_project import AgentProject
 from databricks_mason.deploy import (
     _upsert_manifest_env,
+    mlflow_tracing_config,
     resolve_trace_experiment,
     store_bindings,
-    trace_env,
     validate_stores,
 )
 from databricks_mason.errors import AgentCliError
@@ -66,11 +66,11 @@ def dev(
     ``mason deploy``. The environment is built on first run and reused after; pass
     ``--prepare-environment`` to force a rebuild (e.g. after changing dependencies).
 
-    Tracing is on by default: dev sends the agent's traces to a per-app MLflow experiment (the same
-    one ``mason deploy`` uses), created on first run — configure or turn it off with ``mason tracing
-    configure`` / ``disable``. Stores bound with ``mason memory/sessions bind`` are validated here and
-    read from agent.toml at runtime. Locally you already have access, so no service-principal grant is
-    needed; that grant happens at ``mason deploy`` time.
+    Tracing is on by default: dev sends the agent's traces to the default mason experiment based on
+    the agent name (the same one ``mason deploy`` uses), created on first run — configure or turn it
+    off with ``mason tracing configure`` / ``disable``. Stores bound with ``mason memory/sessions
+    bind`` are validated here and read from agent.toml at runtime. Locally you already have access, so
+    no service-principal grant is needed; that grant happens at ``mason deploy`` time.
     """
     source_dir = pathlib.Path(source)
     app_yaml = source_dir / "app.yaml"
@@ -98,9 +98,11 @@ def dev(
             source_dir, source_dir.resolve().name, obj.client(), obj.profile
         )
         if experiment_id:
-            env_updates.update(trace_env(experiment_id))
+            env_updates.update(mlflow_tracing_config(experiment_id).env())
     except Exception as exc:  # noqa: BLE001 - tracing must never block a local run
-        render.console().print(f"[yellow]⚠[/] Tracing not enabled: {exc}. Running without traces.")
+        render.console().print(
+            f"[yellow]⚠[/] Tracing not enabled: {exc}. Proceeding without tracing."
+        )
     if env_updates:
         _upsert_manifest_env(source_dir, env_updates)
 

--- a/integrations/mason/src/databricks_mason/dev.py
+++ b/integrations/mason/src/databricks_mason/dev.py
@@ -20,7 +20,7 @@ from databricks_mason.agent_project import AgentProject
 from databricks_mason.deploy import (
     _upsert_manifest_env,
     mlflow_tracing_config,
-    resolve_trace_experiment,
+    resolve_trace_experiment_id,
     store_bindings,
     validate_stores,
 )
@@ -94,7 +94,7 @@ def dev(
     # offline, no mlflow, permission) degrades to running without traces rather than aborting a purely
     # local run.
     try:
-        experiment_id = resolve_trace_experiment(
+        experiment_id = resolve_trace_experiment_id(
             source_dir, source_dir.resolve().name, obj.client(), obj.profile
         )
         if experiment_id:

--- a/integrations/mason/src/databricks_mason/dev.py
+++ b/integrations/mason/src/databricks_mason/dev.py
@@ -18,8 +18,10 @@ import yaml
 from databricks_mason import render
 from databricks_mason.deploy import (
     _upsert_manifest_env,
+    resolve_trace_experiment,
     store_bindings,
-    validate_stores_and_trace_env,
+    trace_env,
+    validate_stores,
 )
 from databricks_mason.errors import AgentCliError
 from databricks_mason.store_access import _databricks
@@ -48,25 +50,12 @@ _BUILD_INDEX_ENVS = frozenset({"PIP_INDEX_URL", "UV_INDEX_URL", "UV_DEFAULT_INDE
     "exists yet, and reuse it otherwise. Requires uv.",
 )
 @click.option("--app-port", type=int, default=None, help="Port to run the app on (default 8000).")
-@click.option(
-    "--with-traces",
-    "traces_destination",
-    default=None,
-    help="UC trace destination 'catalog.schema' to wire in via MLFLOW_TRACING_DESTINATION.",
-)
-@click.option(
-    "--traces-experiment",
-    default=None,
-    help="MLflow experiment path to wire in via MLFLOW_EXPERIMENT_NAME.",
-)
 @click.pass_obj
 def dev(
     obj,
     source: str,
     prepare_environment: Optional[bool],
     app_port: Optional[int],
-    traces_destination: Optional[str],
-    traces_experiment: Optional[str],
 ) -> None:
     """Run a scaffolded agent locally from its app.yaml (wraps `databricks apps run-local`).
 
@@ -75,10 +64,11 @@ def dev(
     ``mason deploy``. The environment is built on first run and reused after; pass
     ``--prepare-environment`` to force a rebuild (e.g. after changing dependencies).
 
-    Stores bound with ``mason memory/sessions bind`` are validated here and read from agent.toml at
-    runtime (not written to app.yaml); the ``--with-traces`` flag wires tracing env into app.yaml,
-    exactly as ``mason deploy`` does. Locally the store owner (you) already has access, so no
-    service-principal grant is needed here; that grant happens at ``mason deploy`` time.
+    Tracing is on by default: dev sends the agent's traces to a per-app MLflow experiment (the same
+    one ``mason deploy`` uses), created on first run — configure or turn it off with ``mason tracing
+    configure`` / ``disable``. Stores bound with ``mason memory/sessions bind`` are validated here and
+    read from agent.toml at runtime. Locally you already have access, so no service-principal grant is
+    needed; that grant happens at ``mason deploy`` time.
     """
     source_dir = pathlib.Path(source)
     app_yaml = source_dir / "app.yaml"
@@ -88,24 +78,26 @@ def dev(
             hint="Run from a scaffolded project, or pass --source <dir> (see `mason init`).",
         )
 
-    # Validate the agent.toml store bindings exist and wire any traces into app.yaml. The stores are
-    # read from agent.toml at runtime, so they aren't written to app.yaml — set them (and create them)
-    # with `mason memory/sessions bind`.
+    # Validate the agent.toml store bindings and wire tracing into app.yaml. Stores are read from
+    # agent.toml at runtime (not written here); tracing is on by default, so resolve/create the
+    # per-app experiment and wire its env. Tracing is best-effort locally — if it can't be set up
+    # (e.g. no mlflow installed, or offline), dev still runs the agent, just without traces.
     memory_store, session_store = store_bindings(source_dir)
-    if memory_store or session_store or traces_destination or traces_experiment:
-        # The agent name defaults to the project dir name, so a per-app trace experiment here matches
-        # what `mason deploy <that-name>` derives.
+    env_updates: dict[str, str] = {}
+    client = obj.client()
+    if memory_store or session_store:
         with render.status("Checking stores…"):
-            env_updates = validate_stores_and_trace_env(
-                obj.client(),
-                app=source_dir.resolve().name,
-                memory_store=memory_store,
-                session_store=session_store,
-                traces_destination=traces_destination,
-                traces_experiment=traces_experiment,
-            )
-        if env_updates:
-            _upsert_manifest_env(source_dir, env_updates)
+            validate_stores(client, memory_store=memory_store, session_store=session_store)
+    try:
+        experiment_id = resolve_trace_experiment(
+            source_dir, source_dir.resolve().name, client, obj.profile
+        )
+        if experiment_id:
+            env_updates.update(trace_env(experiment_id))
+    except AgentCliError as exc:
+        render.console().print(f"[yellow]⚠[/] Tracing not enabled: {exc}. Running without traces.")
+    if env_updates:
+        _upsert_manifest_env(source_dir, env_updates)
 
     # Default: prepare only when there's no venv yet, so repeat runs don't rebuild. Explicit
     # --prepare-environment / --no-prepare-environment overrides the auto-detect.

--- a/integrations/mason/src/databricks_mason/dev.py
+++ b/integrations/mason/src/databricks_mason/dev.py
@@ -67,8 +67,8 @@ def dev(
     ``--prepare-environment`` to force a rebuild (e.g. after changing dependencies).
 
     Tracing is on by default: dev sends the agent's traces to the default mason experiment based on
-    the agent name (the same one ``mason deploy`` uses), created on first run — configure or turn it
-    off with ``mason tracing configure`` / ``disable``. Stores bound with ``mason memory/sessions
+    the agent name (the same one ``mason deploy`` uses), created and pinned into agent.toml on first
+    run — configure or turn it off with ``mason tracing configure`` / ``disable``. Stores bound with ``mason memory/sessions
     bind`` are validated here and read from agent.toml at runtime. Locally you already have access, so
     no service-principal grant is needed; that grant happens at ``mason deploy`` time.
     """

--- a/integrations/mason/src/databricks_mason/dev.py
+++ b/integrations/mason/src/databricks_mason/dev.py
@@ -84,17 +84,20 @@ def dev(
     # (e.g. no mlflow installed, or offline), dev still runs the agent, just without traces.
     memory_store, session_store = store_bindings(source_dir)
     env_updates: dict[str, str] = {}
-    client = obj.client()
+    # Stores legitimately require auth, so build the client eagerly only when stores are bound.
     if memory_store or session_store:
         with render.status("Checking stores…"):
-            validate_stores(client, memory_store=memory_store, session_store=session_store)
+            validate_stores(obj.client(), memory_store=memory_store, session_store=session_store)
+    # Tracing is best-effort: build the client and provision inside the try so ANY failure (no auth /
+    # offline, no mlflow, permission) degrades to running without traces rather than aborting a purely
+    # local run.
     try:
         experiment_id = resolve_trace_experiment(
-            source_dir, source_dir.resolve().name, client, obj.profile
+            source_dir, source_dir.resolve().name, obj.client(), obj.profile
         )
         if experiment_id:
             env_updates.update(trace_env(experiment_id))
-    except AgentCliError as exc:
+    except Exception as exc:  # noqa: BLE001 - tracing must never block a local run
         render.console().print(f"[yellow]⚠[/] Tracing not enabled: {exc}. Running without traces.")
     if env_updates:
         _upsert_manifest_env(source_dir, env_updates)

--- a/integrations/mason/src/databricks_mason/help.py
+++ b/integrations/mason/src/databricks_mason/help.py
@@ -173,7 +173,7 @@ _EXAMPLES: dict[CommandPath, tuple[Example, ...]] = {
     ("tracing",): (
         (
             "mason tracing configure",
-            "use the default per-app experiment (tracing is on by default)",
+            "use the default per-project experiment (tracing is on by default)",
         ),
         ("mason tracing configure --experiment 12345", "trace to a specific experiment id"),
         ("mason tracing disable", "turn tracing off"),

--- a/integrations/mason/src/databricks_mason/help.py
+++ b/integrations/mason/src/databricks_mason/help.py
@@ -171,18 +171,19 @@ _EXAMPLES: dict[CommandPath, tuple[Example, ...]] = {
         ),
     ),
     ("tracing",): (
-        ("mason tracing setup --catalog main --schema agent_traces", "link a UC trace destination"),
+        (
+            "mason tracing configure",
+            "use the default per-app experiment (tracing is on by default)",
+        ),
+        ("mason tracing configure --experiment 12345", "trace to a specific experiment id"),
+        ("mason tracing disable", "turn tracing off"),
     ),
-    ("tracing", "setup"): (
-        ("mason tracing setup --catalog main --schema agent_traces", "link a UC trace destination"),
+    ("tracing", "configure"): (
+        ("mason tracing configure --experiment 12345", "trace to a specific experiment id"),
     ),
-    ("tracing", "list"): (
-        ("mason tracing list --experiment /Users/me/mason-traces/my-agent", "list recent traces"),
-    ),
+    ("tracing", "disable"): (("mason tracing disable", "turn tracing off"),),
+    ("tracing", "list"): (("mason tracing list --experiment 12345", "list recent traces"),),
     ("tracing", "get"): (("mason tracing get <trace-id>", "show one trace"),),
-    ("tracing", "instrument"): (
-        ("mason tracing instrument --destination main.agent_traces", "print instrumentation code"),
-    ),
     ("deploy",): (
         ("mason deploy my-agent", "deploy the agent"),
         ("mason deploy my-agent --instances 2", "deploy with two instances"),

--- a/integrations/mason/src/databricks_mason/store_access.py
+++ b/integrations/mason/src/databricks_mason/store_access.py
@@ -96,6 +96,39 @@ def _current_app_resources(app: str, profile: Optional[str]) -> list[dict]:
     return resources if isinstance(resources, list) else []
 
 
+# The app-resource name for the trace experiment (unique across an app's resources, like a store's).
+_TRACE_EXPERIMENT_RESOURCE = "mason-trace-experiment"
+
+
+def apply_experiment_resource(
+    app: str, experiment_id: str, profile: Optional[str]
+) -> Optional[str]:
+    """Bind the trace experiment as an `experiment` app resource so the SP can write traces.
+
+    This is the platform-managed grant: declaring the experiment as a `CAN_EDIT` resource lets the
+    app's service principal log traces to it (no manual SQL grant). Uses the same read-modify-write as
+    `apply_postgres_resources` — `apps update` replaces the whole resource array, so preserve every
+    resource we don't own (including the store `postgres` resources) and re-apply ours by name.
+    Returns None on success or a human-readable reason on failure.
+    """
+    ours = {
+        "name": _TRACE_EXPERIMENT_RESOURCE,
+        "experiment": {"experiment_id": experiment_id, "permission": "CAN_EDIT"},
+    }
+    preserved = [
+        r
+        for r in _current_app_resources(app, profile)
+        if isinstance(r, dict) and r.get("name") != _TRACE_EXPERIMENT_RESOURCE
+    ]
+    payload = {"resources": preserved + [ours]}
+    result = _databricks(
+        ["apps", "update", app, "--json", json.dumps(payload)], profile, capture=True, check=False
+    )
+    if result.returncode == 0:
+        return None
+    return (result.stderr or result.stdout or "").strip() or "unknown error"
+
+
 def apply_postgres_resources(
     app: str, backends: list[LakebaseBackend], profile: Optional[str]
 ) -> Optional[str]:

--- a/integrations/mason/src/databricks_mason/tracing.py
+++ b/integrations/mason/src/databricks_mason/tracing.py
@@ -2,12 +2,13 @@
 
 Tracing is managed MLflow tracing (traces are stored in the workspace's MLflow backend) and is **on
 by default**: with no configuration, ``mason dev`` and ``mason deploy`` send an agent's traces to a
-per-app experiment (``/Users/<you>/mason-traces/<app>``), auto-created and pinned into agent.toml on
-first run (so later runs reuse it by id). The experiment is identified everywhere by its **id** — that
-single value binds the agent (``MLFLOW_EXPERIMENT_ID``), grants the deployed app (an experiment app
-resource), reads traces, and builds the UI link.
+per-project experiment (``/Users/<you>/mason-traces/<project>``), auto-created and pinned into
+agent.toml on first run (so later runs reuse it by id). The experiment is identified everywhere by its
+**id** — that single value binds the agent (``MLFLOW_EXPERIMENT_ID``), grants the deployed app (an
+experiment app resource), reads traces, and builds the UI link.
 
-``mason tracing configure`` pins a specific experiment by id (or re-enables the per-app default after
+``mason tracing configure`` pins a specific experiment by id (or re-enables the per-project default
+after
 a disable); ``mason tracing disable`` turns tracing off; ``list`` / ``get`` read traces back.
 
 MLflow is an optional dependency: ``configure``/``list``/``get`` and the dev/deploy experiment
@@ -38,11 +39,15 @@ TRACES_EXPERIMENT_ID_ENV = "MLFLOW_EXPERIMENT_ID"
 _INSTALL_HINT = "Install the tracing extra: pip install 'databricks-mason[tracing]'"
 
 
-def default_experiment(user: str, app: Optional[str]) -> str:
-    """The per-app experiment path under the user's workspace home (shared by dev and deploy)."""
-    if not app:
-        raise AgentCliError("Cannot derive the default tracing experiment without an app name.")
-    return f"/Users/{user}/{_TRACES_DIR}/{app}"
+def default_experiment(user: str, project: Optional[str]) -> str:
+    """The per-project experiment path under the user's workspace home (shared by dev and deploy).
+
+    ``project`` is the Mason project name (the source directory's basename), not the deployed app name
+    — dev and deploy resolve the same value so they trace to one experiment per project.
+    """
+    if not project:
+        raise AgentCliError("Cannot derive the default tracing experiment without a project name.")
+    return f"/Users/{user}/{_TRACES_DIR}/{project}"
 
 
 def experiment_url(host: Optional[str], experiment_id: str) -> Optional[str]:
@@ -84,7 +89,7 @@ def ensure_experiment(profile: Optional[str], client, name: str) -> str:
     """Create the experiment ``name`` if missing and return its id (idempotent).
 
     ``create_experiment`` won't make the intermediate workspace folder for a nested path (e.g.
-    ``/Users/<you>/mason-traces/<app>``), so the parent dir is created first. Used by dev/deploy to
+    ``/Users/<you>/mason-traces/<project>``), so the parent dir is created first. Used by dev/deploy to
     provision the managed experiment that traces log to.
     """
     mlflow = _mlflow()
@@ -101,7 +106,7 @@ def ensure_experiment(profile: Optional[str], client, name: str) -> str:
 def _project_experiment_id(obj, source: str, mlflow) -> Optional[str]:
     """The experiment id `list` should read for this project, or None if none exists yet.
 
-    Resolution: the project's pinned ``experiment_id``, else the per-app default experiment (looked up
+    Resolution: the project's pinned ``experiment_id``, else the per-project default experiment (looked up
     by name; None when it hasn't been created yet — i.e. nothing has traced here).
     """
     from databricks_mason.agent_project import AgentProject  # noqa: PLC0415 - avoid import cycle
@@ -163,7 +168,7 @@ def tracing() -> None:
     "experiment_id",
     default=None,
     help="MLflow experiment id to trace to. Must be an existing experiment. Omit to use (or return "
-    "to) the per-app experiment mason creates automatically.",
+    "to) the per-project experiment mason creates automatically.",
 )
 @click.option(
     "--source",
@@ -175,9 +180,9 @@ def tracing() -> None:
 def tracing_configure(obj, experiment_id, source) -> None:
     """Configure tracing via MLflow: pin an experiment, rebind, or re-enable after `disable`.
 
-    Tracing is on by default (a per-app experiment mason creates). Use this to pin a specific
+    Tracing is on by default (a per-project experiment mason creates). Use this to pin a specific
     experiment by id, rebind to a different one, or turn tracing back on after ``mason tracing
-    disable``. Omit ``--experiment`` to (re)enable the per-app default.
+    disable``. Omit ``--experiment`` to (re)enable the per-project default.
     """
     from databricks_mason.agent_project import AgentProject  # noqa: PLC0415
 
@@ -205,7 +210,7 @@ def tracing_configure(obj, experiment_id, source) -> None:
     project.configure_tracing(experiment_id)
     project.write()
 
-    target = f"experiment {experiment_id}" if experiment_id else "a per-app experiment"
+    target = f"experiment {experiment_id}" if experiment_id else "a per-project experiment"
     if obj.output == "json":
         render.emit_json({"experiment_id": experiment_id, "disabled": False})
         return
@@ -267,7 +272,7 @@ def tracing_list(obj, experiment_id, limit, source) -> None:
     """List recent agent traces in an experiment.
 
     Resolution: ``--experiment <id>`` (works standalone), else this project's experiment (the pinned
-    one, or its per-app default). A missing experiment just lists nothing (nothing has traced yet).
+    one, or its per-project default). A missing experiment just lists nothing (nothing has traced yet).
     """
     mlflow = _mlflow()
     _configure(mlflow, obj.profile)

--- a/integrations/mason/src/databricks_mason/tracing.py
+++ b/integrations/mason/src/databricks_mason/tracing.py
@@ -1,18 +1,20 @@
-"""`mason tracing` — route an agent's traces to MLflow / Unity Catalog and inspect them.
+"""`mason tracing` — send an agent's traces to an MLflow experiment and inspect them.
 
-Parallel to `mason memory` and `mason sessions`: `setup` provisions the trace destination
-(links a UC schema to an MLflow experiment, the analog of creating a store), `list`/`get`
-read traces back, and `instrument` prints the wiring snippet (the "Starter code" analog).
-`mason deploy --with-traces` injects the destination into a deployment's app.yaml, exactly as
-`--memory` / `--session` inject their stores.
+Tracing is managed MLflow tracing (traces are stored in the workspace's MLflow backend) and is **on
+by default**: with no configuration, ``mason dev`` and ``mason deploy`` send an agent's traces to a
+per-app experiment (``/Users/<you>/mason-traces/<app>``), auto-created on first run. The experiment
+is identified everywhere by its **id** — that single value binds the agent (``MLFLOW_EXPERIMENT_ID``),
+grants the deployed app (an experiment app resource), reads traces, and builds the UI link.
 
-MLflow is an optional dependency: `setup`/`list`/`get` need `mlflow[databricks]>=3.10.1`
-installed and lazily import it; `instrument` (and the deploy wiring) are pure and need nothing.
+``mason tracing configure`` pins a specific experiment by id (or re-enables the per-app default after
+a disable); ``mason tracing disable`` turns tracing off; ``list`` / ``get`` read traces back.
+
+MLflow is an optional dependency: ``configure``/``list``/``get`` and the dev/deploy experiment
+provisioning import it lazily and need ``mlflow[databricks]``; nothing else does.
 """
 
 from __future__ import annotations
 
-import os
 import pathlib
 from typing import Any, Optional
 
@@ -22,34 +24,31 @@ from databricks_mason import render, timefmt
 from databricks_mason.errors import AgentCliError
 
 _BREADCRUMB = "Agent Tracing"
-# Fallback experiment when there's no agent context (e.g. `tracing setup` with no --app). Prefer a
-# per-agent experiment via `default_experiment` so each agent's traces are isolated, not commingled.
-_DEFAULT_EXPERIMENT = "/Shared/mason-agent-traces"
+# Per-app experiment folder: each agent's traces stay in their own experiment under the user's home.
+_TRACES_DIR = "mason-traces"
+
+# The two env vars the deployed/dev agent reads to enable tracing: a destination (the workspace) and
+# an experiment (by id). MLflow turns tracing on only when it has both.
+TRACES_TRACKING_URI_ENV = "MLFLOW_TRACKING_URI"
+TRACES_EXPERIMENT_ID_ENV = "MLFLOW_EXPERIMENT_ID"
+
+# Installing the `tracing` extra (rather than a bare mlflow) resolves both the missing- and
+# too-old-mlflow cases: the extra carries the version floor `mason tracing` needs.
+_INSTALL_HINT = "Install the tracing extra: pip install 'databricks-mason[tracing]'"
 
 
 def default_experiment(user: str, app: Optional[str]) -> str:
-    """The per-agent experiment path for `app`, under the user's workspace home.
-
-    Keeps each agent's traces in their own experiment (and out of other users' view), instead of the
-    single shared bucket. `mason tracing setup`, `dev`, and `deploy` all derive the same path for a
-    given agent, so the experiment `setup` links is the one the agent logs to. Falls back to the
-    shared default only when no app name is available.
-    """
+    """The per-app experiment path under the user's workspace home (shared by dev and deploy)."""
     if not app:
-        return _DEFAULT_EXPERIMENT
-    return f"/Users/{user}/mason-traces/{app}"
+        raise AgentCliError("Cannot derive the default tracing experiment without an app name.")
+    return f"/Users/{user}/{_TRACES_DIR}/{app}"
 
 
-# Env vars the deployed agent reads (see deploy.py). MLFLOW_TRACING_DESTINATION is MLflow's own
-# "catalog.schema" convention; MLFLOW_EXPERIMENT_NAME is the standard MLflow experiment selector.
-TRACES_DEST_ENV = "MLFLOW_TRACING_DESTINATION"
-TRACES_EXPERIMENT_ENV = "MLFLOW_EXPERIMENT_NAME"
-
-
-# Installing the `tracing` extra (rather than a bare mlflow) is what actually resolves both the
-# missing- and too-old-mlflow cases: the extra carries the version floor `mason tracing` needs, so
-# a stale mlflow already in the venv gets upgraded to a compatible one.
-_INSTALL_HINT = "Install the tracing extra: pip install 'databricks-mason[tracing]'"
+def experiment_url(host: Optional[str], experiment_id: str) -> Optional[str]:
+    """The workspace MLflow experiment Traces page, or None when the host is unavailable."""
+    if not host or host == "unknown":
+        return None
+    return f"{host.rstrip('/')}/ml/experiments/{experiment_id}?compareRunsMode=TRACES"
 
 
 def _mlflow():
@@ -60,70 +59,52 @@ def _mlflow():
         return mlflow
     except ImportError as exc:
         raise AgentCliError(
-            "MLflow is required for `mason tracing` setup/list/get.",
+            "MLflow is required for `mason tracing` configure/list/get.",
             hint=_INSTALL_HINT,
         ) from exc
 
 
-def _uc_trace_symbols():
-    """Import the version-specific UC-tracing symbols, surfacing the same clean error as `_mlflow`.
-
-    `import mlflow` succeeding doesn't guarantee these exist — they were added in the tracing API
-    this feature needs. Guard them so an older installed MLflow yields Mason's install hint rather
-    than a raw ImportError traceback.
-    """
-    try:
-        from mlflow.entities import UCSchemaLocation  # noqa: PLC0415 - lazy, version-specific
-        from mlflow.tracing import (  # noqa: PLC0415
-            set_experiment_trace_location,
-            unset_experiment_trace_location,
-        )
-
-        return UCSchemaLocation, set_experiment_trace_location, unset_experiment_trace_location
-    except ImportError as exc:
-        raise AgentCliError(
-            "This MLflow version is too old for `mason tracing setup` (UC trace destinations).",
-            hint=_INSTALL_HINT,
-        ) from exc
-
-
-def _link_trace_location(set_location, unset_location, location, exp_id: str, relink: bool) -> None:
-    """Link the experiment to the UC schema, handling the already-linked case.
-
-    MLflow raises if the experiment is already bound to a storage location. With `relink`, unset the
-    existing binding first and re-link; otherwise surface a clean error pointing at `--relink`.
-    """
-    try:
-        set_location(location=location, experiment_id=exp_id)
-    except Exception as exc:  # noqa: BLE001 - mlflow raises a generic error when already linked
-        if "already" not in str(exc).lower():
-            raise
-        if not relink:
-            raise AgentCliError(
-                "This experiment is already linked to a trace storage location.",
-                hint="Re-run with --relink to replace the existing link.",
-            ) from exc
-        unset_location(location=location, experiment_id=exp_id)
-        set_location(location=location, experiment_id=exp_id)
-
-
-def _configure(mlflow, profile: Optional[str], warehouse_id: Optional[str]) -> None:
-    """Point MLflow at the workspace (honoring mason's --profile) for UC-backed tracing."""
+def _configure(mlflow, profile: Optional[str]) -> None:
+    """Point MLflow at the workspace (honoring mason's --profile)."""
     mlflow.set_tracking_uri(f"databricks://{profile}" if profile else "databricks")
-    if warehouse_id:
-        os.environ["MLFLOW_TRACING_SQL_WAREHOUSE_ID"] = warehouse_id
 
 
-def _ensure_experiment(mlflow, client, name: str) -> str:
+def ensure_experiment(profile: Optional[str], client, name: str) -> str:
+    """Create the experiment ``name`` if missing and return its id (idempotent).
+
+    ``create_experiment`` won't make the intermediate workspace folder for a nested path (e.g.
+    ``/Users/<you>/mason-traces/<app>``), so the parent dir is created first. Used by dev/deploy to
+    provision the managed experiment that traces log to.
+    """
+    mlflow = _mlflow()
+    _configure(mlflow, profile)
     experiment = mlflow.get_experiment_by_name(name)
     if experiment:
         return experiment.experiment_id
-    # create_experiment won't make the intermediate workspace folder for a nested path (e.g.
-    # /Users/<you>/mason-traces/<app>), so create the parent dir first.
     parent = name.rsplit("/", 1)[0]
     if parent:
         client.ensure_workspace_dir(parent)
     return mlflow.create_experiment(name)
+
+
+def _project_experiment_id(obj, source: str, mlflow) -> Optional[str]:
+    """The experiment id `list` should read for this project, or None if none exists yet.
+
+    Resolution: the project's pinned ``experiment_id``, else the per-app default experiment (looked up
+    by name; None when it hasn't been created yet — i.e. nothing has traced here).
+    """
+    from databricks_mason.agent_project import AgentProject  # noqa: PLC0415 - avoid import cycle
+
+    try:
+        project = AgentProject.load(source)
+    except AgentCliError:
+        project = None
+    if project is not None and project.trace_experiment_id:
+        return project.trace_experiment_id
+    client = obj.client()
+    name = default_experiment(client.current_user, pathlib.Path(source).resolve().name)
+    experiment = mlflow.get_experiment_by_name(name)
+    return experiment.experiment_id if experiment else None
 
 
 def _attr(obj: Any, *paths: str, default: Any = None) -> Any:
@@ -145,16 +126,13 @@ def _status_str(status: Any) -> Optional[str]:
     return getattr(status, "name", None) or str(status)
 
 
-def _split_destination(destination: str) -> tuple[str, str]:
-    catalog, _, schema = destination.partition(".")
-    if not catalog or not schema:
-        raise AgentCliError("--destination must be 'catalog.schema'.")
-    return catalog, schema
-
-
-def _experiment_url(host: str, experiment_id: str) -> str:
-    """Workspace URL for an experiment's Traces tab."""
-    return f"{host.rstrip('/')}/ml/experiments/{experiment_id}?compareRunsMode=TRACES"
+def _trace_json(trace: Any) -> dict:
+    return {
+        "trace_id": _attr(trace, "info.trace_id", "info.request_id"),
+        "status": _status_str(_attr(trace, "info.status", "info.state")),
+        "execution_time_ms": _attr(trace, "info.execution_time_ms", "info.execution_duration_ms"),
+        "timestamp_ms": _attr(trace, "info.timestamp_ms", "info.request_time"),
+    }
 
 
 # --- group ------------------------------------------------------------------
@@ -162,89 +140,87 @@ def _experiment_url(host: str, experiment_id: str) -> str:
 
 @click.group()
 def tracing() -> None:
-    """Set up and inspect MLflow traces (in Unity Catalog) for your agents."""
+    """Configure MLflow tracing for your agents, and inspect the traces."""
 
 
-# --- setup: provision the UC trace destination ------------------------------
+# --- configure / disable ----------------------------------------------------
 
 
-@tracing.command("setup")
-@click.option("--catalog", required=True, help="Unity Catalog catalog to store traces in.")
-@click.option("--schema", required=True, help="Unity Catalog schema to store traces in.")
-@click.option(
-    "--app",
-    default=None,
-    help="Agent name — gives this agent its own experiment (/Users/<you>/mason-traces/<app>) so its "
-    "traces aren't commingled with other agents'. Defaults to the current directory name (matching "
-    "`mason dev`/`deploy`). Overridden by --experiment.",
-)
+@tracing.command("configure")
 @click.option(
     "--experiment",
+    "experiment_id",
     default=None,
-    help="MLflow experiment path (overrides the per-app default derived from --app).",
+    help="MLflow experiment id to trace to. Must be an existing experiment. Omit to use (or return "
+    "to) the per-app experiment mason creates automatically.",
 )
 @click.option(
-    "--warehouse-id",
-    default=None,
-    help="SQL warehouse id for trace queries (MLFLOW_TRACING_SQL_WAREHOUSE_ID).",
-)
-@click.option(
-    "--relink",
-    is_flag=True,
-    help="Replace an existing trace-location link on the experiment (unset, then re-link).",
+    "--source",
+    default=".",
+    type=click.Path(exists=True, file_okay=False),
+    help="Project directory containing agent.toml. Defaults to the current directory.",
 )
 @click.pass_obj
-def tracing_setup(obj, catalog, schema, app, experiment, warehouse_id, relink) -> None:
-    """Link a UC schema to an MLflow experiment so agent traces land in Unity Catalog."""
-    mlflow = _mlflow()
-    _configure(mlflow, obj.profile, warehouse_id)
-    # Default the agent name to the current directory, matching `mason dev`/`deploy`, so running
-    # setup from a project dir needs no --app and still lands in that agent's own experiment.
-    app = app or pathlib.Path.cwd().name
-    client = obj.client()
-    exp_name = experiment or default_experiment(client.current_user, app)
-    exp_id = _ensure_experiment(mlflow, client, exp_name)
+def tracing_configure(obj, experiment_id, source) -> None:
+    """Configure tracing via MLflow: pin an experiment, rebind, or re-enable after `disable`.
 
-    UCSchemaLocation, set_location, unset_location = _uc_trace_symbols()
-    _link_trace_location(
-        set_location,
-        unset_location,
-        UCSchemaLocation(catalog_name=catalog, schema_name=schema),
-        exp_id,
-        relink,
+    Tracing is on by default (a per-app experiment mason creates). Use this to pin a specific
+    experiment by id, rebind to a different one, or turn tracing back on after ``mason tracing
+    disable``. Omit ``--experiment`` to (re)enable the per-app default.
+    """
+    from databricks_mason.agent_project import AgentProject  # noqa: PLC0415
+
+    if experiment_id:
+        # Verify the experiment exists so a wrong id fails here, not silently when the agent runs.
+        mlflow = _mlflow()
+        _configure(mlflow, obj.profile)
+        if mlflow.get_experiment(experiment_id) is None:
+            raise AgentCliError(
+                f"No MLflow experiment found with id {experiment_id!r}.",
+                hint="Pass an existing experiment id, or omit --experiment for the per-app default.",
+            )
+
+    project = AgentProject.load(pathlib.Path(source))
+    project.configure_tracing(experiment_id)
+    project.write()
+
+    target = f"experiment {experiment_id}" if experiment_id else "a per-app experiment"
+    if obj.output == "json":
+        render.emit_json({"experiment_id": experiment_id, "disabled": False})
+        return
+    render.success(
+        f"Tracing on: {target}",
+        fields={"Experiment id": experiment_id} if experiment_id else None,
+        next_steps=[
+            ("mason dev", "Run locally with tracing on"),
+            ("mason tracing list", "List traces once you have some"),
+            ("mason tracing disable", "Turn tracing off"),
+        ],
     )
-    destination = f"{catalog}.{schema}"
-    url = _experiment_url(client.host, exp_id)
+
+
+@tracing.command("disable")
+@click.option(
+    "--source",
+    default=".",
+    type=click.Path(exists=True, file_okay=False),
+    help="Project directory containing agent.toml. Defaults to the current directory.",
+)
+@click.pass_obj
+def tracing_disable(obj, source) -> None:
+    """Turn tracing off for this agent (recorded in agent.toml; dev/deploy then wire no MLflow env)."""
+    from databricks_mason.agent_project import AgentProject  # noqa: PLC0415
+
+    project = AgentProject.load(pathlib.Path(source))
+    project.disable_tracing()
+    project.write()
 
     if obj.output == "json":
-        render.emit_json(
-            {
-                "experiment": exp_name,
-                "experiment_id": exp_id,
-                "destination": destination,
-                "url": url,
-            }
-        )
+        render.emit_json({"disabled": True})
         return
-    # dev/deploy derive this same experiment from the agent name (dev: project dir, deploy: <name>),
-    # so only spell out --traces-experiment when the experiment was set explicitly (not per-app).
-    exp_flag = "" if experiment is None else f" --traces-experiment {exp_name}"
-    deploy_name = app
     render.success(
-        f"Linked traces for '{exp_name}' to {destination}",
-        fields={"Experiment": exp_name, "Destination": destination, "View traces": url},
-        next_steps=[
-            (f"mason dev --with-traces {destination}{exp_flag}", "Run locally with tracing on"),
-            (
-                f"mason deploy {deploy_name} --with-traces {destination}{exp_flag}",
-                "Deploy with tracing on",
-            ),
-            (
-                f"mason tracing instrument --destination {destination}",
-                "Print the code snippet to trace your own agent",
-            ),
-            (f"mason tracing list --experiment {exp_name}", "List traces once you have some"),
-        ],
+        "Tracing off",
+        next_steps=[("mason tracing configure", "Turn tracing back on")],
     )
 
 
@@ -253,23 +229,31 @@ def tracing_setup(obj, catalog, schema, app, experiment, warehouse_id, relink) -
 
 @tracing.command("list")
 @click.option(
-    "--experiment", default=None, help=f"MLflow experiment path (default: {_DEFAULT_EXPERIMENT})."
+    "--experiment",
+    "experiment_id",
+    default=None,
+    help="MLflow experiment id to read (default: this project's experiment).",
 )
 @click.option("--limit", type=int, default=20)
+@click.option(
+    "--source",
+    default=".",
+    type=click.Path(file_okay=False),
+    help="Project directory to resolve the default experiment from (default: current dir).",
+)
 @click.pass_obj
-def tracing_list(obj, experiment, limit) -> None:
-    """List recent agent traces in an experiment."""
+def tracing_list(obj, experiment_id, limit, source) -> None:
+    """List recent agent traces in an experiment.
+
+    Resolution: ``--experiment <id>`` (works standalone), else this project's experiment (the pinned
+    one, or its per-app default). A missing experiment just lists nothing (nothing has traced yet).
+    """
     mlflow = _mlflow()
-    _configure(mlflow, obj.profile, None)
-    exp_name = experiment or _DEFAULT_EXPERIMENT
-    # search_traces selects experiments by id, not name, so resolve first. A missing experiment means
-    # no traces have been recorded there yet — show an empty list rather than erroring.
-    exp = mlflow.get_experiment_by_name(exp_name)
+    _configure(mlflow, obj.profile)
+    exp_id = experiment_id or _project_experiment_id(obj, source, mlflow)
     traces = (
-        mlflow.search_traces(
-            experiment_ids=[exp.experiment_id], max_results=limit, return_type="list"
-        )
-        if exp
+        mlflow.search_traces(experiment_ids=[exp_id], max_results=limit, return_type="list")
+        if exp_id
         else []
     )
 
@@ -286,7 +270,7 @@ def tracing_list(obj, experiment, limit) -> None:
         for t in traces
     ]
     render.resource_table(
-        f"Agent Traces · {exp_name}",
+        f"Agent Traces · {exp_id or 'no experiment yet'}",
         [("Trace ID", "left"), ("Status", "left"), ("Latency (ms)", "left"), ("Created", "left")],
         rows,
     )
@@ -298,8 +282,10 @@ def tracing_list(obj, experiment, limit) -> None:
 def tracing_get(obj, trace_id) -> None:
     """Get a single trace by id (status, latency, span count, previews)."""
     mlflow = _mlflow()
-    _configure(mlflow, obj.profile, None)
+    _configure(mlflow, obj.profile)
     trace = mlflow.get_trace(trace_id)
+    if trace is None:
+        raise AgentCliError(f"No trace found with id {trace_id!r}.")
     if obj.output == "json":
         render.emit_json(_trace_json(trace))
         return
@@ -316,52 +302,4 @@ def tracing_get(obj, trace_id) -> None:
             "Created": timefmt.absolute(_attr(trace, "info.timestamp_ms", "info.request_time")),
         },
         status=_status_str(_attr(trace, "info.status", "info.state")),
-    )
-
-
-def _trace_json(trace: Any) -> dict:
-    return {
-        "trace_id": _attr(trace, "info.trace_id", "info.request_id"),
-        "status": _status_str(_attr(trace, "info.status", "info.state")),
-        "execution_time_ms": _attr(trace, "info.execution_time_ms", "info.execution_duration_ms"),
-        "timestamp_ms": _attr(trace, "info.timestamp_ms", "info.request_time"),
-    }
-
-
-# --- instrument: print the agent wiring snippet (no MLflow needed) ----------
-
-
-@tracing.command("instrument")
-@click.option(
-    "--destination",
-    default=None,
-    help="UC trace destination 'catalog.schema' (from `mason tracing setup`).",
-)
-@click.option(
-    "--experiment", default=None, help=f"MLflow experiment path (default: {_DEFAULT_EXPERIMENT})."
-)
-@click.pass_obj
-def tracing_instrument(obj, destination, experiment) -> None:
-    """Print the snippet that routes an OpenAI Agents SDK agent's traces to UC."""
-    catalog, schema = _split_destination(destination) if destination else ("<catalog>", "<schema>")
-    exp_name = experiment or _DEFAULT_EXPERIMENT
-    dest = destination or f"{catalog}.{schema}"
-    code = (
-        "import mlflow\n"
-        "from mlflow.entities import UCSchemaLocation\n\n"
-        'mlflow.set_tracking_uri("databricks")\n'
-        f'mlflow.set_experiment("{exp_name}")\n'
-        f'mlflow.tracing.set_destination(UCSchemaLocation(catalog_name="{catalog}", schema_name="{schema}"))\n'
-        "mlflow.openai.autolog()   # OpenAI Agents SDK spans -> Unity Catalog traces\n"
-        "# NOTE: do NOT call agents.set_tracing_disabled(True) — that turns tracing off."
-    )
-    if obj.output == "json":
-        render.emit_json({"destination": dest, "experiment": exp_name, "snippet": code})
-        return
-    render.detail(
-        _BREADCRUMB,
-        dest,
-        {"Experiment": exp_name, "Destination": dest, "Requires": "mlflow[databricks]>=3.10.1"},
-        status="ACTIVE",
-        snippets=[("python", "python", code)],
     )

--- a/integrations/mason/src/databricks_mason/tracing.py
+++ b/integrations/mason/src/databricks_mason/tracing.py
@@ -2,9 +2,10 @@
 
 Tracing is managed MLflow tracing (traces are stored in the workspace's MLflow backend) and is **on
 by default**: with no configuration, ``mason dev`` and ``mason deploy`` send an agent's traces to a
-per-app experiment (``/Users/<you>/mason-traces/<app>``), auto-created on first run. The experiment
-is identified everywhere by its **id** — that single value binds the agent (``MLFLOW_EXPERIMENT_ID``),
-grants the deployed app (an experiment app resource), reads traces, and builds the UI link.
+per-app experiment (``/Users/<you>/mason-traces/<app>``), auto-created and pinned into agent.toml on
+first run (so later runs reuse it by id). The experiment is identified everywhere by its **id** — that
+single value binds the agent (``MLFLOW_EXPERIMENT_ID``), grants the deployed app (an experiment app
+resource), reads traces, and builds the UI link.
 
 ``mason tracing configure`` pins a specific experiment by id (or re-enables the per-app default after
 a disable); ``mason tracing disable`` turns tracing off; ``list`` / ``get`` read traces back.

--- a/integrations/mason/src/databricks_mason/tracing.py
+++ b/integrations/mason/src/databricks_mason/tracing.py
@@ -39,7 +39,7 @@ TRACES_EXPERIMENT_ID_ENV = "MLFLOW_EXPERIMENT_ID"
 _INSTALL_HINT = "Install the tracing extra: pip install 'databricks-mason[tracing]'"
 
 
-def default_experiment(user: str, project: Optional[str]) -> str:
+def default_experiment_name(user: str, project: Optional[str]) -> str:
     """The per-project experiment path under the user's workspace home (shared by dev and deploy).
 
     ``project`` is the Mason project name (the source directory's basename), not the deployed app name
@@ -70,7 +70,7 @@ def _mlflow():
         ) from exc
 
 
-def _configure(mlflow, profile: Optional[str]) -> None:
+def _set_tracking_uri(mlflow, profile: Optional[str]) -> None:
     """Point MLflow at the workspace (honoring mason's --profile)."""
     mlflow.set_tracking_uri(f"databricks://{profile}" if profile else "databricks")
 
@@ -85,7 +85,7 @@ def _is_uc_backed(experiment) -> bool:
     return _UC_TRACE_TAG in (getattr(experiment, "tags", None) or {})
 
 
-def ensure_experiment(profile: Optional[str], client, name: str) -> str:
+def create_experiment_idempotent(profile: Optional[str], client, name: str) -> str:
     """Create the experiment ``name`` if missing and return its id (idempotent).
 
     ``create_experiment`` won't make the intermediate workspace folder for a nested path (e.g.
@@ -93,7 +93,7 @@ def ensure_experiment(profile: Optional[str], client, name: str) -> str:
     provision the managed experiment that traces log to.
     """
     mlflow = _mlflow()
-    _configure(mlflow, profile)
+    _set_tracking_uri(mlflow, profile)
     experiment = mlflow.get_experiment_by_name(name)
     if experiment:
         return experiment.experiment_id
@@ -118,7 +118,7 @@ def _project_experiment_id(obj, source: str, mlflow) -> Optional[str]:
     if project is not None and project.trace_experiment_id:
         return project.trace_experiment_id
     client = obj.client()
-    name = default_experiment(client.current_user, pathlib.Path(source).resolve().name)
+    name = default_experiment_name(client.current_user, pathlib.Path(source).resolve().name)
     experiment = mlflow.get_experiment_by_name(name)
     return experiment.experiment_id if experiment else None
 
@@ -189,7 +189,7 @@ def tracing_configure(obj, experiment_id, source) -> None:
     if experiment_id:
         # Verify the experiment exists so a wrong id fails here, not silently when the agent runs.
         mlflow = _mlflow()
-        _configure(mlflow, obj.profile)
+        _set_tracking_uri(mlflow, obj.profile)
         experiment = mlflow.get_experiment(experiment_id)
         if experiment is None:
             raise AgentCliError(
@@ -275,7 +275,7 @@ def tracing_list(obj, experiment_id, limit, source) -> None:
     one, or its per-project default). A missing experiment just lists nothing (nothing has traced yet).
     """
     mlflow = _mlflow()
-    _configure(mlflow, obj.profile)
+    _set_tracking_uri(mlflow, obj.profile)
     exp_id = experiment_id or _project_experiment_id(obj, source, mlflow)
     traces = (
         mlflow.search_traces(locations=[exp_id], max_results=limit, return_type="list")
@@ -308,7 +308,7 @@ def tracing_list(obj, experiment_id, limit, source) -> None:
 def tracing_get(obj, trace_id) -> None:
     """Get a single trace by id (status, latency, span count, previews)."""
     mlflow = _mlflow()
-    _configure(mlflow, obj.profile)
+    _set_tracking_uri(mlflow, obj.profile)
     trace = mlflow.get_trace(trace_id)
     if trace is None:
         raise AgentCliError(f"No trace found with id {trace_id!r}.")

--- a/integrations/mason/src/databricks_mason/tracing.py
+++ b/integrations/mason/src/databricks_mason/tracing.py
@@ -252,7 +252,7 @@ def tracing_list(obj, experiment_id, limit, source) -> None:
     _configure(mlflow, obj.profile)
     exp_id = experiment_id or _project_experiment_id(obj, source, mlflow)
     traces = (
-        mlflow.search_traces(experiment_ids=[exp_id], max_results=limit, return_type="list")
+        mlflow.search_traces(locations=[exp_id], max_results=limit, return_type="list")
         if exp_id
         else []
     )

--- a/integrations/mason/src/databricks_mason/tracing.py
+++ b/integrations/mason/src/databricks_mason/tracing.py
@@ -136,7 +136,7 @@ def _status_str(status: Any) -> Optional[str]:
     return getattr(status, "name", None) or str(status)
 
 
-def _trace_json(trace: Any) -> dict:
+def _trace_to_json(trace: Any) -> dict:
     return {
         "trace_id": _attr(trace, "info.trace_id", "info.request_id"),
         "status": _status_str(_attr(trace, "info.status", "info.state")),
@@ -188,7 +188,7 @@ def tracing_configure(obj, experiment_id, source) -> None:
         if experiment is None:
             raise AgentCliError(
                 f"No MLflow experiment found with id {experiment_id!r}.",
-                hint="Pass an existing experiment id, or omit --experiment for the per-app default.",
+                hint="Pass an existing experiment id, or omit --experiment to use the mason default.",
             )
         if _is_uc_backed(experiment):
             # Traces for a UC-backed experiment land in governed UC tables, which need a SQL warehouse
@@ -196,8 +196,8 @@ def tracing_configure(obj, experiment_id, source) -> None:
             # yet. Reject it up front rather than silently wiring a config that fails at read/deploy.
             raise AgentCliError(
                 "UC-backed MLflow tracing is not supported by mason.",
-                hint="Pass a managed (non-UC) experiment, or omit --experiment to use the per-app "
-                "experiment mason creates.",
+                hint="Pass a managed (non-UC) experiment, or omit --experiment to use the mason "
+                "default.",
             )
 
     project = AgentProject.load(pathlib.Path(source))
@@ -278,7 +278,7 @@ def tracing_list(obj, experiment_id, limit, source) -> None:
     )
 
     if obj.output == "json":
-        render.emit_json([_trace_json(t) for t in traces])
+        render.emit_json([_trace_to_json(t) for t in traces])
         return
     rows = [
         [
@@ -307,7 +307,7 @@ def tracing_get(obj, trace_id) -> None:
     if trace is None:
         raise AgentCliError(f"No trace found with id {trace_id!r}.")
     if obj.output == "json":
-        render.emit_json(_trace_json(trace))
+        render.emit_json(_trace_to_json(trace))
         return
     spans = _attr(trace, "data.spans", default=[]) or []
     render.detail(

--- a/integrations/mason/src/databricks_mason/tracing.py
+++ b/integrations/mason/src/databricks_mason/tracing.py
@@ -69,6 +69,16 @@ def _configure(mlflow, profile: Optional[str]) -> None:
     mlflow.set_tracking_uri(f"databricks://{profile}" if profile else "databricks")
 
 
+# An experiment linked to a UC schema for trace storage carries this tag (the destination schema);
+# managed experiments don't. mason supports managed tracing only (UC support is a follow-up).
+_UC_TRACE_TAG = "mlflow.experiment.databricksTraceDestinationPath"
+
+
+def _is_uc_backed(experiment) -> bool:
+    """True if the experiment stores traces in Unity Catalog rather than the managed MLflow backend."""
+    return _UC_TRACE_TAG in (getattr(experiment, "tags", None) or {})
+
+
 def ensure_experiment(profile: Optional[str], client, name: str) -> str:
     """Create the experiment ``name`` if missing and return its id (idempotent).
 
@@ -174,10 +184,20 @@ def tracing_configure(obj, experiment_id, source) -> None:
         # Verify the experiment exists so a wrong id fails here, not silently when the agent runs.
         mlflow = _mlflow()
         _configure(mlflow, obj.profile)
-        if mlflow.get_experiment(experiment_id) is None:
+        experiment = mlflow.get_experiment(experiment_id)
+        if experiment is None:
             raise AgentCliError(
                 f"No MLflow experiment found with id {experiment_id!r}.",
                 hint="Pass an existing experiment id, or omit --experiment for the per-app default.",
+            )
+        if _is_uc_backed(experiment):
+            # Traces for a UC-backed experiment land in governed UC tables, which need a SQL warehouse
+            # to read and UC grants for a deployed app's SP to write - neither of which mason sets up
+            # yet. Reject it up front rather than silently wiring a config that fails at read/deploy.
+            raise AgentCliError(
+                "UC-backed MLflow tracing is not supported by mason.",
+                hint="Pass a managed (non-UC) experiment, or omit --experiment to use the per-app "
+                "experiment mason creates.",
             )
 
     project = AgentProject.load(pathlib.Path(source))

--- a/integrations/mason/tests/unit_tests/deploy_bugfix_test.py
+++ b/integrations/mason/tests/unit_tests/deploy_bugfix_test.py
@@ -110,14 +110,7 @@ def test_validate_stores_raises_when_session_store_missing():
         "session store not found", error_code="NOT_FOUND"
     )
     with pytest.raises(AgentCliError) as exc:
-        deploy_mod.validate_stores_and_trace_env(
-            client,
-            app="a",
-            memory_store=None,
-            session_store="ghost",
-            traces_destination=None,
-            traces_experiment=None,
-        )
+        deploy_mod.validate_stores(client, memory_store=None, session_store="ghost")
     assert "does not exist" in str(exc.value)
     client.get_session_store.assert_called_once_with("ghost")
 

--- a/integrations/mason/tests/unit_tests/deploy_test.py
+++ b/integrations/mason/tests/unit_tests/deploy_test.py
@@ -697,7 +697,7 @@ def test_deploy_keys_experiment_on_source_dir_name_not_prefixed(
     tmp_path: pathlib.Path, monkeypatch
 ):
     # dev keys the experiment on the source dir name; deploy must match it (NOT the mason-prefixed
-    # deployment name), so dev and deploy trace to the same per-agent experiment.
+    # deployment name), so dev and deploy trace to the same per-project experiment.
     src = tmp_path / "my-agent"
     src.mkdir()
     (src / "app.yaml").write_text(yaml.safe_dump({"command": ["x"]}))
@@ -867,7 +867,7 @@ def test_resolve_trace_experiment_uses_pinned_id_without_creating(
     assert _REAL_RESOLVE_TRACE(tmp_path, "app", _FakeClient(), None) == "pinned-1"
 
 
-def test_resolve_trace_experiment_creates_per_app_default(tmp_path: pathlib.Path, monkeypatch):
+def test_resolve_trace_experiment_creates_per_project_default(tmp_path: pathlib.Path, monkeypatch):
     (tmp_path / "agent.toml").write_text('schema_version = 1\n\n[agent]\nframework = "openai"\n')
     created: dict = {}
     monkeypatch.setattr(

--- a/integrations/mason/tests/unit_tests/deploy_test.py
+++ b/integrations/mason/tests/unit_tests/deploy_test.py
@@ -878,6 +878,26 @@ def test_resolve_trace_experiment_creates_per_app_default(tmp_path: pathlib.Path
     exp_id = _REAL_RESOLVE_TRACE(tmp_path, "my-agent", _FakeClient(), None)
     assert exp_id == "made-id"
     assert created["name"] == "/Users/me@example.com/mason-traces/my-agent"
+    # First run pins the resolved default into agent.toml so later runs reuse it by id.
+    from databricks_mason.agent_project import AgentProject
+
+    assert AgentProject.load(tmp_path).trace_experiment_id == "made-id"
+
+
+def test_resolve_trace_experiment_reuses_pinned_default_on_second_run(
+    tmp_path: pathlib.Path, monkeypatch
+):
+    (tmp_path / "agent.toml").write_text('schema_version = 1\n\n[agent]\nframework = "openai"\n')
+    calls: list[str] = []
+    monkeypatch.setattr(
+        deploy_mod,
+        "ensure_experiment",
+        lambda profile, client, name: calls.append(name) or "made-id",
+    )
+    # First run creates + pins; the second reads the pinned id straight from agent.toml.
+    assert _REAL_RESOLVE_TRACE(tmp_path, "my-agent", _FakeClient(), None) == "made-id"
+    assert _REAL_RESOLVE_TRACE(tmp_path, "my-agent", _FakeClient(), None) == "made-id"
+    assert calls == ["/Users/me@example.com/mason-traces/my-agent"]  # created only once
 
 
 def _run_deploy(src, monkeypatch, extra_args):

--- a/integrations/mason/tests/unit_tests/deploy_test.py
+++ b/integrations/mason/tests/unit_tests/deploy_test.py
@@ -14,9 +14,9 @@ from click.testing import CliRunner
 from databricks_mason import deploy as deploy_mod
 from databricks_mason.errors import AgentCliError
 
-# The autouse fixture below stubs `resolve_trace_experiment` for deploy-command tests; capture the
+# The autouse fixture below stubs `resolve_trace_experiment_id` for deploy-command tests; capture the
 # real function here so its own unit tests can exercise the actual logic.
-_REAL_RESOLVE_TRACE = deploy_mod.resolve_trace_experiment
+_REAL_RESOLVE_TRACE = deploy_mod.resolve_trace_experiment_id
 
 
 @pytest.fixture(autouse=True)
@@ -30,7 +30,7 @@ def _compute_active(monkeypatch):
 def _no_tracing_by_default(monkeypatch):
     # Tracing is on by default and would create an MLflow experiment (a live workspace op); stub the
     # provisioning off so non-tracing deploy tests stay hermetic. Tracing tests override this.
-    monkeypatch.setattr(deploy_mod, "resolve_trace_experiment", lambda *a, **k: None)
+    monkeypatch.setattr(deploy_mod, "resolve_trace_experiment_id", lambda *a, **k: None)
 
 
 def test_upsert_manifest_env_scaffolds_when_missing(tmp_path: pathlib.Path):
@@ -670,7 +670,7 @@ def test_deploy_wires_tracing_env_and_grants_experiment_resource(
     (src / "app.yaml").write_text(yaml.safe_dump({"command": ["x"]}))
 
     monkeypatch.setattr(deploy_mod, "_deployment_exists", lambda a, p: True)
-    monkeypatch.setattr(deploy_mod, "resolve_trace_experiment", lambda *a, **k: "exp-42")
+    monkeypatch.setattr(deploy_mod, "resolve_trace_experiment_id", lambda *a, **k: "exp-42")
     granted: dict = {}
     monkeypatch.setattr(
         deploy_mod,
@@ -705,7 +705,7 @@ def test_deploy_keys_experiment_on_source_dir_name_not_prefixed(
     monkeypatch.setattr(deploy_mod, "_deployment_exists", lambda a, p: True)
     monkeypatch.setattr(
         deploy_mod,
-        "resolve_trace_experiment",
+        "resolve_trace_experiment_id",
         lambda source, app, client, profile: captured.update(app=app) or None,
     )
     monkeypatch.setattr(
@@ -731,7 +731,7 @@ def test_deploy_proceeds_when_tracing_provisioning_raises(tmp_path: pathlib.Path
         raise RuntimeError("mlflow create_experiment blew up")
 
     monkeypatch.setattr(deploy_mod, "_deployment_exists", lambda a, p: True)
-    monkeypatch.setattr(deploy_mod, "resolve_trace_experiment", _boom)
+    monkeypatch.setattr(deploy_mod, "resolve_trace_experiment_id", _boom)
     monkeypatch.setattr(
         deploy_mod,
         "_databricks",
@@ -862,7 +862,7 @@ def test_resolve_trace_experiment_uses_pinned_id_without_creating(
     )
     # A pinned id is used directly — no experiment creation.
     monkeypatch.setattr(
-        deploy_mod, "ensure_experiment", lambda *a, **k: pytest.fail("should not create")
+        deploy_mod, "create_experiment_idempotent", lambda *a, **k: pytest.fail("should not create")
     )
     assert _REAL_RESOLVE_TRACE(tmp_path, "app", _FakeClient(), None) == "pinned-1"
 
@@ -872,7 +872,7 @@ def test_resolve_trace_experiment_creates_per_project_default(tmp_path: pathlib.
     created: dict = {}
     monkeypatch.setattr(
         deploy_mod,
-        "ensure_experiment",
+        "create_experiment_idempotent",
         lambda profile, client, name: created.update(name=name) or "made-id",
     )
     exp_id = _REAL_RESOLVE_TRACE(tmp_path, "my-agent", _FakeClient(), None)
@@ -891,7 +891,7 @@ def test_resolve_trace_experiment_reuses_pinned_default_on_second_run(
     calls: list[str] = []
     monkeypatch.setattr(
         deploy_mod,
-        "ensure_experiment",
+        "create_experiment_idempotent",
         lambda profile, client, name: calls.append(name) or "made-id",
     )
     # First run creates + pins; the second reads the pinned id straight from agent.toml.

--- a/integrations/mason/tests/unit_tests/deploy_test.py
+++ b/integrations/mason/tests/unit_tests/deploy_test.py
@@ -839,9 +839,9 @@ def test_deploy_errors_when_bound_store_missing(tmp_path: pathlib.Path, monkeypa
     assert "mason memory bind ghost" in result.output
 
 
-def test_trace_env_binds_experiment_by_id_and_workspace():
-    # The agent binding is exactly two vars: the workspace (destination) and the experiment id.
-    assert deploy_mod.trace_env("exp-9") == {
+def test_mlflow_tracing_config_binds_experiment_by_id_and_workspace():
+    # The agent binding is exactly two env vars: the workspace (destination) and the experiment id.
+    assert deploy_mod.mlflow_tracing_config("exp-9").env() == {
         "MLFLOW_TRACKING_URI": "databricks",
         "MLFLOW_EXPERIMENT_ID": "exp-9",
     }

--- a/integrations/mason/tests/unit_tests/deploy_test.py
+++ b/integrations/mason/tests/unit_tests/deploy_test.py
@@ -14,12 +14,23 @@ from click.testing import CliRunner
 from databricks_mason import deploy as deploy_mod
 from databricks_mason.errors import AgentCliError
 
+# The autouse fixture below stubs `resolve_trace_experiment` for deploy-command tests; capture the
+# real function here so its own unit tests can exercise the actual logic.
+_REAL_RESOLVE_TRACE = deploy_mod.resolve_trace_experiment
+
 
 @pytest.fixture(autouse=True)
 def _compute_active(monkeypatch):
     # `mason deploy` now waits for compute on every deploy; report ACTIVE so the wait returns
     # immediately. Tests that exercise _wait_for_running directly override _app_compute_state.
     monkeypatch.setattr(deploy_mod, "_app_compute_state", lambda name, profile: "ACTIVE")
+
+
+@pytest.fixture(autouse=True)
+def _no_tracing_by_default(monkeypatch):
+    # Tracing is on by default and would create an MLflow experiment (a live workspace op); stub the
+    # provisioning off so non-tracing deploy tests stay hermetic. Tracing tests override this.
+    monkeypatch.setattr(deploy_mod, "resolve_trace_experiment", lambda *a, **k: None)
 
 
 def test_upsert_manifest_env_scaffolds_when_missing(tmp_path: pathlib.Path):
@@ -434,37 +445,37 @@ def test_deploy_does_not_write_store_env_to_app_yaml(tmp_path: pathlib.Path, mon
     assert "AGENT_SESSION_ACTOR_ID" not in env
 
 
-def test_deploy_with_traces_injects_tracing_env(tmp_path: pathlib.Path, monkeypatch):
+def test_deploy_wires_tracing_env_and_grants_experiment_resource(
+    tmp_path: pathlib.Path, monkeypatch
+):
+    # Tracing is on by default: deploy wires the two MLflow env vars (id + workspace) into app.yaml
+    # and grants the app's SP write access by declaring the experiment as an app resource.
     src = tmp_path / "app"
     src.mkdir()
     (src / "app.yaml").write_text(yaml.safe_dump({"command": ["x"]}))
 
     monkeypatch.setattr(deploy_mod, "_deployment_exists", lambda a, p: True)
+    monkeypatch.setattr(deploy_mod, "resolve_trace_experiment", lambda *a, **k: "exp-42")
+    granted: dict = {}
+    monkeypatch.setattr(
+        deploy_mod,
+        "apply_experiment_resource",
+        lambda app, experiment_id, profile: granted.update(app=app, experiment_id=experiment_id),
+    )
     monkeypatch.setattr(
         deploy_mod,
         "_databricks",
         lambda args, profile, **kw: types.SimpleNamespace(returncode=0, stdout="", stderr=""),
     )
 
-    result = CliRunner().invoke(
-        deploy_mod.deploy,
-        [
-            "myapp",
-            "--source",
-            str(src),
-            "--with-traces",
-            "cat.schema",
-            "--traces-experiment",
-            "/Shared/x",
-        ],
-        obj=_FakeCtx(),
-    )
+    result = CliRunner().invoke(deploy_mod.deploy, ["myapp", "--source", str(src)], obj=_FakeCtx())
 
     assert result.exit_code == 0, result.output
-    doc = yaml.safe_load((src / "app.yaml").read_text())
-    env = {e["name"]: e["value"] for e in doc["env"]}
-    assert env["MLFLOW_TRACING_DESTINATION"] == "cat.schema"
-    assert env["MLFLOW_EXPERIMENT_NAME"] == "/Shared/x"
+    env = {e["name"]: e["value"] for e in yaml.safe_load((src / "app.yaml").read_text())["env"]}
+    assert env["MLFLOW_EXPERIMENT_ID"] == "exp-42"
+    assert env["MLFLOW_TRACKING_URI"] == "databricks"
+    # the experiment is granted to the app's SP as an app resource (no manual SQL grant)
+    assert granted == {"app": "mason-myapp", "experiment_id": "exp-42"}
 
 
 def test_resolve_memory_store_pages_at_100_and_matches_display_name():
@@ -563,32 +574,45 @@ def test_deploy_errors_when_bound_store_missing(tmp_path: pathlib.Path, monkeypa
     assert "mason memory bind ghost" in result.output
 
 
-def test_with_traces_defaults_the_experiment_per_app():
-    # --with-traces alone must still set the experiment, or the agent ships tracing half-configured
-    # (destination set, experiment missing) and silently disables it. The default is per-app, so
-    # each agent's traces are isolated instead of piling into one shared experiment.
-    env = deploy_mod.validate_stores_and_trace_env(
-        _FakeClient(),
-        app="my-agent",
-        memory_store=None,
-        session_store=None,
-        traces_destination="cat.schema",
-        traces_experiment=None,
-    )
-    assert env["MLFLOW_TRACING_DESTINATION"] == "cat.schema"
-    assert env["MLFLOW_EXPERIMENT_NAME"] == "/Users/me@example.com/mason-traces/my-agent"
+def test_trace_env_binds_experiment_by_id_and_workspace():
+    # The agent binding is exactly two vars: the workspace (destination) and the experiment id.
+    assert deploy_mod.trace_env("exp-9") == {
+        "MLFLOW_TRACKING_URI": "databricks",
+        "MLFLOW_EXPERIMENT_ID": "exp-9",
+    }
 
 
-def test_with_traces_explicit_experiment_wins_over_per_app():
-    env = deploy_mod.validate_stores_and_trace_env(
-        _FakeClient(),
-        app="my-agent",
-        memory_store=None,
-        session_store=None,
-        traces_destination="cat.schema",
-        traces_experiment="/Shared/custom",
+def test_resolve_trace_experiment_none_when_disabled(tmp_path: pathlib.Path):
+    (tmp_path / "agent.toml").write_text(
+        'schema_version = 1\n\n[agent]\nframework = "openai"\n\n[tracing]\ndisabled = true\n'
     )
-    assert env["MLFLOW_EXPERIMENT_NAME"] == "/Shared/custom"
+    assert _REAL_RESOLVE_TRACE(tmp_path, "app", _FakeClient(), None) is None
+
+
+def test_resolve_trace_experiment_uses_pinned_id_without_creating(
+    tmp_path: pathlib.Path, monkeypatch
+):
+    (tmp_path / "agent.toml").write_text(
+        'schema_version = 1\n\n[agent]\nframework = "openai"\n\n[tracing]\nexperiment_id = "pinned-1"\n'
+    )
+    # A pinned id is used directly — no experiment creation.
+    monkeypatch.setattr(
+        deploy_mod, "ensure_experiment", lambda *a, **k: pytest.fail("should not create")
+    )
+    assert _REAL_RESOLVE_TRACE(tmp_path, "app", _FakeClient(), None) == "pinned-1"
+
+
+def test_resolve_trace_experiment_creates_per_app_default(tmp_path: pathlib.Path, monkeypatch):
+    (tmp_path / "agent.toml").write_text('schema_version = 1\n\n[agent]\nframework = "openai"\n')
+    created: dict = {}
+    monkeypatch.setattr(
+        deploy_mod,
+        "ensure_experiment",
+        lambda profile, client, name: created.update(name=name) or "made-id",
+    )
+    exp_id = _REAL_RESOLVE_TRACE(tmp_path, "my-agent", _FakeClient(), None)
+    assert exp_id == "made-id"
+    assert created["name"] == "/Users/me@example.com/mason-traces/my-agent"
 
 
 def _run_deploy(src, monkeypatch, extra_args):

--- a/integrations/mason/tests/unit_tests/deploy_test.py
+++ b/integrations/mason/tests/unit_tests/deploy_test.py
@@ -495,6 +495,56 @@ def test_deploy_wires_tracing_env_and_grants_experiment_resource(
     assert granted == {"app": "mason-myapp", "experiment_id": "exp-42"}
 
 
+def test_deploy_keys_experiment_on_source_dir_name_not_prefixed(
+    tmp_path: pathlib.Path, monkeypatch
+):
+    # dev keys the experiment on the source dir name; deploy must match it (NOT the mason-prefixed
+    # deployment name), so dev and deploy trace to the same per-agent experiment.
+    src = tmp_path / "my-agent"
+    src.mkdir()
+    (src / "app.yaml").write_text(yaml.safe_dump({"command": ["x"]}))
+    captured: dict = {}
+    monkeypatch.setattr(deploy_mod, "_deployment_exists", lambda a, p: True)
+    monkeypatch.setattr(
+        deploy_mod,
+        "resolve_trace_experiment",
+        lambda source, app, client, profile: captured.update(app=app) or None,
+    )
+    monkeypatch.setattr(
+        deploy_mod,
+        "_databricks",
+        lambda args, profile, **kw: types.SimpleNamespace(returncode=0, stdout="", stderr=""),
+    )
+    result = CliRunner().invoke(
+        deploy_mod.deploy, ["my-agent", "--source", str(src)], obj=_FakeCtx()
+    )
+    assert result.exit_code == 0, result.output
+    assert captured["app"] == "my-agent"  # source dir name, not "mason-my-agent"
+
+
+def test_deploy_proceeds_when_tracing_provisioning_raises(tmp_path: pathlib.Path, monkeypatch):
+    # Tracing provisioning is best-effort: a non-AgentCliError (e.g. MLflow/network) must not abort
+    # the deploy — it proceeds without tracing.
+    src = tmp_path / "app"
+    src.mkdir()
+    (src / "app.yaml").write_text(yaml.safe_dump({"command": ["x"]}))
+
+    def _boom(*a, **k):
+        raise RuntimeError("mlflow create_experiment blew up")
+
+    monkeypatch.setattr(deploy_mod, "_deployment_exists", lambda a, p: True)
+    monkeypatch.setattr(deploy_mod, "resolve_trace_experiment", _boom)
+    monkeypatch.setattr(
+        deploy_mod,
+        "_databricks",
+        lambda args, profile, **kw: types.SimpleNamespace(returncode=0, stdout="", stderr=""),
+    )
+    result = CliRunner().invoke(deploy_mod.deploy, ["myapp", "--source", str(src)], obj=_FakeCtx())
+    assert result.exit_code == 0, result.output  # deploy still succeeded
+    env_entries = yaml.safe_load((src / "app.yaml").read_text()).get("env") or []
+    assert not any(e["name"].startswith("MLFLOW") for e in env_entries)  # tracing skipped
+
+
 def test_resolve_memory_store_pages_at_100_and_matches_display_name():
     # The list API caps page_size at 100, so resolution must page (not request 1000) and match the
     # display name across pages.

--- a/integrations/mason/tests/unit_tests/dev_test.py
+++ b/integrations/mason/tests/unit_tests/dev_test.py
@@ -153,7 +153,7 @@ def test_dev_without_bindings_does_not_validate(tmp_path: pathlib.Path):
 
 
 def test_dev_wires_tracing_env_on_by_default(tmp_path: pathlib.Path, monkeypatch):
-    # Tracing is on by default: dev resolves the per-app experiment and wires the two MLflow env vars
+    # Tracing is on by default: dev resolves the per-project experiment and wires the two MLflow env vars
     # into app.yaml (the experiment id + the workspace tracking uri).
     import yaml
 

--- a/integrations/mason/tests/unit_tests/dev_test.py
+++ b/integrations/mason/tests/unit_tests/dev_test.py
@@ -168,6 +168,27 @@ def test_dev_wires_tracing_env_on_by_default(tmp_path: pathlib.Path, monkeypatch
     assert env["MLFLOW_TRACKING_URI"] == "databricks"
 
 
+def test_dev_runs_offline_when_client_unavailable(tmp_path: pathlib.Path):
+    # No stores + no auth: obj.client() raises, but tracing is best-effort, so dev still runs the
+    # agent locally (it doesn't regress the offline path).
+    from databricks_mason.errors import AgentCliError
+
+    (tmp_path / "app.yaml").write_text("command: []\n")
+    (tmp_path / ".venv").mkdir()
+
+    class _OfflineCtx:
+        output = "text"
+        profile = None
+
+        def client(self):
+            raise AgentCliError("no databricks auth configured")
+
+    with mock.patch.object(dev_mod, "_databricks") as db:
+        result = CliRunner().invoke(dev_mod.dev, ["--source", str(tmp_path)], obj=_OfflineCtx())
+    assert result.exit_code == 0, result.output
+    assert db.call_args.args[0][:2] == ["apps", "run-local"]  # agent still ran
+
+
 def test_dev_runs_without_traces_when_tracing_setup_fails(tmp_path: pathlib.Path, monkeypatch):
     # Tracing is best-effort locally: if provisioning raises (e.g. no mlflow), dev still runs the
     # agent, just without wiring any MLflow env.

--- a/integrations/mason/tests/unit_tests/dev_test.py
+++ b/integrations/mason/tests/unit_tests/dev_test.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import pathlib
 from unittest import mock
 
+import pytest
 from click.testing import CliRunner
 
 from databricks_mason import dev as dev_mod
@@ -15,8 +16,15 @@ class _Ctx:
         self.output = output
         self.profile = profile
 
-    def client(self):  # only used when --with-* flags are passed
-        return mock.Mock()
+    def client(self):
+        return mock.Mock(current_user="me@example.com")
+
+
+@pytest.fixture(autouse=True)
+def _stub_tracing(monkeypatch):
+    """Tracing is on by default and would hit MLflow/the workspace; stub the provisioning so the
+    non-tracing dev tests stay hermetic. Tracing-specific tests override this."""
+    monkeypatch.setattr(dev_mod, "resolve_trace_experiment", lambda *a, **k: None)
 
 
 def test_dev_prepares_when_no_venv(tmp_path: pathlib.Path):
@@ -118,7 +126,7 @@ def test_dev_validates_bound_stores_without_writing_store_env(tmp_path: pathlib.
     (tmp_path / ".venv").mkdir()
     with (
         mock.patch.object(dev_mod, "_databricks") as db,
-        mock.patch.object(dev_mod, "validate_stores_and_trace_env", return_value={}) as validate,
+        mock.patch.object(dev_mod, "validate_stores") as validate,
     ):
         result = CliRunner().invoke(dev_mod.dev, ["--source", str(tmp_path)], obj=_Ctx())
     assert result.exit_code == 0, result.output
@@ -130,16 +138,56 @@ def test_dev_validates_bound_stores_without_writing_store_env(tmp_path: pathlib.
 
 
 def test_dev_without_bindings_does_not_validate(tmp_path: pathlib.Path):
-    # No agent.toml store bindings (and no --with-* traces) -> nothing to validate.
+    # No agent.toml store bindings -> nothing to validate (tracing is stubbed by the autouse fixture).
     (tmp_path / "app.yaml").write_text("command: []\n")
     (tmp_path / ".venv").mkdir()
     with (
         mock.patch.object(dev_mod, "_databricks"),
-        mock.patch.object(dev_mod, "validate_stores_and_trace_env") as validate,
+        mock.patch.object(dev_mod, "validate_stores") as validate,
     ):
         result = CliRunner().invoke(dev_mod.dev, ["--source", str(tmp_path)], obj=_Ctx())
     assert result.exit_code == 0, result.output
     validate.assert_not_called()
+
+
+def test_dev_wires_tracing_env_on_by_default(tmp_path: pathlib.Path, monkeypatch):
+    # Tracing is on by default: dev resolves the per-app experiment and wires the two MLflow env vars
+    # into app.yaml (the experiment id + the workspace tracking uri).
+    import yaml
+
+    (tmp_path / "app.yaml").write_text(yaml.safe_dump({"command": ["x"]}))
+    (tmp_path / ".venv").mkdir()
+    monkeypatch.setattr(dev_mod, "resolve_trace_experiment", lambda *a, **k: "exp-123")
+    with mock.patch.object(dev_mod, "_databricks"):
+        result = CliRunner().invoke(dev_mod.dev, ["--source", str(tmp_path)], obj=_Ctx())
+    assert result.exit_code == 0, result.output
+    env = {
+        e["name"]: e["value"] for e in yaml.safe_load((tmp_path / "app.yaml").read_text())["env"]
+    }
+    assert env["MLFLOW_EXPERIMENT_ID"] == "exp-123"
+    assert env["MLFLOW_TRACKING_URI"] == "databricks"
+
+
+def test_dev_runs_without_traces_when_tracing_setup_fails(tmp_path: pathlib.Path, monkeypatch):
+    # Tracing is best-effort locally: if provisioning raises (e.g. no mlflow), dev still runs the
+    # agent, just without wiring any MLflow env.
+    import yaml
+
+    from databricks_mason.errors import AgentCliError
+
+    (tmp_path / "app.yaml").write_text(yaml.safe_dump({"command": ["x"]}))
+    (tmp_path / ".venv").mkdir()
+
+    def _boom(*a, **k):
+        raise AgentCliError("MLflow is required")
+
+    monkeypatch.setattr(dev_mod, "resolve_trace_experiment", _boom)
+    with mock.patch.object(dev_mod, "_databricks") as db:
+        result = CliRunner().invoke(dev_mod.dev, ["--source", str(tmp_path)], obj=_Ctx())
+    assert result.exit_code == 0, result.output
+    env_entries = yaml.safe_load((tmp_path / "app.yaml").read_text()).get("env") or []
+    assert not any(e["name"].startswith("MLFLOW") for e in env_entries)
+    assert db.call_args.args[0][:2] == ["apps", "run-local"]
 
 
 def test_dev_requires_app_yaml(tmp_path: pathlib.Path):

--- a/integrations/mason/tests/unit_tests/dev_test.py
+++ b/integrations/mason/tests/unit_tests/dev_test.py
@@ -25,7 +25,7 @@ class _Ctx:
 def _stub_tracing(monkeypatch):
     """Tracing is on by default and would hit MLflow/the workspace; stub the provisioning so the
     non-tracing dev tests stay hermetic. Tracing-specific tests override this."""
-    monkeypatch.setattr(dev_mod, "resolve_trace_experiment", lambda *a, **k: None)
+    monkeypatch.setattr(dev_mod, "resolve_trace_experiment_id", lambda *a, **k: None)
 
 
 def test_dev_prepares_when_no_venv(tmp_path: pathlib.Path):
@@ -159,7 +159,7 @@ def test_dev_wires_tracing_env_on_by_default(tmp_path: pathlib.Path, monkeypatch
 
     (tmp_path / "app.yaml").write_text(yaml.safe_dump({"command": ["x"]}))
     (tmp_path / ".venv").mkdir()
-    monkeypatch.setattr(dev_mod, "resolve_trace_experiment", lambda *a, **k: "exp-123")
+    monkeypatch.setattr(dev_mod, "resolve_trace_experiment_id", lambda *a, **k: "exp-123")
     with mock.patch.object(dev_mod, "_databricks"):
         result = CliRunner().invoke(dev_mod.dev, ["--source", str(tmp_path)], obj=_Ctx())
     assert result.exit_code == 0, result.output
@@ -204,7 +204,7 @@ def test_dev_runs_without_traces_when_tracing_setup_fails(tmp_path: pathlib.Path
     def _boom(*a, **k):
         raise AgentCliError("MLflow is required")
 
-    monkeypatch.setattr(dev_mod, "resolve_trace_experiment", _boom)
+    monkeypatch.setattr(dev_mod, "resolve_trace_experiment_id", _boom)
     with mock.patch.object(dev_mod, "_databricks") as db:
         result = CliRunner().invoke(dev_mod.dev, ["--source", str(tmp_path)], obj=_Ctx())
     assert result.exit_code == 0, result.output

--- a/integrations/mason/tests/unit_tests/tracing_test.py
+++ b/integrations/mason/tests/unit_tests/tracing_test.py
@@ -183,7 +183,7 @@ def test_list_searches_by_explicit_experiment_id(tmp_path: pathlib.Path):
         )
     assert result.exit_code == 0, result.output
     kwargs = mlflow.search_traces.call_args.kwargs
-    assert kwargs["experiment_ids"] == ["eid-9"]
+    assert kwargs["locations"] == ["eid-9"]
     assert kwargs["max_results"] == 7
     assert json.loads(result.output)[0]["trace_id"] == "tr-1"
 
@@ -200,7 +200,7 @@ def test_list_defaults_to_projects_pinned_experiment(tmp_path: pathlib.Path):
             tracing_mod.tracing_list, ["--source", str(tmp_path)], obj=_Ctx(output="json")
         )
     assert result.exit_code == 0, result.output
-    assert mlflow.search_traces.call_args.kwargs["experiment_ids"] == ["p1"]
+    assert mlflow.search_traces.call_args.kwargs["locations"] == ["p1"]
 
 
 def test_list_empty_when_no_experiment_exists(tmp_path: pathlib.Path):

--- a/integrations/mason/tests/unit_tests/tracing_test.py
+++ b/integrations/mason/tests/unit_tests/tracing_test.py
@@ -1,8 +1,8 @@
 """Unit tests for `mason tracing`: configure/disable binding, experiment provisioning, list/get.
 
-Tracing is managed MLflow tracing, `experiment_id`-centric. The pure surface (default_experiment,
+Tracing is managed MLflow tracing, `experiment_id`-centric. The pure surface (default_experiment_name,
 experiment_url) is tested directly; the mlflow-backed paths are exercised with a mocked
-`_mlflow`/`_configure` (the hermetic env shouldn't touch a real workspace).
+`_mlflow`/`_set_tracking_uri` (the hermetic env shouldn't touch a real workspace).
 """
 
 from __future__ import annotations
@@ -48,16 +48,16 @@ def _project(tmp_path: pathlib.Path, *, experiment_id: str | None = None, disabl
 # --- pure surface -----------------------------------------------------------
 
 
-def test_default_experiment_is_per_project_under_user_home():
+def test_default_experiment_name_is_per_project_under_user_home():
     assert (
-        tracing_mod.default_experiment("me@x.com", "my-agent")
+        tracing_mod.default_experiment_name("me@x.com", "my-agent")
         == "/Users/me@x.com/mason-traces/my-agent"
     )
 
 
-def test_default_experiment_requires_project():
+def test_default_experiment_name_requires_project():
     with pytest.raises(AgentCliError):
-        tracing_mod.default_experiment("me@x.com", None)
+        tracing_mod.default_experiment_name("me@x.com", None)
 
 
 def test_experiment_url_builds_traces_tab_link():
@@ -69,27 +69,29 @@ def test_experiment_url_builds_traces_tab_link():
     assert tracing_mod.experiment_url("unknown", "123") is None
 
 
-# --- ensure_experiment ------------------------------------------------------
+# --- create_experiment_idempotent ------------------------------------------------------
 
 
-def test_ensure_experiment_creates_parent_dir_for_nested_path():
+def test_create_experiment_idempotent_creates_parent_dir_for_nested_path():
     mlflow = mock.Mock()
     mlflow.get_experiment_by_name.return_value = None  # doesn't exist yet
     mlflow.create_experiment.return_value = "eid-1"
     client = mock.Mock()
     with mock.patch.object(tracing_mod, "_mlflow", return_value=mlflow):
-        eid = tracing_mod.ensure_experiment(None, client, "/Users/me@x.com/mason-traces/demo")
+        eid = tracing_mod.create_experiment_idempotent(
+            None, client, "/Users/me@x.com/mason-traces/demo"
+        )
     assert eid == "eid-1"
     # the intermediate workspace folder is created before the experiment (mlflow won't make it)
     client.ensure_workspace_dir.assert_called_once_with("/Users/me@x.com/mason-traces")
 
 
-def test_ensure_experiment_reuses_existing_without_mkdir():
+def test_create_experiment_idempotent_reuses_existing_without_mkdir():
     mlflow = mock.Mock()
     mlflow.get_experiment_by_name.return_value = mock.Mock(experiment_id="eid-2")
     client = mock.Mock()
     with mock.patch.object(tracing_mod, "_mlflow", return_value=mlflow):
-        assert tracing_mod.ensure_experiment(None, client, "/Shared/x") == "eid-2"
+        assert tracing_mod.create_experiment_idempotent(None, client, "/Shared/x") == "eid-2"
     client.ensure_workspace_dir.assert_not_called()  # existing experiment -> no dir work
     mlflow.create_experiment.assert_not_called()
 
@@ -103,7 +105,7 @@ def test_configure_pins_experiment_id(tmp_path: pathlib.Path):
     mlflow.get_experiment.return_value = mock.Mock(tags={})  # exists, managed (no UC tag)
     with (
         mock.patch.object(tracing_mod, "_mlflow", return_value=mlflow),
-        mock.patch.object(tracing_mod, "_configure"),
+        mock.patch.object(tracing_mod, "_set_tracking_uri"),
     ):
         result = CliRunner().invoke(
             tracing_mod.tracing_configure,
@@ -121,7 +123,7 @@ def test_configure_rejects_unknown_experiment_id(tmp_path: pathlib.Path):
     mlflow.get_experiment.return_value = None  # no such experiment
     with (
         mock.patch.object(tracing_mod, "_mlflow", return_value=mlflow),
-        mock.patch.object(tracing_mod, "_configure"),
+        mock.patch.object(tracing_mod, "_set_tracking_uri"),
     ):
         result = CliRunner().invoke(
             tracing_mod.tracing_configure,
@@ -143,7 +145,7 @@ def test_configure_rejects_uc_backed_experiment(tmp_path: pathlib.Path):
     )
     with (
         mock.patch.object(tracing_mod, "_mlflow", return_value=mlflow),
-        mock.patch.object(tracing_mod, "_configure"),
+        mock.patch.object(tracing_mod, "_set_tracking_uri"),
     ):
         result = CliRunner().invoke(
             tracing_mod.tracing_configure,
@@ -196,7 +198,7 @@ def test_list_searches_by_explicit_experiment_id(tmp_path: pathlib.Path):
     mlflow.search_traces.return_value = [_trace("tr-1")]
     with (
         mock.patch.object(tracing_mod, "_mlflow", return_value=mlflow),
-        mock.patch.object(tracing_mod, "_configure"),
+        mock.patch.object(tracing_mod, "_set_tracking_uri"),
     ):
         result = CliRunner().invoke(
             tracing_mod.tracing_list,
@@ -216,7 +218,7 @@ def test_list_defaults_to_projects_pinned_experiment(tmp_path: pathlib.Path):
     mlflow.search_traces.return_value = []
     with (
         mock.patch.object(tracing_mod, "_mlflow", return_value=mlflow),
-        mock.patch.object(tracing_mod, "_configure"),
+        mock.patch.object(tracing_mod, "_set_tracking_uri"),
     ):
         result = CliRunner().invoke(
             tracing_mod.tracing_list, ["--source", str(tmp_path)], obj=_Ctx(output="json")
@@ -232,7 +234,7 @@ def test_list_empty_when_no_experiment_exists(tmp_path: pathlib.Path):
     mlflow.get_experiment_by_name.return_value = None
     with (
         mock.patch.object(tracing_mod, "_mlflow", return_value=mlflow),
-        mock.patch.object(tracing_mod, "_configure"),
+        mock.patch.object(tracing_mod, "_set_tracking_uri"),
     ):
         result = CliRunner().invoke(
             tracing_mod.tracing_list, ["--source", str(tmp_path)], obj=_Ctx(output="json")
@@ -247,7 +249,7 @@ def test_get_reports_missing_trace(tmp_path: pathlib.Path):
     mlflow.get_trace.return_value = None
     with (
         mock.patch.object(tracing_mod, "_mlflow", return_value=mlflow),
-        mock.patch.object(tracing_mod, "_configure"),
+        mock.patch.object(tracing_mod, "_set_tracking_uri"),
     ):
         result = CliRunner().invoke(tracing_mod.tracing_get, ["tr-x"], obj=_Ctx())
     assert result.exit_code != 0

--- a/integrations/mason/tests/unit_tests/tracing_test.py
+++ b/integrations/mason/tests/unit_tests/tracing_test.py
@@ -48,14 +48,14 @@ def _project(tmp_path: pathlib.Path, *, experiment_id: str | None = None, disabl
 # --- pure surface -----------------------------------------------------------
 
 
-def test_default_experiment_is_per_app_under_user_home():
+def test_default_experiment_is_per_project_under_user_home():
     assert (
         tracing_mod.default_experiment("me@x.com", "my-agent")
         == "/Users/me@x.com/mason-traces/my-agent"
     )
 
 
-def test_default_experiment_requires_app():
+def test_default_experiment_requires_project():
     with pytest.raises(AgentCliError):
         tracing_mod.default_experiment("me@x.com", None)
 
@@ -155,8 +155,8 @@ def test_configure_rejects_uc_backed_experiment(tmp_path: pathlib.Path):
     assert AgentProject.load(tmp_path).trace_experiment_id is None  # nothing persisted
 
 
-def test_configure_default_enables_per_app_offline(tmp_path: pathlib.Path):
-    # No --experiment: enables the per-app default. Pure agent.toml write, no mlflow call.
+def test_configure_default_enables_per_project_offline(tmp_path: pathlib.Path):
+    # No --experiment: enables the per-project default. Pure agent.toml write, no mlflow call.
     _project(tmp_path, disabled=True)
     result = CliRunner().invoke(
         tracing_mod.tracing_configure, ["--source", str(tmp_path)], obj=_Ctx()
@@ -226,7 +226,7 @@ def test_list_defaults_to_projects_pinned_experiment(tmp_path: pathlib.Path):
 
 
 def test_list_empty_when_no_experiment_exists(tmp_path: pathlib.Path):
-    # No pinned id and the per-app experiment isn't created yet -> nothing traced, list is empty.
+    # No pinned id and the per-project experiment isn't created yet -> nothing traced, list is empty.
     _project(tmp_path)
     mlflow = mock.Mock()
     mlflow.get_experiment_by_name.return_value = None

--- a/integrations/mason/tests/unit_tests/tracing_test.py
+++ b/integrations/mason/tests/unit_tests/tracing_test.py
@@ -100,7 +100,7 @@ def test_ensure_experiment_reuses_existing_without_mkdir():
 def test_configure_pins_experiment_id(tmp_path: pathlib.Path):
     _project(tmp_path)
     mlflow = mock.Mock()
-    mlflow.get_experiment.return_value = mock.Mock()  # the id exists
+    mlflow.get_experiment.return_value = mock.Mock(tags={})  # exists, managed (no UC tag)
     with (
         mock.patch.object(tracing_mod, "_mlflow", return_value=mlflow),
         mock.patch.object(tracing_mod, "_configure"),
@@ -130,6 +130,28 @@ def test_configure_rejects_unknown_experiment_id(tmp_path: pathlib.Path):
         )
     assert result.exit_code != 0
     assert "No MLflow experiment" in result.output
+    assert AgentProject.load(tmp_path).trace_experiment_id is None  # nothing persisted
+
+
+def test_configure_rejects_uc_backed_experiment(tmp_path: pathlib.Path):
+    # mason supports managed tracing only; a UC-backed experiment (carries the UC destination tag)
+    # is rejected up front rather than silently wiring a config that fails at read/deploy.
+    _project(tmp_path)
+    mlflow = mock.Mock()
+    mlflow.get_experiment.return_value = mock.Mock(
+        tags={"mlflow.experiment.databricksTraceDestinationPath": "cat.schema"}
+    )
+    with (
+        mock.patch.object(tracing_mod, "_mlflow", return_value=mlflow),
+        mock.patch.object(tracing_mod, "_configure"),
+    ):
+        result = CliRunner().invoke(
+            tracing_mod.tracing_configure,
+            ["--experiment", "uc-1", "--source", str(tmp_path)],
+            obj=_Ctx(),
+        )
+    assert result.exit_code != 0
+    assert "UC-backed MLflow tracing is not supported" in result.output
     assert AgentProject.load(tmp_path).trace_experiment_id is None  # nothing persisted
 
 

--- a/integrations/mason/tests/unit_tests/tracing_test.py
+++ b/integrations/mason/tests/unit_tests/tracing_test.py
@@ -1,101 +1,51 @@
-"""Unit tests for `mason tracing`: instrument snippet, destination parsing, mlflow guard.
+"""Unit tests for `mason tracing`: configure/disable binding, experiment provisioning, list/get.
 
-The pure-Python surface (instrument, destination parsing) is covered directly. The
-mlflow-backed commands are exercised only for their "mlflow not installed" guard, since the
-hermetic test env does not carry mlflow on the deptree.
+Tracing is managed MLflow tracing, `experiment_id`-centric. The pure surface (default_experiment,
+experiment_url) is tested directly; the mlflow-backed paths are exercised with a mocked
+`_mlflow`/`_configure` (the hermetic env shouldn't touch a real workspace).
 """
 
 from __future__ import annotations
 
 import json
+import pathlib
+from unittest import mock
 
+import pytest
 from click.testing import CliRunner
 
 from databricks_mason import tracing as tracing_mod
+from databricks_mason.agent_project import AgentProject
 from databricks_mason.errors import AgentCliError
+
+_AGENT_TOML = 'schema_version = 1\n\n[agent]\nframework = "openai"\n'
 
 
 class _Ctx:
-    """Stand-in for CliContext: tracing commands read only .profile and .output."""
+    """Stand-in for CliContext: tracing reads .profile / .output, and .client() for the list default."""
 
-    def __init__(self, output: str = "text", profile=None):
+    def __init__(self, output: str = "text", profile=None, user="me@example.com"):
         self.output = output
         self.profile = profile
+        self._user = user
+
+    def client(self):
+        return mock.Mock(current_user=self._user, host="https://ws")
 
 
-def test_instrument_text_runs():
-    result = CliRunner().invoke(
-        tracing_mod.tracing_instrument,
-        ["--destination", "cat.schema", "--experiment", "/Shared/x"],
-        obj=_Ctx(),
-    )
-    assert result.exit_code == 0, result.output
-    assert "Agent Tracing" in result.output
+def _project(tmp_path: pathlib.Path, *, experiment_id: str | None = None, disabled: bool = False):
+    body = _AGENT_TOML
+    if experiment_id or disabled:
+        body += "\n[tracing]\n"
+        if experiment_id:
+            body += f'experiment_id = "{experiment_id}"\n'
+        if disabled:
+            body += "disabled = true\n"
+    (tmp_path / "agent.toml").write_text(body)
+    return tmp_path
 
 
-def test_instrument_json_snippet_contents():
-    result = CliRunner().invoke(
-        tracing_mod.tracing_instrument,
-        ["--destination", "cat.schema", "--experiment", "/Shared/x"],
-        obj=_Ctx(output="json"),
-    )
-    assert result.exit_code == 0, result.output
-    payload = json.loads(result.output)
-    assert payload["destination"] == "cat.schema"
-    assert payload["experiment"] == "/Shared/x"
-    snippet = payload["snippet"]
-    assert 'catalog_name="cat"' in snippet
-    assert 'schema_name="schema"' in snippet
-    assert "mlflow.openai.autolog" in snippet
-    assert 'mlflow.set_experiment("/Shared/x")' in snippet
-
-
-def test_instrument_defaults_to_placeholders_and_default_experiment():
-    result = CliRunner().invoke(tracing_mod.tracing_instrument, [], obj=_Ctx(output="json"))
-    assert result.exit_code == 0, result.output
-    payload = json.loads(result.output)
-    assert payload["experiment"] == tracing_mod._DEFAULT_EXPERIMENT
-    assert "<catalog>" in payload["snippet"] and "<schema>" in payload["snippet"]
-
-
-def test_split_destination_valid():
-    assert tracing_mod._split_destination("my_cat.my_schema") == ("my_cat", "my_schema")
-
-
-def test_split_destination_invalid_raises():
-    for bad in ("nodot", ".schema", "catalog."):
-        try:
-            tracing_mod._split_destination(bad)
-            raise AssertionError(f"expected AgentCliError for {bad!r}")
-        except AgentCliError:
-            pass
-
-
-def test_ensure_experiment_creates_parent_dir_for_nested_path():
-    from unittest import mock
-
-    mlflow = mock.Mock()
-    mlflow.get_experiment_by_name.return_value = None  # doesn't exist yet
-    mlflow.create_experiment.return_value = "eid-1"
-    client = mock.Mock()
-
-    eid = tracing_mod._ensure_experiment(mlflow, client, "/Users/me@x.com/mason-traces/demo")
-
-    assert eid == "eid-1"
-    # the intermediate workspace folder is created before the experiment (mlflow won't make it)
-    client.ensure_workspace_dir.assert_called_once_with("/Users/me@x.com/mason-traces")
-
-
-def test_ensure_experiment_reuses_existing_without_mkdir():
-    from unittest import mock
-
-    mlflow = mock.Mock()
-    mlflow.get_experiment_by_name.return_value = mock.Mock(experiment_id="eid-2")
-    client = mock.Mock()
-
-    assert tracing_mod._ensure_experiment(mlflow, client, "/Shared/x") == "eid-2"
-    client.ensure_workspace_dir.assert_not_called()  # existing experiment -> no dir work
-    mlflow.create_experiment.assert_not_called()
+# --- pure surface -----------------------------------------------------------
 
 
 def test_default_experiment_is_per_app_under_user_home():
@@ -105,91 +55,157 @@ def test_default_experiment_is_per_app_under_user_home():
     )
 
 
-def test_default_experiment_falls_back_to_shared_without_app():
-    assert tracing_mod.default_experiment("me@x.com", None) == tracing_mod._DEFAULT_EXPERIMENT
+def test_default_experiment_requires_app():
+    with pytest.raises(AgentCliError):
+        tracing_mod.default_experiment("me@x.com", None)
 
 
 def test_experiment_url_builds_traces_tab_link():
-    url = tracing_mod._experiment_url("https://ws.databricks.com/", "123")
-    assert url == "https://ws.databricks.com/ml/experiments/123?compareRunsMode=TRACES"
-
-
-def test_link_trace_location_reports_already_linked_without_relink():
-    def set_location(location, experiment_id):
-        raise RuntimeError("experiment is already linked to a storage location")
-
-    try:
-        tracing_mod._link_trace_location(
-            set_location, lambda **k: None, object(), "e1", relink=False
-        )
-        raise AssertionError("expected AgentCliError")
-    except AgentCliError as exc:
-        assert "--relink" in (exc.hint or "")
-
-
-def test_link_trace_location_relinks_when_requested():
-    calls = []
-
-    def set_location(location, experiment_id):
-        calls.append("set")
-        if calls.count("set") == 1:  # first attempt fails as already-linked
-            raise RuntimeError("already linked")
-
-    def unset_location(location, experiment_id):
-        calls.append("unset")
-
-    tracing_mod._link_trace_location(set_location, unset_location, object(), "e1", relink=True)
-    assert calls == ["set", "unset", "set"]  # try, unset existing, re-link
-
-
-def test_link_trace_location_propagates_unrelated_errors():
-    def set_location(location, experiment_id):
-        raise RuntimeError("permission denied on catalog")
-
-    try:
-        tracing_mod._link_trace_location(
-            set_location, lambda **k: None, object(), "e1", relink=True
-        )
-        raise AssertionError("expected the original error")
-    except RuntimeError as exc:
-        assert "permission denied" in str(exc)  # not swallowed as an already-linked case
-
-
-def test_setup_requires_mlflow_when_absent():
-    # mlflow is not on the hermetic test deptree, so setup should surface a clean CLI error
-    # (non-zero exit) rather than a traceback.
-    result = CliRunner().invoke(
-        tracing_mod.tracing_setup, ["--catalog", "c", "--schema", "s"], obj=_Ctx()
+    assert (
+        tracing_mod.experiment_url("https://ws.databricks.com/", "123")
+        == "https://ws.databricks.com/ml/experiments/123?compareRunsMode=TRACES"
     )
-    assert result.exit_code != 0
+    assert tracing_mod.experiment_url(None, "123") is None
+    assert tracing_mod.experiment_url("unknown", "123") is None
 
 
-def test_list_resolves_experiment_name_to_id_for_search():
-    # search_traces selects by experiment_ids, not names, so list must resolve the name first.
-    from unittest import mock
+# --- ensure_experiment ------------------------------------------------------
 
+
+def test_ensure_experiment_creates_parent_dir_for_nested_path():
     mlflow = mock.Mock()
-    mlflow.get_experiment_by_name.return_value = mock.Mock(experiment_id="eid-9")
+    mlflow.get_experiment_by_name.return_value = None  # doesn't exist yet
+    mlflow.create_experiment.return_value = "eid-1"
+    client = mock.Mock()
+    with mock.patch.object(tracing_mod, "_mlflow", return_value=mlflow):
+        eid = tracing_mod.ensure_experiment(None, client, "/Users/me@x.com/mason-traces/demo")
+    assert eid == "eid-1"
+    # the intermediate workspace folder is created before the experiment (mlflow won't make it)
+    client.ensure_workspace_dir.assert_called_once_with("/Users/me@x.com/mason-traces")
+
+
+def test_ensure_experiment_reuses_existing_without_mkdir():
+    mlflow = mock.Mock()
+    mlflow.get_experiment_by_name.return_value = mock.Mock(experiment_id="eid-2")
+    client = mock.Mock()
+    with mock.patch.object(tracing_mod, "_mlflow", return_value=mlflow):
+        assert tracing_mod.ensure_experiment(None, client, "/Shared/x") == "eid-2"
+    client.ensure_workspace_dir.assert_not_called()  # existing experiment -> no dir work
+    mlflow.create_experiment.assert_not_called()
+
+
+# --- configure / disable ----------------------------------------------------
+
+
+def test_configure_pins_experiment_id(tmp_path: pathlib.Path):
+    _project(tmp_path)
+    mlflow = mock.Mock()
+    mlflow.get_experiment.return_value = mock.Mock()  # the id exists
+    with (
+        mock.patch.object(tracing_mod, "_mlflow", return_value=mlflow),
+        mock.patch.object(tracing_mod, "_configure"),
+    ):
+        result = CliRunner().invoke(
+            tracing_mod.tracing_configure,
+            ["--experiment", "123", "--source", str(tmp_path)],
+            obj=_Ctx(output="json"),
+        )
+    assert result.exit_code == 0, result.output
+    assert json.loads(result.output) == {"experiment_id": "123", "disabled": False}
+    assert AgentProject.load(tmp_path).trace_experiment_id == "123"
+
+
+def test_configure_rejects_unknown_experiment_id(tmp_path: pathlib.Path):
+    _project(tmp_path)
+    mlflow = mock.Mock()
+    mlflow.get_experiment.return_value = None  # no such experiment
+    with (
+        mock.patch.object(tracing_mod, "_mlflow", return_value=mlflow),
+        mock.patch.object(tracing_mod, "_configure"),
+    ):
+        result = CliRunner().invoke(
+            tracing_mod.tracing_configure,
+            ["--experiment", "nope", "--source", str(tmp_path)],
+            obj=_Ctx(),
+        )
+    assert result.exit_code != 0
+    assert "No MLflow experiment" in result.output
+    assert AgentProject.load(tmp_path).trace_experiment_id is None  # nothing persisted
+
+
+def test_configure_default_enables_per_app_offline(tmp_path: pathlib.Path):
+    # No --experiment: enables the per-app default. Pure agent.toml write, no mlflow call.
+    _project(tmp_path, disabled=True)
+    result = CliRunner().invoke(
+        tracing_mod.tracing_configure, ["--source", str(tmp_path)], obj=_Ctx()
+    )
+    assert result.exit_code == 0, result.output
+    project = AgentProject.load(tmp_path)
+    assert project.trace_experiment_id is None
+    assert project.trace_disabled is False  # re-enabled
+
+
+def test_disable_writes_disabled(tmp_path: pathlib.Path):
+    _project(tmp_path, experiment_id="123")
+    result = CliRunner().invoke(
+        tracing_mod.tracing_disable, ["--source", str(tmp_path)], obj=_Ctx(output="json")
+    )
+    assert result.exit_code == 0, result.output
+    assert json.loads(result.output) == {"disabled": True}
+    assert AgentProject.load(tmp_path).trace_disabled is True
+
+
+# --- list / get -------------------------------------------------------------
+
+
+def _trace(trace_id):
+    import types
+
+    return types.SimpleNamespace(
+        info=types.SimpleNamespace(
+            trace_id=trace_id, status="OK", execution_time_ms=5, timestamp_ms=1
+        )
+    )
+
+
+def test_list_searches_by_explicit_experiment_id(tmp_path: pathlib.Path):
+    _project(tmp_path)
+    mlflow = mock.Mock()
+    mlflow.search_traces.return_value = [_trace("tr-1")]
+    with (
+        mock.patch.object(tracing_mod, "_mlflow", return_value=mlflow),
+        mock.patch.object(tracing_mod, "_configure"),
+    ):
+        result = CliRunner().invoke(
+            tracing_mod.tracing_list,
+            ["--experiment", "eid-9", "--limit", "7", "--source", str(tmp_path)],
+            obj=_Ctx(output="json"),
+        )
+    assert result.exit_code == 0, result.output
+    kwargs = mlflow.search_traces.call_args.kwargs
+    assert kwargs["experiment_ids"] == ["eid-9"]
+    assert kwargs["max_results"] == 7
+    assert json.loads(result.output)[0]["trace_id"] == "tr-1"
+
+
+def test_list_defaults_to_projects_pinned_experiment(tmp_path: pathlib.Path):
+    _project(tmp_path, experiment_id="p1")
+    mlflow = mock.Mock()
     mlflow.search_traces.return_value = []
     with (
         mock.patch.object(tracing_mod, "_mlflow", return_value=mlflow),
         mock.patch.object(tracing_mod, "_configure"),
     ):
         result = CliRunner().invoke(
-            tracing_mod.tracing_list, ["--experiment", "/Shared/x", "--limit", "7"], obj=_Ctx()
+            tracing_mod.tracing_list, ["--source", str(tmp_path)], obj=_Ctx(output="json")
         )
-
     assert result.exit_code == 0, result.output
-    mlflow.get_experiment_by_name.assert_called_once_with("/Shared/x")
-    _, kwargs = mlflow.search_traces.call_args
-    assert kwargs["experiment_ids"] == ["eid-9"]
-    assert kwargs["max_results"] == 7
+    assert mlflow.search_traces.call_args.kwargs["experiment_ids"] == ["p1"]
 
 
-def test_list_returns_empty_when_experiment_absent():
-    # A not-yet-created experiment has no traces; list should show none, not error.
-    from unittest import mock
-
+def test_list_empty_when_no_experiment_exists(tmp_path: pathlib.Path):
+    # No pinned id and the per-app experiment isn't created yet -> nothing traced, list is empty.
+    _project(tmp_path)
     mlflow = mock.Mock()
     mlflow.get_experiment_by_name.return_value = None
     with (
@@ -197,12 +213,36 @@ def test_list_returns_empty_when_experiment_absent():
         mock.patch.object(tracing_mod, "_configure"),
     ):
         result = CliRunner().invoke(
-            tracing_mod.tracing_list, ["--experiment", "/Shared/missing"], obj=_Ctx(output="json")
+            tracing_mod.tracing_list, ["--source", str(tmp_path)], obj=_Ctx(output="json")
         )
-
     assert result.exit_code == 0, result.output
     assert json.loads(result.output) == []
     mlflow.search_traces.assert_not_called()
+
+
+def test_get_reports_missing_trace(tmp_path: pathlib.Path):
+    mlflow = mock.Mock()
+    mlflow.get_trace.return_value = None
+    with (
+        mock.patch.object(tracing_mod, "_mlflow", return_value=mlflow),
+        mock.patch.object(tracing_mod, "_configure"),
+    ):
+        result = CliRunner().invoke(tracing_mod.tracing_get, ["tr-x"], obj=_Ctx())
+    assert result.exit_code != 0
+    assert "No trace found" in result.output
+
+
+# --- mlflow guard -----------------------------------------------------------
+
+
+def test_list_surfaces_clean_error_when_mlflow_absent(tmp_path: pathlib.Path):
+    _project(tmp_path)
+    with mock.patch.object(tracing_mod, "_mlflow", side_effect=AgentCliError("MLflow is required")):
+        result = CliRunner().invoke(
+            tracing_mod.tracing_list, ["--experiment", "1", "--source", str(tmp_path)], obj=_Ctx()
+        )
+    assert result.exit_code != 0
+    assert "MLflow is required" in result.output
 
 
 def test_status_str_handles_enum_like_and_none():


### PR DESCRIPTION
## Summary
- Make tracing **default on** for mason dev / mason deploy and writing to a default mlflow experiment derived from the current agent 
- Introduced `mason tracing configure` to bind to an existing experiment
- Remove support for UC based tracing due to its setup complexity (will address in a follow up)


## What changed

- **`mason tracing`**: `configure [--experiment <id>]` (on / rebind, id-only override), `disable` (off), `list`, `get`. Dropped `setup --catalog/--schema/--warehouse-id`, the UC `set_experiment_trace_location` linking, and `instrument`.
- **On by default**: `mason dev` and `mason deploy` send traces to a per-app experiment (`/Users/<user>/mason-traces/<app>`), auto-created on first run. No `--with-traces` flags.
- **One identifier**: the runtime binding is just `MLFLOW_TRACKING_URI=databricks` + `MLFLOW_EXPERIMENT_ID=<id>`.
- **`agent.toml`**: a single `[tracing]` table (`experiment_id` / `disabled`).
- **Deploy grant**: the experiment is declared as an `AppResourceExperiment(experiment_id, CAN_EDIT)` app resource so the app's service principal can write traces with no manual grant.
- Provisioning is best-effort: dev/deploy never block on tracing (no auth, no mlflow, or offline all degrade to running without traces).

## Managed-only for now (UC-backed rejected)

`mason` manages **managed** (non-UC) experiments. If `configure --experiment <id>` is pointed at a **UC-backed** experiment, it errors clearly (`UC-backed MLflow tracing is not supported by mason.`) rather than silently wiring a config that would fail at read/deploy - reading UC traces needs a SQL warehouse and a deployed app's SP needs UC grants mason doesn't set up. Supporting UC-backed experiments (require a warehouse + grant the app SP `USE_CATALOG`/`USE_SCHEMA`/`SELECT`/`MODIFY` on the schema) is deferred to a **follow-up**.

## Testing done

Unit: `401 passed`, `ty` clean, `ruff` clean.

Live (e2-dogfood, fresh env - installed the CLI, scaffolded, `dev`, `deploy`):
- **`mason dev`**: the per-app experiment was auto-created and the two MLflow env vars wired into `app.yaml`; invoking the local agent produced a trace that `mason tracing list` shows.
- **`mason deploy`**: the deploy reported `Trace access - granted to app service principal` (the experiment app-resource), and invoking the **deployed** app via OAuth produced a second trace in the same experiment - written by the app's service principal with **no manual grant**. Both traces (dev + deployed) appear in `mason tracing list`.
- **UC-backed guard**: created a UC-linked experiment and confirmed `configure --experiment <it>` errors cleanly; a managed experiment still configures fine.

Isaac Review found three MAJOR bugs that unit tests and the initial live run missed - dev/deploy keying the experiment on different names, a non-`AgentCliError` from provisioning aborting the deploy, and an offline `mason dev` regression - each now fixed and covered by a regression test.

## Note

This supersedes the UC-only tracing PR #545 (different branch); that approach is abandoned in favor of this simpler managed model.

This pull request and its description were written by Isaac.
