### PR TITLE
mason: load .env with override=False in template runtimes

### DIFF
--- a/integrations/mason/templates/agent-langgraph/runtime/main.py
+++ b/integrations/mason/templates/agent-langgraph/runtime/main.py
@@ -10,7 +10,10 @@ from dotenv import load_dotenv
 
 from databricks_mason import AgentApp
 
-load_dotenv(dotenv_path=Path(__file__).parent.parent / ".env", override=True)
+# .env fills unset config only; the real environment wins (override=False). `mason dev -p` and
+# the deploy platform inject DATABRICKS_* into the process, and a checked-in .env must not clobber
+# them — overriding only the profile while leaving the injected host mismatches host and credential.
+load_dotenv(dotenv_path=Path(__file__).parent.parent / ".env", override=False)
 agent.agent.configure()
 
 DURABLE_RUNTIME = True

--- a/integrations/mason/templates/agent-langgraph/runtime/main.py
+++ b/integrations/mason/templates/agent-langgraph/runtime/main.py
@@ -10,9 +10,8 @@ from dotenv import load_dotenv
 
 from databricks_mason import AgentApp
 
-# .env fills unset config only; the real environment wins (override=False). `mason dev -p` and
-# the deploy platform inject DATABRICKS_* into the process, and a checked-in .env must not clobber
-# them — overriding only the profile while leaving the injected host mismatches host and credential.
+# override=False so injected DATABRICKS_* (from `mason dev -p` or the deploy platform) win over a
+# checked-in .env, which otherwise overrides the profile but not the host and breaks auth.
 load_dotenv(dotenv_path=Path(__file__).parent.parent / ".env", override=False)
 agent.agent.configure()
 

--- a/integrations/mason/templates/agent-langgraph/runtime/main.py
+++ b/integrations/mason/templates/agent-langgraph/runtime/main.py
@@ -11,7 +11,7 @@ from dotenv import load_dotenv
 from databricks_mason import AgentApp
 
 # override=False so injected DATABRICKS_* (from `mason dev -p` or the deploy platform) win over a
-# checked-in .env, which otherwise overrides the profile but not the host and breaks auth.
+# checked-in .env.
 load_dotenv(dotenv_path=Path(__file__).parent.parent / ".env", override=False)
 agent.agent.configure()
 

--- a/integrations/mason/templates/agent-openai/runtime/main.py
+++ b/integrations/mason/templates/agent-openai/runtime/main.py
@@ -10,7 +10,10 @@ from dotenv import load_dotenv
 
 from databricks_mason import AgentApp
 
-load_dotenv(dotenv_path=Path(__file__).parent.parent / ".env", override=True)
+# .env fills unset config only; the real environment wins (override=False). `mason dev -p` and
+# the deploy platform inject DATABRICKS_* into the process, and a checked-in .env must not clobber
+# them — overriding only the profile while leaving the injected host mismatches host and credential.
+load_dotenv(dotenv_path=Path(__file__).parent.parent / ".env", override=False)
 agent.agent.configure()
 
 DURABLE_RUNTIME = True

--- a/integrations/mason/templates/agent-openai/runtime/main.py
+++ b/integrations/mason/templates/agent-openai/runtime/main.py
@@ -10,9 +10,8 @@ from dotenv import load_dotenv
 
 from databricks_mason import AgentApp
 
-# .env fills unset config only; the real environment wins (override=False). `mason dev -p` and
-# the deploy platform inject DATABRICKS_* into the process, and a checked-in .env must not clobber
-# them — overriding only the profile while leaving the injected host mismatches host and credential.
+# override=False so injected DATABRICKS_* (from `mason dev -p` or the deploy platform) win over a
+# checked-in .env, which otherwise overrides the profile but not the host and breaks auth.
 load_dotenv(dotenv_path=Path(__file__).parent.parent / ".env", override=False)
 agent.agent.configure()
 

--- a/integrations/mason/templates/agent-openai/runtime/main.py
+++ b/integrations/mason/templates/agent-openai/runtime/main.py
@@ -11,7 +11,7 @@ from dotenv import load_dotenv
 from databricks_mason import AgentApp
 
 # override=False so injected DATABRICKS_* (from `mason dev -p` or the deploy platform) win over a
-# checked-in .env, which otherwise overrides the profile but not the host and breaks auth.
+# checked-in .env.
 load_dotenv(dotenv_path=Path(__file__).parent.parent / ".env", override=False)
 agent.agent.configure()
 

