### PR TITLE
[mason] Deploy apps with `agent-mason-` prefix instead of `mason-`

### DIFF
--- a/integrations/mason/src/databricks_mason/deploy.py
+++ b/integrations/mason/src/databricks_mason/deploy.py
@@ -44,9 +44,10 @@ _DEFAULT_PIP_INDEX_URL = "https://pypi.org/simple/"
 _PIP_INDEX_ENVS = ("PIP_INDEX_URL", "UV_INDEX_URL", "UV_DEFAULT_INDEX")
 _AGENT_COMPUTE_OUTPUT = ("App compute", "Agent compute")
 
-# Mason names every deployment `agent-<name>` so `deployments list` can filter to its own apps.
-# The `agent-` prefix is also what the Databricks agent registry keys on to surface these apps.
-_DEPLOYMENT_PREFIX = "agent-"
+# Mason names every deployment `agent-mason-<name>` so `deployments list` can filter to its own apps.
+# The `agent-` prefix is what the Databricks agent registry keys on to surface these apps; the
+# `-mason-` segment narrows `deployments list` to Mason's own agents, not every `agent-*` app.
+_DEPLOYMENT_PREFIX = "agent-mason-"
 _MAX_DEPLOYMENT_NAME_LEN = 30  # Databricks Apps name limit
 
 
@@ -125,7 +126,7 @@ def _instance_args(instances: Optional[int]) -> list[str]:
 
 
 def _prefixed_name(name: str) -> str:
-    """Mason deployments carry an `agent-` prefix so `deployments list` can find only its own apps."""
+    """Mason deployments carry an `agent-mason-` prefix so `deployments list` finds only its own apps."""
     return name if name.startswith(_DEPLOYMENT_PREFIX) else f"{_DEPLOYMENT_PREFIX}{name}"
 
 
