### PR TITLE
mason: adapt sessions for OpenAI agents

### DIFF
--- a/integrations/mason/README.md
+++ b/integrations/mason/README.md
@@ -94,6 +94,15 @@ memory = memory.update(content="The user prefers very concise answers.")
 memory.delete()
 ```
 
+An existing durable Mason session can also be passed directly to the OpenAI Agents SDK:
+
+```python
+from agents import Runner
+from databricks_mason.openai import OpenAISession
+
+result = await Runner.run(agent, "Hello", session=OpenAISession(session))
+```
+
 The root collections manage stores: `mason.memory_stores.create/get/list` and
 `mason.session_stores.create/get/list`. A returned store owns operations on its
 contents, such as `memory_store.add()`, `memory_store.get("memory-id")`,

--- a/integrations/mason/src/databricks_mason/openai/__init__.py
+++ b/integrations/mason/src/databricks_mason/openai/__init__.py
@@ -32,7 +32,7 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from databricks_mason.openai.mcp import mcp_servers
     from databricks_mason.openai.memory import memory_tools
-    from databricks_mason.openai.sessions import session_store
+    from databricks_mason.openai.sessions import OpenAISession, session_store
     from databricks_mason.runtime import tag_session, workspace_client, workspace_headers
 
 
@@ -56,6 +56,8 @@ __all__ = [
     "memory_tools",
     # Session persistence — pass session_store(session_id) to Runner.run(session=...).
     "session_store",
+    # Adapter for a Session obtained explicitly through MasonClient.session_stores.
+    "OpenAISession",
     # MLflow tracing (OpenAI autolog bound in) — call configure_tracing() once at startup.
     "configure_tracing",
     "tag_session",
@@ -70,6 +72,7 @@ _MODULE_BY_NAME = {
     "mcp_servers": "databricks_mason.openai.mcp",
     "memory_tools": "databricks_mason.openai.memory",
     "session_store": "databricks_mason.openai.sessions",
+    "OpenAISession": "databricks_mason.openai.sessions",
     "tag_session": "databricks_mason.runtime",
     "workspace_client": "databricks_mason.runtime",
     "workspace_headers": "databricks_mason.runtime",

--- a/integrations/mason/src/databricks_mason/openai/sessions.py
+++ b/integrations/mason/src/databricks_mason/openai/sessions.py
@@ -32,6 +32,7 @@ from agents.memory import SessionABC
 
 from databricks_mason.runtime.session_store_client import Session as _StoreSession
 from databricks_mason.runtime.session_store_client import SessionStoreClient
+from databricks_mason.session_store import Session as MasonSession
 
 # Fetch items oldest-first so the transcript replays in write order.
 _ORDER_BY = "create_time asc"
@@ -39,6 +40,31 @@ _ORDER_BY = "create_time asc"
 # One in-process Session per session id, built lazily and shared — that's what makes multi-turn work
 # in-process (the durable store needs no cache; each call resolves the same REST-backed session).
 _local_sessions: dict[str, SQLiteSession] = {}
+
+
+class OpenAISession(SessionABC):
+    """Adapt an existing Mason ``Session`` for the OpenAI Agents SDK."""
+
+    def __init__(self, session: MasonSession) -> None:
+        self.session_id = session.session_id
+        self._session = session
+
+    async def get_items(self, limit: int | None = None) -> list[TResponseInputItem]:
+        items = await _run_sync(
+            lambda: [item.data for item in self._session.list_items(order_by=_ORDER_BY)]
+        )
+        return items[-limit:] if limit is not None else items
+
+    async def add_items(self, items: list[TResponseInputItem]) -> None:
+        if items:
+            await _run_sync(lambda: self._session.append_items(items))
+
+    async def pop_item(self) -> TResponseInputItem | None:
+        item = await _run_sync(self._session.pop_item)
+        return item.data if item is not None else None
+
+    async def clear_session(self) -> None:
+        await _run_sync(self._session.clear_items)
 
 
 def session_store(


### PR DESCRIPTION
## What did you change, and why?

**Change:** Add a public `OpenAISession` adapter that wraps an existing typed Mason `Session` and implements the OpenAI Agents SDK session contract. Export it lazily from `databricks_mason.openai` and document passing it to `Runner.run`.

**Why:** Callers that explicitly create or resolve durable sessions through `MasonClient.session_stores` can now reuse those sessions directly with OpenAI agents instead of resolving a second session through environment or project configuration.

## How do you know it works?