--- a/integrations/mason/templates/custom-agent-langgraph/runtime/main.py
+++ b/integrations/mason/templates/custom-agent-langgraph/runtime/main.py
@@ -8,7 +8,10 @@ from dotenv import load_dotenv
 from fastapi import FastAPI
 from pydantic import BaseModel, ConfigDict, Field
 
-load_dotenv(dotenv_path=Path(__file__).parent.parent / ".env", override=True)
+# .env fills unset config only; the real environment wins (override=False). `mason dev -p` and
+# the deploy platform inject DATABRICKS_* into the process, and a checked-in .env must not clobber
+# them — overriding only the profile while leaving the injected host mismatches host and credential.
+load_dotenv(dotenv_path=Path(__file__).parent.parent / ".env", override=False)
 
 
 class InvocationRequest(BaseModel):

--- a/integrations/mason/templates/custom-agent-langgraph/runtime/main.py
+++ b/integrations/mason/templates/custom-agent-langgraph/runtime/main.py
@@ -9,7 +9,7 @@ from fastapi import FastAPI
 from pydantic import BaseModel, ConfigDict, Field
 
 # override=False so injected DATABRICKS_* (from `mason dev -p` or the deploy platform) win over a
-# checked-in .env, which otherwise overrides the profile but not the host and breaks auth.
+# checked-in .env.
 load_dotenv(dotenv_path=Path(__file__).parent.parent / ".env", override=False)
 
 

--- a/integrations/mason/templates/custom-agent-langgraph/runtime/main.py
+++ b/integrations/mason/templates/custom-agent-langgraph/runtime/main.py
@@ -8,9 +8,8 @@ from dotenv import load_dotenv
 from fastapi import FastAPI
 from pydantic import BaseModel, ConfigDict, Field
 
-# .env fills unset config only; the real environment wins (override=False). `mason dev -p` and
-# the deploy platform inject DATABRICKS_* into the process, and a checked-in .env must not clobber
-# them — overriding only the profile while leaving the injected host mismatches host and credential.
+# override=False so injected DATABRICKS_* (from `mason dev -p` or the deploy platform) win over a
+# checked-in .env, which otherwise overrides the profile but not the host and breaks auth.
 load_dotenv(dotenv_path=Path(__file__).parent.parent / ".env", override=False)
 
 

--- a/integrations/mason/templates/custom-agent-openai/runtime/main.py
+++ b/integrations/mason/templates/custom-agent-openai/runtime/main.py
@@ -8,7 +8,10 @@ from dotenv import load_dotenv
 from fastapi import FastAPI
 from pydantic import BaseModel, ConfigDict, Field
 
-load_dotenv(dotenv_path=Path(__file__).parent.parent / ".env", override=True)
+# .env fills unset config only; the real environment wins (override=False). `mason dev -p` and
+# the deploy platform inject DATABRICKS_* into the process, and a checked-in .env must not clobber
+# them — overriding only the profile while leaving the injected host mismatches host and credential.
+load_dotenv(dotenv_path=Path(__file__).parent.parent / ".env", override=False)
 
 
 class InvocationRequest(BaseModel):

--- a/integrations/mason/templates/custom-agent-openai/runtime/main.py
+++ b/integrations/mason/templates/custom-agent-openai/runtime/main.py
@@ -9,7 +9,7 @@ from fastapi import FastAPI
 from pydantic import BaseModel, ConfigDict, Field
 
 # override=False so injected DATABRICKS_* (from `mason dev -p` or the deploy platform) win over a
-# checked-in .env, which otherwise overrides the profile but not the host and breaks auth.
+# checked-in .env.
 load_dotenv(dotenv_path=Path(__file__).parent.parent / ".env", override=False)
 
 

--- a/integrations/mason/templates/custom-agent-openai/runtime/main.py
+++ b/integrations/mason/templates/custom-agent-openai/runtime/main.py
@@ -8,9 +8,8 @@ from dotenv import load_dotenv
 from fastapi import FastAPI
 from pydantic import BaseModel, ConfigDict, Field
 
-# .env fills unset config only; the real environment wins (override=False). `mason dev -p` and
-# the deploy platform inject DATABRICKS_* into the process, and a checked-in .env must not clobber
-# them — overriding only the profile while leaving the injected host mismatches host and credential.
+# override=False so injected DATABRICKS_* (from `mason dev -p` or the deploy platform) win over a
+# checked-in .env, which otherwise overrides the profile but not the host and breaks auth.
 load_dotenv(dotenv_path=Path(__file__).parent.parent / ".env", override=False)
 
 

--- a/integrations/mason/templates/ui/agent-langgraph/runtime/main.py
+++ b/integrations/mason/templates/ui/agent-langgraph/runtime/main.py
@@ -10,9 +10,8 @@ from runtime.ui import install_ui
 
 from databricks_mason import AgentApp
 
