### PR TITLE
mason: move the databricks CLI wrapper out of store_access

### DIFF
--- a/integrations/mason/src/databricks_mason/databricks_cli.py
+++ b/integrations/mason/src/databricks_mason/databricks_cli.py
@@ -1,0 +1,38 @@
+"""Thin wrapper around the ``databricks`` CLI.
+
+Mason shells out to the ``databricks`` CLI for the operations it doesn't call over the REST client
+(``apps`` lifecycle, ``sync``, ``postgres`` endpoint/credential lookups). This is the single place
+that builds the argv, threads the ``--profile`` through, and normalizes a non-zero exit into an
+``AgentCliError``. Kept separate from any one caller so ``deploy``, ``dev``, and ``store_access``
+share it without importing each other.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from typing import Optional
+
+from databricks_mason.errors import AgentCliError
+
+
+def _databricks(
+    args: list[str],
+    profile: Optional[str],
+    *,
+    capture: bool = False,
+    check: bool = True,
+    cwd: Optional[str] = None,
+    action: Optional[str] = None,
+) -> subprocess.CompletedProcess:
+    cmd = ["databricks", *args]
+    if profile:
+        cmd += ["--profile", profile]
+    result = subprocess.run(cmd, text=True, capture_output=capture, cwd=cwd)
+    if check and result.returncode != 0:
+        # Mason drives the `databricks apps` CLI as an implementation detail; surface a failure in
+        # Mason's own terms (`action`) rather than echoing the raw subcommand and --profile, which
+        # leaks the underlying tool at the customer. The captured stderr still rides along as the
+        # hint so debugging isn't lost.
+        detail = (result.stderr or result.stdout or "").strip() if capture else None
+        raise AgentCliError(action or "A Databricks CLI command failed.", hint=detail)
+    return result

--- a/integrations/mason/src/databricks_mason/deploy.py
+++ b/integrations/mason/src/databricks_mason/deploy.py
@@ -29,10 +29,10 @@ from databricks_mason import (
     session_store_access,
     timefmt,
 )
+from databricks_mason.databricks_cli import _databricks
 from databricks_mason.errors import AgentCliError
 from databricks_mason.render import field
 from databricks_mason.store_access import (
-    _databricks,
     apply_experiment_resource,
     apply_postgres_resources,
     grant_tables,

--- a/integrations/mason/src/databricks_mason/dev.py
+++ b/integrations/mason/src/databricks_mason/dev.py
@@ -17,6 +17,7 @@ import yaml
 
 from databricks_mason import render
 from databricks_mason.agent_project import AgentProject
+from databricks_mason.databricks_cli import _databricks
 from databricks_mason.deploy import (
     _upsert_manifest_env,
     mlflow_tracing_config,
@@ -26,7 +27,6 @@ from databricks_mason.deploy import (
 )
 from databricks_mason.errors import AgentCliError
 from databricks_mason.project_config import load_project_metadata
-from databricks_mason.store_access import _databricks
 
 # Default local port; `databricks apps run-local` listens here unless --app-port overrides it.
 _DEFAULT_APP_PORT = 8000

--- a/integrations/mason/src/databricks_mason/store_access.py
+++ b/integrations/mason/src/databricks_mason/store_access.py
@@ -16,36 +16,12 @@ supply the per-store project/schema/table specifics.
 from __future__ import annotations
 
 import json
-import subprocess
 from dataclasses import dataclass
 from typing import Optional
 
 import psycopg
 
-from databricks_mason.errors import AgentCliError
-
-
-def _databricks(
-    args: list[str],
-    profile: Optional[str],
-    *,
-    capture: bool = False,
-    check: bool = True,
-    cwd: Optional[str] = None,
-    action: Optional[str] = None,
-) -> subprocess.CompletedProcess:
-    cmd = ["databricks", *args]
-    if profile:
-        cmd += ["--profile", profile]
-    result = subprocess.run(cmd, text=True, capture_output=capture, cwd=cwd)
-    if check and result.returncode != 0:
-        # Mason drives the `databricks apps` CLI as an implementation detail; surface a failure in
-        # Mason's own terms (`action`) rather than echoing the raw subcommand and --profile, which
-        # leaks the underlying tool at the customer. The captured stderr still rides along as the
-        # hint so debugging isn't lost.
-        detail = (result.stderr or result.stdout or "").strip() if capture else None
-        raise AgentCliError(action or "A Databricks CLI command failed.", hint=detail)
-    return result
+from databricks_mason.databricks_cli import _databricks
 
 
 @dataclass(frozen=True)

--- a/integrations/mason/tests/unit_tests/databricks_cli_test.py
+++ b/integrations/mason/tests/unit_tests/databricks_cli_test.py
@@ -1,0 +1,41 @@
+"""Unit tests for the databricks CLI wrapper (`_databricks`)."""
+
+from __future__ import annotations
+
+import types
+
+from databricks_mason import databricks_cli as dc
+
+
+def test_databricks_failure_hides_the_apps_subcommand(monkeypatch):
+    # Mason drives `databricks apps` as an implementation detail; a failure must be reported in
+    # Mason's terms (the `action`) and must NOT echo the raw subcommand or --profile at the customer.
+    def fake_run(cmd, **kw):
+        return types.SimpleNamespace(returncode=1, stdout="", stderr="boom from the CLI")
+
+    monkeypatch.setattr(dc.subprocess, "run", fake_run)
+    try:
+        dc._databricks(
+            ["apps", "run-local", "--prepare-environment"],
+            "e2-dogfood",
+            capture=True,
+            action="Could not start the agent locally.",
+        )
+        raise AssertionError("expected AgentCliError")
+    except dc.AgentCliError as exc:
+        assert exc.message == "Could not start the agent locally."
+        assert "apps" not in exc.message and "e2-dogfood" not in exc.message  # no leak
+        assert exc.hint == "boom from the CLI"  # underlying stderr preserved for debugging
+
+
+def test_databricks_failure_without_action_is_generic(monkeypatch):
+    # No action label: still no raw subcommand/profile echo — just a generic message.
+    def fake_run(cmd, **kw):
+        return types.SimpleNamespace(returncode=1, stdout="", stderr="err")
+
+    monkeypatch.setattr(dc.subprocess, "run", fake_run)
+    try:
+        dc._databricks(["apps", "deploy", "x"], "prof", capture=True)
+        raise AssertionError("expected AgentCliError")
+    except dc.AgentCliError as exc:
+        assert "apps" not in exc.message and "prof" not in exc.message

--- a/integrations/mason/tests/unit_tests/store_access_test.py
+++ b/integrations/mason/tests/unit_tests/store_access_test.py
@@ -33,40 +33,6 @@ def test_memory_backend_targets_memory_entries():
     assert b.resource_name == "postgres-memory"  # distinct name so both stores coexist on one app
 
 
-def test_databricks_failure_hides_the_apps_subcommand(monkeypatch):
-    # Mason drives `databricks apps` as an implementation detail; a failure must be reported in
-    # Mason's terms (the `action`) and must NOT echo the raw subcommand or --profile at the customer.
-    def fake_run(cmd, **kw):
-        return types.SimpleNamespace(returncode=1, stdout="", stderr="boom from the CLI")
-
-    monkeypatch.setattr(sa.subprocess, "run", fake_run)
-    try:
-        sa._databricks(
-            ["apps", "run-local", "--prepare-environment"],
-            "e2-dogfood",
-            capture=True,
-            action="Could not start the agent locally.",
-        )
-        raise AssertionError("expected AgentCliError")
-    except sa.AgentCliError as exc:
-        assert exc.message == "Could not start the agent locally."
-        assert "apps" not in exc.message and "e2-dogfood" not in exc.message  # no leak
-        assert exc.hint == "boom from the CLI"  # underlying stderr preserved for debugging
-
-
-def test_databricks_failure_without_action_is_generic(monkeypatch):
-    # No action label: still no raw subcommand/profile echo — just a generic message.
-    def fake_run(cmd, **kw):
-        return types.SimpleNamespace(returncode=1, stdout="", stderr="err")
-
-    monkeypatch.setattr(sa.subprocess, "run", fake_run)
-    try:
-        sa._databricks(["apps", "deploy", "x"], "prof", capture=True)
-        raise AssertionError("expected AgentCliError")
-    except sa.AgentCliError as exc:
-        assert "apps" not in exc.message and "prof" not in exc.message
-
-
 def test_apply_postgres_resources_sends_all_backends_in_one_update(monkeypatch):
     captured = {}
 


### PR DESCRIPTION
_databricks (the generic 'shell out to the databricks CLI' helper) lived in store_access.py only because that was the first module to need it. deploy and dev then imported it from there, coupling unrelated modules — mason dev has nothing to do with store-access grants. Move it to a neutral databricks_cli module that store_access, deploy, and dev all import from. No behavior change.