### PR TITLE
[mason] deploy: record deployment name in agent.toml so re-deploys can omit it

### DIFF
--- a/integrations/mason/src/databricks_mason/agent_project.py
+++ b/integrations/mason/src/databricks_mason/agent_project.py
@@ -296,6 +296,7 @@ class AgentProject:
         memory_store: str | None = None,
         session_store: str | None = None,
         memory_store_id: str | None = None,
+        deployment_name: str | None = None,
     ) -> None:
         self.root = root
         self.path = root / "agent.toml"
@@ -307,6 +308,8 @@ class AgentProject:
         self.memory_store = memory_store
         self.session_store = session_store
         self.memory_store_id = memory_store_id
+        # The deployment's base name (`mason deploy` prefixes it with `mason-`); None until named.
+        self.deployment_name = deployment_name
 
     @classmethod
     def load(cls, root: pathlib.Path | str) -> "AgentProject":
@@ -333,6 +336,11 @@ class AgentProject:
         framework = _required_string(agent.get("framework"), "agent.framework")
         if framework not in _SUPPORTED_FRAMEWORKS:
             raise AgentCliError(f"Unsupported Mason framework {framework!r}.")
+        deployment_name = agent.get("deployment_name")
+        if deployment_name is not None and not (
+            isinstance(deployment_name, str) and deployment_name
+        ):
+            raise AgentCliError("agent.toml [agent] deployment_name must be a non-empty string.")
         raw_tools = document.get("tools", [])
         if not isinstance(raw_tools, list):
             raise AgentCliError("agent.toml tools must be an array of tables.")
@@ -355,6 +363,7 @@ class AgentProject:
             memory_store,
             session_store,
             memory_store_id,
+            str(deployment_name) if deployment_name is not None else None,
         )
 
     @classmethod
@@ -369,6 +378,18 @@ class AgentProject:
         agent.add("framework", framework)
         document.add("agent", agent)
         return cls(project_root, document, framework, [])
+
+    def set_deployment_name(self, name: str) -> bool:
+        """Record the deployment's base name under [agent].deployment_name. True if it changed."""
+        name = _required_string(name, "[agent] deployment_name")
+        if self.deployment_name == name:
+            return False
+        agent = self._document.get("agent")
+        if not isinstance(agent, Mapping):
+            raise AgentCliError("agent.toml must declare an [agent] table.")
+        agent["deployment_name"] = name
+        self.deployment_name = name
+        return True
 
     def add_tool(self, spec: ToolSpec) -> bool:
         for existing in self.tools:

--- a/integrations/mason/src/databricks_mason/deploy.py
+++ b/integrations/mason/src/databricks_mason/deploy.py
@@ -232,6 +232,16 @@ def _memory_store_database(client, memory_store: str) -> Optional[str]:
     return memory_store_access.database_from_backend_id(backend_id) if backend_id else None
 
 
+def _load_project(source: pathlib.Path):
+    """The AgentProject at `source`, or None when there's no readable agent.toml."""
+    from databricks_mason.agent_project import AgentProject
+
+    try:
+        return AgentProject.load(source)
+    except AgentCliError:
+        return None
+
+
 def store_bindings(source: pathlib.Path) -> tuple[Optional[str], Optional[str]]:
     """The (memory, session) stores bound in agent.toml via `mason memory/sessions bind`.
 
@@ -239,16 +249,28 @@ def store_bindings(source: pathlib.Path) -> tuple[Optional[str], Optional[str]]:
     deploy` resolve through here so the store env AND the deploy-time access grant honor the same
     bindings. Missing/invalid agent.toml is ignored (no stores), so this never blocks a run.
     """
-    try:
-        from databricks_mason.agent_project import AgentProject
-
-        project = AgentProject.load(source)
-    except AgentCliError:
+    project = _load_project(source)
+    if project is None:
         return None, None
     # str(): agent.toml bindings come back as tomlkit strings, which don't serialize to app.yaml.
     memory = str(project.memory_store) if project.memory_store else None
     session = str(project.session_store) if project.session_store else None
     return memory, session