-# .env fills unset config only; the real environment wins (override=False). `mason dev -p` and
-# the deploy platform inject DATABRICKS_* into the process, and a checked-in .env must not clobber
-# them — overriding only the profile while leaving the injected host mismatches host and credential.
+# override=False so injected DATABRICKS_* (from `mason dev -p` or the deploy platform) win over a
+# checked-in .env, which otherwise overrides the profile but not the host and breaks auth.
 load_dotenv(dotenv_path=Path(__file__).parent.parent / ".env", override=False)
 agent.agent.configure()
 

--- a/integrations/mason/templates/ui/agent-langgraph/runtime/main.py
+++ b/integrations/mason/templates/ui/agent-langgraph/runtime/main.py
@@ -11,7 +11,7 @@ from runtime.ui import install_ui
 from databricks_mason import AgentApp
 
 # override=False so injected DATABRICKS_* (from `mason dev -p` or the deploy platform) win over a
-# checked-in .env, which otherwise overrides the profile but not the host and breaks auth.
+# checked-in .env.
 load_dotenv(dotenv_path=Path(__file__).parent.parent / ".env", override=False)
 agent.agent.configure()
 

--- a/integrations/mason/templates/ui/agent-langgraph/runtime/main.py
+++ b/integrations/mason/templates/ui/agent-langgraph/runtime/main.py
@@ -10,7 +10,10 @@ from runtime.ui import install_ui
 
 from databricks_mason import AgentApp
 
-load_dotenv(dotenv_path=Path(__file__).parent.parent / ".env", override=True)
+# .env fills unset config only; the real environment wins (override=False). `mason dev -p` and
+# the deploy platform inject DATABRICKS_* into the process, and a checked-in .env must not clobber
+# them — overriding only the profile while leaving the injected host mismatches host and credential.
+load_dotenv(dotenv_path=Path(__file__).parent.parent / ".env", override=False)
 agent.agent.configure()
 
 DURABLE_RUNTIME = True

--- a/integrations/mason/templates/ui/agent-openai/runtime/main.py
+++ b/integrations/mason/templates/ui/agent-openai/runtime/main.py
@@ -10,9 +10,8 @@ from runtime.ui import install_ui
 
 from databricks_mason import AgentApp
 
-# .env fills unset config only; the real environment wins (override=False). `mason dev -p` and
-# the deploy platform inject DATABRICKS_* into the process, and a checked-in .env must not clobber
-# them — overriding only the profile while leaving the injected host mismatches host and credential.
+# override=False so injected DATABRICKS_* (from `mason dev -p` or the deploy platform) win over a
+# checked-in .env, which otherwise overrides the profile but not the host and breaks auth.
 load_dotenv(dotenv_path=Path(__file__).parent.parent / ".env", override=False)
 agent.agent.configure()
 

--- a/integrations/mason/templates/ui/agent-openai/runtime/main.py
+++ b/integrations/mason/templates/ui/agent-openai/runtime/main.py
@@ -11,7 +11,7 @@ from runtime.ui import install_ui
 from databricks_mason import AgentApp
 
 # override=False so injected DATABRICKS_* (from `mason dev -p` or the deploy platform) win over a
-# checked-in .env, which otherwise overrides the profile but not the host and breaks auth.
+# checked-in .env.
 load_dotenv(dotenv_path=Path(__file__).parent.parent / ".env", override=False)
 agent.agent.configure()
 

--- a/integrations/mason/templates/ui/agent-openai/runtime/main.py
+++ b/integrations/mason/templates/ui/agent-openai/runtime/main.py
@@ -10,7 +10,10 @@ from runtime.ui import install_ui
 
 from databricks_mason import AgentApp
 
-load_dotenv(dotenv_path=Path(__file__).parent.parent / ".env", override=True)
+# .env fills unset config only; the real environment wins (override=False). `mason dev -p` and
+# the deploy platform inject DATABRICKS_* into the process, and a checked-in .env must not clobber
+# them — overriding only the profile while leaving the injected host mismatches host and credential.
+load_dotenv(dotenv_path=Path(__file__).parent.parent / ".env", override=False)
 agent.agent.configure()
 
 DURABLE_RUNTIME = True


### PR DESCRIPTION
A checked-in .env with override=True clobbered the DATABRICKS_CONFIG_PROFILE that `mason dev -p` (via apps run-local) and the deploy platform inject, while leaving the injected DATABRICKS_HOST — so the agent authenticated to one workspace's host with another profile's credential and failed with "Unable to load OAuth Config". override=False lets the real environment win and .env only fill unset vars.