@@ -413,7 +414,7 @@ def deploy(
     """Deploy an agent: validate its bound stores, wire in tracing, and roll out the deployment.
 
     NAME is recorded in agent.toml on first deploy, so later `mason deploy` (from the project dir)
-    can omit it; passing NAME again updates the recorded name. The app is named `agent-<name>`
+    can omit it; passing NAME again updates the recorded name. The app is named `agent-mason-<name>`
     (Mason adds the prefix if absent); use that full name with the other `mason deployments` verbs.
     `deployments list` shows only apps carrying this prefix.
 
@@ -627,7 +628,7 @@ def _deployment_status(a: dict) -> Optional[str]:
 @deployments.command("list")
 @click.pass_obj
 def deployments_list(obj) -> None:
-    """List Mason agent deployments (apps named `agent-*`) in the workspace."""
+    """List Mason agent deployments (apps named `agent-mason-*`) in the workspace."""
     result = _databricks(
         ["apps", "list", "-o", "json"],
         obj.profile,

--- a/integrations/mason/src/databricks_mason/deploy.py
+++ b/integrations/mason/src/databricks_mason/deploy.py
@@ -44,8 +44,9 @@ _DEFAULT_PIP_INDEX_URL = "https://pypi.org/simple/"
 _PIP_INDEX_ENVS = ("PIP_INDEX_URL", "UV_INDEX_URL", "UV_DEFAULT_INDEX")
 _AGENT_COMPUTE_OUTPUT = ("App compute", "Agent compute")
 
-# Mason names every deployment `mason-<name>` so `deployments list` can filter to its own apps.
-_DEPLOYMENT_PREFIX = "mason-"
+# Mason names every deployment `agent-<name>` so `deployments list` can filter to its own apps.
+# The `agent-` prefix is also what the Databricks agent registry keys on to surface these apps.
+_DEPLOYMENT_PREFIX = "agent-"
 _MAX_DEPLOYMENT_NAME_LEN = 30  # Databricks Apps name limit
 
 
@@ -124,7 +125,7 @@ def _instance_args(instances: Optional[int]) -> list[str]:
 
 
 def _prefixed_name(name: str) -> str:
-    """Mason deployments carry a `mason-` prefix so `deployments list` can find only its own apps."""
+    """Mason deployments carry an `agent-` prefix so `deployments list` can find only its own apps."""
     return name if name.startswith(_DEPLOYMENT_PREFIX) else f"{_DEPLOYMENT_PREFIX}{name}"
 
 
@@ -412,7 +413,7 @@ def deploy(
     """Deploy an agent: validate its bound stores, wire in tracing, and roll out the deployment.
 
     NAME is recorded in agent.toml on first deploy, so later `mason deploy` (from the project dir)
-    can omit it; passing NAME again updates the recorded name. The app is named `mason-<name>`
+    can omit it; passing NAME again updates the recorded name. The app is named `agent-<name>`
     (Mason adds the prefix if absent); use that full name with the other `mason deployments` verbs.
     `deployments list` shows only apps carrying this prefix.
 
@@ -626,7 +627,7 @@ def _deployment_status(a: dict) -> Optional[str]:
 @deployments.command("list")
 @click.pass_obj
 def deployments_list(obj) -> None:
-    """List Mason agent deployments (apps named `mason-*`) in the workspace."""
+    """List Mason agent deployments (apps named `agent-*`) in the workspace."""
     result = _databricks(
         ["apps", "list", "-o", "json"],
         obj.profile,

--- a/integrations/mason/src/databricks_mason/help.py
+++ b/integrations/mason/src/databricks_mason/help.py
@@ -189,14 +189,20 @@ _EXAMPLES: dict[CommandPath, tuple[Example, ...]] = {
     ),
     ("deployments",): (("mason deployments list", "list agent deployments"),),
     ("deployments", "list"): (("mason deployments list", "list agent deployments"),),
-    ("deployments", "get"): (("mason deployments get agent-my-agent", "show one deployment"),),
-    ("deployments", "logs"): (
-        ("mason deployments logs agent-my-agent", "stream a deployment's logs"),
+    ("deployments", "get"): (
+        ("mason deployments get agent-mason-my-agent", "show one deployment"),
     ),
-    ("deployments", "start"): (("mason deployments start agent-my-agent", "start a deployment"),),
-    ("deployments", "stop"): (("mason deployments stop agent-my-agent", "stop a deployment"),),
+    ("deployments", "logs"): (
+        ("mason deployments logs agent-mason-my-agent", "stream a deployment's logs"),
+    ),
+    ("deployments", "start"): (
+        ("mason deployments start agent-mason-my-agent", "start a deployment"),
+    ),
+    ("deployments", "stop"): (
+        ("mason deployments stop agent-mason-my-agent", "stop a deployment"),
+    ),
     ("deployments", "delete"): (
-        ("mason deployments delete agent-my-agent", "delete a deployment"),
+        ("mason deployments delete agent-mason-my-agent", "delete a deployment"),
     ),
     ("tools",): (
         ("mason tools add --help", "see all tool types you can add"),

--- a/integrations/mason/src/databricks_mason/help.py
+++ b/integrations/mason/src/databricks_mason/help.py
@@ -189,14 +189,14 @@ _EXAMPLES: dict[CommandPath, tuple[Example, ...]] = {
     ),
     ("deployments",): (("mason deployments list", "list agent deployments"),),
     ("deployments", "list"): (("mason deployments list", "list agent deployments"),),
-    ("deployments", "get"): (("mason deployments get mason-my-agent", "show one deployment"),),
+    ("deployments", "get"): (("mason deployments get agent-my-agent", "show one deployment"),),
     ("deployments", "logs"): (
-        ("mason deployments logs mason-my-agent", "stream a deployment's logs"),
+        ("mason deployments logs agent-my-agent", "stream a deployment's logs"),
     ),
-    ("deployments", "start"): (("mason deployments start mason-my-agent", "start a deployment"),),
-    ("deployments", "stop"): (("mason deployments stop mason-my-agent", "stop a deployment"),),
+    ("deployments", "start"): (("mason deployments start agent-my-agent", "start a deployment"),),
+    ("deployments", "stop"): (("mason deployments stop agent-my-agent", "stop a deployment"),),
     ("deployments", "delete"): (
-        ("mason deployments delete mason-my-agent", "delete a deployment"),
+        ("mason deployments delete agent-my-agent", "delete a deployment"),
     ),
     ("tools",): (
         ("mason tools add --help", "see all tool types you can add"),

--- a/integrations/mason/tests/unit_tests/deploy_bugfix_test.py
+++ b/integrations/mason/tests/unit_tests/deploy_bugfix_test.py
@@ -38,19 +38,25 @@ def test_validate_deployment_name_rejects_too_long():
         deploy_mod._validate_deployment_name("mason-" + "a" * 25)  # 31 chars
 
 
-# --- `agent-` deployment prefix + list filtering -----------------------------
+# --- `agent-mason-` deployment prefix + list filtering -----------------------------
 
 
 def test_prefixed_name_adds_prefix_when_absent():
-    assert deploy_mod._prefixed_name("foo") == "agent-foo"
+    assert deploy_mod._prefixed_name("foo") == "agent-mason-foo"
 
 
 def test_prefixed_name_is_idempotent():
-    assert deploy_mod._prefixed_name("agent-foo") == "agent-foo"
+    assert deploy_mod._prefixed_name("agent-mason-foo") == "agent-mason-foo"
 
 
 def test_deployments_list_shows_only_agent_apps(monkeypatch):
-    apps = {"apps": [{"name": "agent-foo"}, {"name": "someone-else-app"}, {"name": "agent-bar"}]}
+    apps = {
+        "apps": [
+            {"name": "agent-mason-foo"},
+            {"name": "someone-else-app"},
+            {"name": "agent-mason-bar"},
+        ]
+    }
     monkeypatch.setattr(
         deploy_mod,
         "_databricks",
@@ -64,7 +70,7 @@ def test_deployments_list_shows_only_agent_apps(monkeypatch):
     result = CliRunner().invoke(deploy_mod.deployments_list, [], obj=_JsonCtx())
     assert result.exit_code == 0, result.output
     names = {a["name"] for a in json.loads(result.output)}
-    assert names == {"agent-foo", "agent-bar"}
+    assert names == {"agent-mason-foo", "agent-mason-bar"}
 
 
 def test_deployments_get_rejects_empty_name_without_calling_cli(monkeypatch):

--- a/integrations/mason/tests/unit_tests/deploy_bugfix_test.py
+++ b/integrations/mason/tests/unit_tests/deploy_bugfix_test.py
@@ -38,19 +38,19 @@ def test_validate_deployment_name_rejects_too_long():
         deploy_mod._validate_deployment_name("mason-" + "a" * 25)  # 31 chars
 
 
-# --- `mason-` deployment prefix + list filtering -----------------------------
+# --- `agent-` deployment prefix + list filtering -----------------------------
 
 
 def test_prefixed_name_adds_prefix_when_absent():
-    assert deploy_mod._prefixed_name("foo") == "mason-foo"
+    assert deploy_mod._prefixed_name("foo") == "agent-foo"
 
 
 def test_prefixed_name_is_idempotent():
-    assert deploy_mod._prefixed_name("mason-foo") == "mason-foo"
+    assert deploy_mod._prefixed_name("agent-foo") == "agent-foo"
 
 
-def test_deployments_list_shows_only_mason_apps(monkeypatch):
-    apps = {"apps": [{"name": "mason-foo"}, {"name": "someone-else-app"}, {"name": "mason-bar"}]}
+def test_deployments_list_shows_only_agent_apps(monkeypatch):
+    apps = {"apps": [{"name": "agent-foo"}, {"name": "someone-else-app"}, {"name": "agent-bar"}]}
     monkeypatch.setattr(
         deploy_mod,
         "_databricks",
@@ -64,7 +64,7 @@ def test_deployments_list_shows_only_mason_apps(monkeypatch):
     result = CliRunner().invoke(deploy_mod.deployments_list, [], obj=_JsonCtx())
     assert result.exit_code == 0, result.output
     names = {a["name"] for a in json.loads(result.output)}
-    assert names == {"mason-foo", "mason-bar"}
+    assert names == {"agent-foo", "agent-bar"}
 
 
 def test_deployments_get_rejects_empty_name_without_calling_cli(monkeypatch):

--- a/integrations/mason/tests/unit_tests/deploy_test.py
+++ b/integrations/mason/tests/unit_tests/deploy_test.py
@@ -169,11 +169,11 @@ def test_deploy_drives_sync_and_apps_deploy(tmp_path: pathlib.Path, monkeypatch)
     )
 
     assert result.exit_code == 0, result.output
-    # Mason prefixes the app name with `mason-` so `deployments list` can find its own apps.
-    ws = "/Workspace/Users/me@example.com/mason_deployments/mason-myapp"
+    # Mason prefixes the app name with `agent-` so `deployments list` can find its own apps.
+    ws = "/Workspace/Users/me@example.com/mason_deployments/agent-myapp"
     # uv.lock is excluded so the build resolves fresh against its own index (not the dev machine's).
     assert ["sync", str(src), ws, "--exclude", "uv.lock"] in calls
-    assert ["apps", "deploy", "mason-myapp", "--source-code-path", ws] in calls
+    assert ["apps", "deploy", "agent-myapp", "--source-code-path", ws] in calls
     # Stores are read from agent.toml at runtime, so deploy does NOT write store env into app.yaml.
     env_entries = yaml.safe_load((src / "app.yaml").read_text()).get("env") or []
     env = {e["name"]: e["value"] for e in env_entries}
@@ -206,7 +206,7 @@ def test_deploy_creates_with_instance_count(tmp_path: pathlib.Path, monkeypatch)
         [
             "apps",
             "create",
-            "mason-myapp",
+            "agent-myapp",
             "--compute-min-instances",
             "2",
             "--compute-max-instances",
@@ -214,7 +214,7 @@ def test_deploy_creates_with_instance_count(tmp_path: pathlib.Path, monkeypatch)
         ],
         {
             "capture": True,
-            "action": "Could not create deployment 'mason-myapp'.",
+            "action": "Could not create deployment 'agent-myapp'.",
         },
     ) in calls
 
@@ -241,11 +241,11 @@ def test_deploy_updates_existing_instance_count(tmp_path: pathlib.Path, monkeypa
 
     assert result.exit_code == 0, result.output
     update_args, update_kwargs = next(
-        call for call in calls if call[0][:3] == ["apps", "create-update", "mason-myapp"]
+        call for call in calls if call[0][:3] == ["apps", "create-update", "agent-myapp"]
     )
     assert update_kwargs == {
         "capture": True,
-        "action": "Could not update deployment 'mason-myapp'.",
+        "action": "Could not update deployment 'agent-myapp'.",
     }
     payload = json.loads(update_args[update_args.index("--json") + 1])
     assert payload == {
@@ -352,7 +352,7 @@ def test_deploy_durability_binding_reuses_session_store_before_startup(
     assert [event[0] for event in events] == ["attach", "deploy"]
     backend = events[0][1][0]
     assert backend.database == "sessions"
-    assert backend.schema == deploy_mod.lakebase_durability_store.get_lakebase_schema("mason-myapp")
+    assert backend.schema == deploy_mod.lakebase_durability_store.get_lakebase_schema("agent-myapp")
     assert backend.tables == ()
     env = {
         entry["name"]: entry["value"]
@@ -360,7 +360,7 @@ def test_deploy_durability_binding_reuses_session_store_before_startup(
     }
     assert env["DATABRICKS_MASON_RUNTIME_ENDPOINT"] == backend.endpoint_path
     assert env["DATABRICKS_MASON_RUNTIME_SCHEMA"] == (
-        deploy_mod.lakebase_durability_store.get_lakebase_schema("mason-myapp")
+        deploy_mod.lakebase_durability_store.get_lakebase_schema("agent-myapp")
     )
 
 
@@ -371,7 +371,7 @@ def test_deploy_durability_binding_does_not_reuse_memory_store(
     src.mkdir()
     (src / "app.yaml").write_text(yaml.safe_dump({"command": ["x"]}))
     _write_agent_manifest(src, durability=True, memory="mem")
-    selected = deploy_mod.lakebase_durability_store.backend("mason-myapp")
+    selected = deploy_mod.lakebase_durability_store.backend("agent-myapp")
     events = []
 
     monkeypatch.setattr(deploy_mod, "_deployment_exists", lambda a, p: True)
@@ -437,9 +437,9 @@ def test_deploy_renames_underlying_app_compute_output(tmp_path: pathlib.Path, mo
     # reported in Mason's terms instead of echoing the raw `databricks apps` command.
     assert apps_calls[0][1] == {
         "capture": True,
-        "action": "Could not create deployment 'mason-myapp'.",
+        "action": "Could not create deployment 'agent-myapp'.",
     }
-    assert apps_calls[1][1] == {"action": "Could not deploy 'mason-myapp'."}
+    assert apps_calls[1][1] == {"action": "Could not deploy 'agent-myapp'."}
     assert "Agent compute is starting" in result.output
     assert "App compute" not in result.output
     get_call = next(call for call in calls if call[0][:2] == ["apps", "get"])
@@ -494,7 +494,7 @@ def test_deploy_sync_keeps_directly_edited_agent_manifest(tmp_path: pathlib.Path
     assert sync[:3] == [
         "sync",
         str(src),
-        "/Workspace/Users/me@example.com/mason_deployments/mason-myapp",
+        "/Workspace/Users/me@example.com/mason_deployments/agent-myapp",
     ]
     excluded = {sync[index + 1] for index, value in enumerate(sync[:-1]) if value == "--exclude"}
     assert "agent.toml" not in excluded
@@ -527,7 +527,7 @@ def test_first_deploy_waits_for_running_before_deploying(tmp_path: pathlib.Path,
     result = CliRunner().invoke(deploy_mod.deploy, ["myapp", "--source", str(src)], obj=_FakeCtx())
 
     assert result.exit_code == 0, result.output
-    assert ["apps", "create", "mason-myapp"] in calls
+    assert ["apps", "create", "agent-myapp"] in calls
     assert waited["called"], "must wait for the new app to be running before deploying"
 
 
@@ -556,7 +556,7 @@ def test_redeploy_waits_for_running_and_skips_create(tmp_path: pathlib.Path, mon
     result = CliRunner().invoke(deploy_mod.deploy, ["myapp", "--source", str(src)], obj=_FakeCtx())
 
     assert result.exit_code == 0, result.output
-    assert ["apps", "create", "mason-myapp"] not in calls  # never re-create an existing app
+    assert ["apps", "create", "agent-myapp"] not in calls  # never re-create an existing app
     assert waited["called"], "re-deploy must also wait for compute"
 
 
@@ -883,8 +883,8 @@ def test_deploy_reads_deployment_name_from_toml_when_omitted(tmp_path: pathlib.P
     result = CliRunner().invoke(deploy_mod.deploy, ["--source", str(src)], obj=_FakeCtx())
 
     assert result.exit_code == 0, result.output
-    ws = "/Workspace/Users/me@example.com/mason_deployments/mason-stored"
-    assert ["apps", "deploy", "mason-stored", "--source-code-path", ws] in calls
+    ws = "/Workspace/Users/me@example.com/mason_deployments/agent-stored"
+    assert ["apps", "deploy", "agent-stored", "--source-code-path", ws] in calls
 
 
 def test_deploy_without_name_or_toml_errors(tmp_path: pathlib.Path, monkeypatch):

--- a/integrations/mason/tests/unit_tests/deploy_test.py
+++ b/integrations/mason/tests/unit_tests/deploy_test.py
@@ -169,11 +169,11 @@ def test_deploy_drives_sync_and_apps_deploy(tmp_path: pathlib.Path, monkeypatch)
     )
 
     assert result.exit_code == 0, result.output
-    # Mason prefixes the app name with `agent-` so `deployments list` can find its own apps.
-    ws = "/Workspace/Users/me@example.com/mason_deployments/agent-myapp"
+    # Mason prefixes the app name with `agent-mason-` so `deployments list` can find its own apps.
+    ws = "/Workspace/Users/me@example.com/mason_deployments/agent-mason-myapp"
     # uv.lock is excluded so the build resolves fresh against its own index (not the dev machine's).
     assert ["sync", str(src), ws, "--exclude", "uv.lock"] in calls
-    assert ["apps", "deploy", "agent-myapp", "--source-code-path", ws] in calls
+    assert ["apps", "deploy", "agent-mason-myapp", "--source-code-path", ws] in calls
     # Stores are read from agent.toml at runtime, so deploy does NOT write store env into app.yaml.
     env_entries = yaml.safe_load((src / "app.yaml").read_text()).get("env") or []
     env = {e["name"]: e["value"] for e in env_entries}
@@ -206,7 +206,7 @@ def test_deploy_creates_with_instance_count(tmp_path: pathlib.Path, monkeypatch)
         [
             "apps",
             "create",
-            "agent-myapp",
+            "agent-mason-myapp",
             "--compute-min-instances",
             "2",
             "--compute-max-instances",
@@ -214,7 +214,7 @@ def test_deploy_creates_with_instance_count(tmp_path: pathlib.Path, monkeypatch)
         ],
         {
             "capture": True,
-            "action": "Could not create deployment 'agent-myapp'.",
+            "action": "Could not create deployment 'agent-mason-myapp'.",
         },
     ) in calls
 
@@ -241,11 +241,11 @@ def test_deploy_updates_existing_instance_count(tmp_path: pathlib.Path, monkeypa
 
     assert result.exit_code == 0, result.output
     update_args, update_kwargs = next(
-        call for call in calls if call[0][:3] == ["apps", "create-update", "agent-myapp"]
+        call for call in calls if call[0][:3] == ["apps", "create-update", "agent-mason-myapp"]
     )
     assert update_kwargs == {
         "capture": True,
-        "action": "Could not update deployment 'agent-myapp'.",
+        "action": "Could not update deployment 'agent-mason-myapp'.",
     }
     payload = json.loads(update_args[update_args.index("--json") + 1])
     assert payload == {
@@ -352,7 +352,9 @@ def test_deploy_durability_binding_reuses_session_store_before_startup(
     assert [event[0] for event in events] == ["attach", "deploy"]
     backend = events[0][1][0]
     assert backend.database == "sessions"
-    assert backend.schema == deploy_mod.lakebase_durability_store.get_lakebase_schema("agent-myapp")
+    assert backend.schema == deploy_mod.lakebase_durability_store.get_lakebase_schema(
+        "agent-mason-myapp"
+    )
     assert backend.tables == ()
     env = {
         entry["name"]: entry["value"]
@@ -360,7 +362,7 @@ def test_deploy_durability_binding_reuses_session_store_before_startup(
     }
     assert env["DATABRICKS_MASON_RUNTIME_ENDPOINT"] == backend.endpoint_path
     assert env["DATABRICKS_MASON_RUNTIME_SCHEMA"] == (
-        deploy_mod.lakebase_durability_store.get_lakebase_schema("agent-myapp")
+        deploy_mod.lakebase_durability_store.get_lakebase_schema("agent-mason-myapp")
     )
 
 
@@ -371,7 +373,7 @@ def test_deploy_durability_binding_does_not_reuse_memory_store(
     src.mkdir()
     (src / "app.yaml").write_text(yaml.safe_dump({"command": ["x"]}))
     _write_agent_manifest(src, durability=True, memory="mem")
-    selected = deploy_mod.lakebase_durability_store.backend("agent-myapp")
+    selected = deploy_mod.lakebase_durability_store.backend("agent-mason-myapp")
     events = []
 
     monkeypatch.setattr(deploy_mod, "_deployment_exists", lambda a, p: True)
@@ -437,9 +439,9 @@ def test_deploy_renames_underlying_app_compute_output(tmp_path: pathlib.Path, mo
     # reported in Mason's terms instead of echoing the raw `databricks apps` command.
     assert apps_calls[0][1] == {
         "capture": True,
-        "action": "Could not create deployment 'agent-myapp'.",
+        "action": "Could not create deployment 'agent-mason-myapp'.",
     }
-    assert apps_calls[1][1] == {"action": "Could not deploy 'agent-myapp'."}
+    assert apps_calls[1][1] == {"action": "Could not deploy 'agent-mason-myapp'."}
     assert "Agent compute is starting" in result.output
     assert "App compute" not in result.output
     get_call = next(call for call in calls if call[0][:2] == ["apps", "get"])
@@ -494,7 +496,7 @@ def test_deploy_sync_keeps_directly_edited_agent_manifest(tmp_path: pathlib.Path
     assert sync[:3] == [
         "sync",
         str(src),
-        "/Workspace/Users/me@example.com/mason_deployments/agent-myapp",
+        "/Workspace/Users/me@example.com/mason_deployments/agent-mason-myapp",
     ]
     excluded = {sync[index + 1] for index, value in enumerate(sync[:-1]) if value == "--exclude"}
     assert "agent.toml" not in excluded
@@ -527,7 +529,7 @@ def test_first_deploy_waits_for_running_before_deploying(tmp_path: pathlib.Path,
     result = CliRunner().invoke(deploy_mod.deploy, ["myapp", "--source", str(src)], obj=_FakeCtx())
 
     assert result.exit_code == 0, result.output
-    assert ["apps", "create", "agent-myapp"] in calls
+    assert ["apps", "create", "agent-mason-myapp"] in calls
     assert waited["called"], "must wait for the new app to be running before deploying"
 
 
@@ -556,7 +558,7 @@ def test_redeploy_waits_for_running_and_skips_create(tmp_path: pathlib.Path, mon
     result = CliRunner().invoke(deploy_mod.deploy, ["myapp", "--source", str(src)], obj=_FakeCtx())
 
     assert result.exit_code == 0, result.output
-    assert ["apps", "create", "agent-myapp"] not in calls  # never re-create an existing app
+    assert ["apps", "create", "agent-mason-myapp"] not in calls  # never re-create an existing app
     assert waited["called"], "re-deploy must also wait for compute"
 
 
@@ -883,8 +885,8 @@ def test_deploy_reads_deployment_name_from_toml_when_omitted(tmp_path: pathlib.P
     result = CliRunner().invoke(deploy_mod.deploy, ["--source", str(src)], obj=_FakeCtx())
 
     assert result.exit_code == 0, result.output
-    ws = "/Workspace/Users/me@example.com/mason_deployments/agent-stored"
-    assert ["apps", "deploy", "agent-stored", "--source-code-path", ws] in calls
+    ws = "/Workspace/Users/me@example.com/mason_deployments/agent-mason-stored"
+    assert ["apps", "deploy", "agent-mason-stored", "--source-code-path", ws] in calls
 
 
 def test_deploy_without_name_or_toml_errors(tmp_path: pathlib.Path, monkeypatch):


### PR DESCRIPTION
## What

Mason names every deployment with a fixed prefix so `deployments list` can filter the workspace's apps down to its own. This PR switches that prefix from `mason-` to **`agent-mason-`**.

## Why

Our platform's **agent registry hardcodes the `agent-*` name prefix** to decide which Apps to surface. Deploying under `mason-*` means Mason-built agents never show up there.

`agent-mason-` threads two goals at once:
- The `agent-` head still matches the registry's `agent-*` glob, so deployed agents appear in the registry.
- The `-mason-` segment keeps the prefix specific to Mason, so `mason deployments list` won't scoop up unrelated `agent-*` apps deployed from non-Mason sources.

## How

- Flips the single `_DEPLOYMENT_PREFIX` constant in `deploy.py`. It drives both the name Mason assigns on deploy (`_prefixed_name`) and the filter `deployments list` applies, so the two stay consistent.
- Updates command help examples, docstrings, and unit tests to match.
- The `mason_deployments/` workspace folder and the `mason-traces` MLflow experiment path are separate concerns and are left unchanged.

## Compatibility note

The prefix is applied at deploy time and used to filter `deployments list`. Apps already deployed under the old `mason-` prefix will no longer appear in `mason deployments list`, and re-deploying an existing agent creates a new `agent-mason-<name>` app rather than updating the `mason-<name>` one. Given the registry requirement this is intended; existing deployments can be redeployed to pick up the new name.

Note the added prefix is longer (`agent-mason-`, 12 chars) than before, so slightly less of the 30-char Databricks app-name budget is left for the user-chosen name; `_validate_deployment_name` already enforces the cap against the full prefixed name.

## Testing

- `uv run --group tests pytest tests/` — 406 passed, 1 pre-existing failure unrelated to this change (`test_langgraph_runtime_loads_direct_manifest_and_protects_sandbox_meta`, the known `custom_headers` fake-client issue on `main`).
- `uv run ruff check` / `ruff format --check` — clean.
- `uv run ty check` — clean.

This pull request and its description were written by Isaac.