+
+
+def _resolve_deployment_name(project, name: Optional[str]) -> str:
+    """The deployment's base name: the NAME arg if given, else agent.toml's [agent].deployment_name.
+
+    Errors when neither is available, pointing the user at the one-time `mason deploy <name>`.
+    """
+    if name is not None and name.strip():
+        return name.strip()
+    if project is not None and project.deployment_name:
+        return str(project.deployment_name)
+    raise AgentCliError(
+        "No deployment name given and none recorded in agent.toml.",
+        hint="Run `mason deploy <name>` once to name the agent; later `mason deploy` can omit it.",
+    )
 
 
 def validate_stores_and_trace_env(
@@ -332,7 +354,7 @@ def _grant_store_access(
 
 
 @click.command()
-@click.argument("name")
+@click.argument("name", required=False)
 @click.option(
     "--source",
     default=".",
@@ -382,8 +404,10 @@ def deploy(
 ) -> None:
     """Deploy an agent: validate its bound stores, wire in tracing, and roll out the deployment.
 
-    The app is named `mason-<name>` (Mason adds the prefix if absent); use that full name with the
-    other `mason deployments` verbs. `deployments list` shows only apps carrying this prefix.
+    NAME is recorded in agent.toml on first deploy, so later `mason deploy` (from the project dir)
+    can omit it; passing NAME again updates the recorded name. The app is named `mason-<name>`
+    (Mason adds the prefix if absent); use that full name with the other `mason deployments` verbs.
+    `deployments list` shows only apps carrying this prefix.
 
     Horizontally scaled deployments use best-effort sticky routing (session affinity). Browsers
     preserve the routing cookie automatically.
@@ -392,10 +416,15 @@ def deploy(
     API clients must reuse a stable UUID in this cookie on every request:
       __Host-databricks-app-router=<uuid>
     """
-    name = _prefixed_name(name)
-    _validate_deployment_name(name)
-    instance_args = _instance_args(instances)
     source_dir = pathlib.Path(source)
+    project = _load_project(source_dir)
+    base_name = _resolve_deployment_name(project, name)
+    name = _prefixed_name(base_name)
+    _validate_deployment_name(name)
+    # Persist the base name so a later `mason deploy` (no NAME) resolves to the same app.
+    if project is not None and project.set_deployment_name(base_name):
+        project.write()
+    instance_args = _instance_args(instances)
     client = obj.client()
 
     # 1. Validate the agent's bound stores (`mason memory/sessions bind` creates them) and build any

--- a/integrations/mason/templates/agent-langgraph/README.md
+++ b/integrations/mason/templates/agent-langgraph/README.md
@@ -238,6 +238,9 @@ Deploy with the [Mason](../../README.md) CLI:
 mason deploy agent-langgraph --source .
 ```
 
+The name is recorded in `agent.toml` on first deploy, so later re-deploys can just be `mason deploy`
+(from the project dir); passing a name again updates it. The app is named `mason-<name>`.
+
 Add `--memory <name> --session <name>` to wire managed state. Mason provisions or resolves the
 stores (creating them if missing), injects the store env vars, and deploys the App. Memory and
 session data are partitioned per signed-in user automatically (see `_actor` in `agent/agent.py`).

--- a/integrations/mason/templates/agent-openai/README.md
+++ b/integrations/mason/templates/agent-openai/README.md
@@ -237,6 +237,9 @@ Deploy with the [Mason](../../README.md) CLI:
 mason deploy agent-openai --source .
 ```
 
+The name is recorded in `agent.toml` on first deploy, so later re-deploys can just be `mason deploy`
+(from the project dir); passing a name again updates it. The app is named `mason-<name>`.
+
 Add `--memory <name> --session <name>` to wire managed state. Mason provisions or resolves the
 stores (creating them if missing), injects the store env vars, and deploys the App. Memory and
 session data are partitioned per signed-in user automatically (see `_actor` in `agent/agent.py`).

--- a/integrations/mason/tests/unit_tests/agent_project_test.py
+++ b/integrations/mason/tests/unit_tests/agent_project_test.py
@@ -126,6 +126,32 @@ def test_bind_and_unbind_stores_round_trip(tmp_path: pathlib.Path):
     assert final.memory_store == "mem"
 
 
+def test_deployment_name_round_trips(tmp_path: pathlib.Path):
+    _write_manifest(tmp_path)
+    project = AgentProject.load(tmp_path)
+    assert project.deployment_name is None
+
+    assert project.set_deployment_name("my-agent") is True
+    assert project.set_deployment_name("my-agent") is False  # idempotent no-op
+    project.write()
+
+    reloaded = AgentProject.load(tmp_path)
+    assert reloaded.deployment_name == "my-agent"
+    assert "# keep me" in (tmp_path / "agent.toml").read_text(encoding="utf-8")
+
+    assert reloaded.set_deployment_name("renamed") is True  # a new name wins
+    reloaded.write()
+    assert AgentProject.load(tmp_path).deployment_name == "renamed"
+
+
+def test_load_rejects_empty_deployment_name(tmp_path: pathlib.Path):
+    _write_manifest(
+        tmp_path, 'schema_version = 1\n\n[agent]\nframework = "openai"\ndeployment_name = ""\n'
+    )
+    with pytest.raises(AgentCliError, match="deployment_name"):
+        AgentProject.load(tmp_path)
+
+
 def test_rebinding_replaces_the_store_name(tmp_path: pathlib.Path):
     _write_manifest(tmp_path)
     project = AgentProject.load(tmp_path)

--- a/integrations/mason/tests/unit_tests/deploy_test.py
+++ b/integrations/mason/tests/unit_tests/deploy_test.py
@@ -647,8 +647,10 @@ def test_lifecycle_commands_honor_json_output(monkeypatch):
         assert json.loads(result.output) == {key: "myapp"}
 
 
-def _agent_toml(source: pathlib.Path, *, memory=None, session=None) -> None:
+def _agent_toml(source: pathlib.Path, *, memory=None, session=None, deployment_name=None) -> None:
     text = 'schema_version = 1\n\n[agent]\nframework = "openai"\n'
+    if deployment_name:
+        text += f'deployment_name = "{deployment_name}"\n'
     if memory:
         text += f'\n[memory_store]\nname = "{memory}"\n'
     if session:
@@ -669,6 +671,65 @@ def test_store_bindings_none_when_unbound(tmp_path: pathlib.Path):
 def test_store_bindings_ignores_missing_manifest(tmp_path: pathlib.Path):
     # No agent.toml -> no stores, never raises (so deploy/dev aren't blocked).
     assert deploy_mod.store_bindings(tmp_path) == (None, None)
+
+
+def test_deploy_writes_deployment_name_to_toml(tmp_path: pathlib.Path, monkeypatch):
+    from databricks_mason.agent_project import AgentProject
+
+    src = tmp_path / "app"
+    src.mkdir()
+    (src / "app.yaml").write_text(yaml.safe_dump({"command": ["x"]}))
+    _agent_toml(src)  # a project with no deployment_name yet
+
+    monkeypatch.setattr(deploy_mod, "_deployment_exists", lambda a, p: True)
+    monkeypatch.setattr(
+        deploy_mod,
+        "_databricks",
+        lambda args, profile, **kw: types.SimpleNamespace(returncode=0, stdout="", stderr=""),
+    )
+
+    result = CliRunner().invoke(deploy_mod.deploy, ["myapp", "--source", str(src)], obj=_FakeCtx())
+
+    assert result.exit_code == 0, result.output
+    assert AgentProject.load(src).deployment_name == "myapp"  # persisted for later deploys
+
+
+def test_deploy_reads_deployment_name_from_toml_when_omitted(tmp_path: pathlib.Path, monkeypatch):
+    src = tmp_path / "app"
+    src.mkdir()
+    (src / "app.yaml").write_text(yaml.safe_dump({"command": ["x"]}))
+    _agent_toml(src, deployment_name="stored")
+
+    calls: list[list[str]] = []
+    monkeypatch.setattr(deploy_mod, "_deployment_exists", lambda a, p: True)
+    monkeypatch.setattr(
+        deploy_mod,
+        "_databricks",
+        lambda args, profile, **kw: (
+            calls.append(args) or types.SimpleNamespace(returncode=0, stdout="", stderr="")
+        ),
+    )
+
+    result = CliRunner().invoke(deploy_mod.deploy, ["--source", str(src)], obj=_FakeCtx())
+
+    assert result.exit_code == 0, result.output
+    ws = "/Workspace/Users/me@example.com/mason_deployments/mason-stored"
+    assert ["apps", "deploy", "mason-stored", "--source-code-path", ws] in calls
+
+
+def test_deploy_without_name_or_toml_errors(tmp_path: pathlib.Path, monkeypatch):
+    src = tmp_path / "app"
+    src.mkdir()
+    (src / "app.yaml").write_text(yaml.safe_dump({"command": ["x"]}))  # no agent.toml
+
+    called: list = []
+    monkeypatch.setattr(deploy_mod, "_databricks", lambda *a, **k: called.append(a))
+
+    result = CliRunner().invoke(deploy_mod.deploy, ["--source", str(src)], obj=_FakeCtx())
+
+    assert result.exit_code != 0
+    assert "No deployment name" in result.output
+    assert called == []  # errored before shelling out to `databricks apps`
 
 
 def test_deploy_grants_bound_store(tmp_path: pathlib.Path, monkeypatch):


### PR DESCRIPTION
## Summary

`mason deploy` required a `NAME` on every invocation. This records the name in `agent.toml` on the first deploy, so subsequent re-deploys from the project directory can be a bare `mason deploy`.

- **`agent.toml` gains `[agent].deployment_name`.** `AgentProject` reads it on `load()` and exposes `set_deployment_name()`. An empty stored value is rejected at load.
- **`mason deploy foo`** validates the name, deploys `mason-foo`, and persists the base name (`foo`) to `agent.toml`.
- **`mason deploy`** (no `NAME`, from the project dir) reads the recorded name. Passing a `NAME` again updates it (the argument is authoritative, so it also serves as a rename).
- **Neither a `NAME` nor a stored one** → a clear error pointing at the one-time `mason deploy <name>`.
- The resolved name is **validated before it's written**, so a bad name never lands in `agent.toml`. When there's no `agent.toml` at all (deploy still tolerates that), `NAME` stays required and nothing is persisted.
- Both template READMEs document the record-once / re-deploy-without-name flow.

The `mason-` app-name prefix (from #526) is unchanged: the stored name is the base name, and `mason-` is applied at deploy time.

## Test plan

- [x] `pytest tests/unit_tests/` — 323 passed. Added `set_deployment_name`/load round-trip + empty-name rejection in `agent_project_test.py`, and deploy tests for (a) name written to toml, (b) name read from toml when omitted, (c) neither → error. Existing tests unchanged.
- [x] `ruff check` / `ruff format --check` — clean

This pull request and its description were written by Isaac.