### PR TITLE
[mason] deploy: create default memory/session stores; dev warns when unbound

### DIFF
--- a/integrations/mason/src/databricks_mason/deploy.py
+++ b/integrations/mason/src/databricks_mason/deploy.py
@@ -299,6 +299,30 @@ def _resolve_deployment_name(project, name: Optional[str]) -> str:
     )
 
 
+def _ensure_default_stores(project, base_name: str, client) -> None:
+    """Create + bind default memory/session stores for any slot not already bound in agent.toml.
+
+    Fills only the gaps: a store already bound is left untouched. Defaults are named
+    ``<base_name>-memory`` / ``<base_name>-session`` (create-or-reuse), and the new bindings are
+    persisted so later deploys reuse them and the validate/grant steps pick them up. There is no way
+    to tell from the agent's code whether it uses a store — the binding is the signal — so
+    `mason deploy` provisions both by default; pass --no-create-stores to skip.
+    """
+    changed = False
+    if not project.memory_store:
+        store = f"{base_name}-memory"
+        resolved, _ = _ensure_memory_store(client, store)
+        store_id = (field(resolved, "name") or "").split("/", 1)[-1] or None
+        project.bind_memory_store(store, store_id)
+        changed = True
+    if not project.session_store:
+        _ensure_session_store(client, f"{base_name}-session")
+        project.bind_session_store(f"{base_name}-session")
+        changed = True
+    if changed:
+        project.write()
+
+
 def validate_stores(client, *, memory_store: Optional[str], session_store: Optional[str]) -> None:
     """Validate the agent's bound stores exist. Shared by `mason deploy` and `mason dev`.
 
@@ -440,6 +464,11 @@ def _grant_store_access(
     default=None,
     help="Number of deployment instances.",
 )
+@click.option(
+    "--no-create-stores",
+    is_flag=True,
+    help="Don't auto-create the default memory/session stores for slots unbound in agent.toml.",
+)
 @click.pass_obj
 def deploy(
     obj,
@@ -448,6 +477,7 @@ def deploy(
     pip_index_url,
     workspace_path,
     instances,
+    no_create_stores,
 ) -> None:
     """Deploy an agent: validate its bound stores, wire in tracing, and roll out the deployment.
 
@@ -455,6 +485,9 @@ def deploy(
     can omit it; passing NAME again updates the recorded name. The app is named `mason-<name>`
     (Mason adds the prefix if absent); use that full name with the other `mason deployments` verbs.
     `deployments list` shows only apps carrying this prefix.
+
+    By default any memory/session store not yet bound in agent.toml is created and bound as
+    `<name>-memory` / `<name>-session`; pass --no-create-stores to skip that.
 
     Horizontally scaled deployments use best-effort sticky routing (session affinity). Browsers
     preserve the routing cookie automatically.
@@ -476,6 +509,16 @@ def deploy(
         project.write()
     instance_args = _instance_args(instances)
     client = obj.client()
+
+    # 0. Create + bind default memory/session stores for any slot unbound in agent.toml (unless
+    #    --no-create-stores). Writes the bindings so the store_bindings read below picks them up.
+    if (
+        project is not None
+        and not no_create_stores
+        and not (project.memory_store and project.session_store)
+    ):
+        with render.status("Provisioning default memory/session stores…"):
+            _ensure_default_stores(project, base_name, client)
 
     # 1. Validate the agent's bound stores (`mason memory/sessions bind` creates them). Stores are
     #    read from agent.toml at runtime, not wired into app.yaml; the bindings also drive the store

--- a/integrations/mason/src/databricks_mason/dev.py
+++ b/integrations/mason/src/databricks_mason/dev.py
@@ -97,6 +97,17 @@ def dev(
     # per-project experiment and wire its env. Tracing is best-effort locally — if it can't be set up
     # (e.g. no mlflow installed, or offline), dev still runs the agent, just without traces.
     memory_store, session_store = store_bindings(source_dir)
+    # `mason dev` never provisions stores (unlike `mason deploy`); warn so the missing durability /
+    # long-term memory isn't a silent surprise.
+    if not memory_store:
+        render.warning(
+            "No memory store bound — long-term memory is disabled. Run 'mason memory bind <name>'."
+        )
+    if not session_store:
+        render.warning(
+            "No session store bound — conversation history is in-memory (not durable). "
+            "Run 'mason sessions bind <name>'."
+        )
     env_updates: dict[str, str] = {}
     # Stores legitimately require auth, so build the client eagerly only when stores are bound.
     if memory_store or session_store:

--- a/integrations/mason/src/databricks_mason/render.py
+++ b/integrations/mason/src/databricks_mason/render.py
@@ -111,6 +111,11 @@ def status_pill(status: Optional[str]) -> Text:
     return Text("● ", style=MUTED) + Text(value.title() or "Unknown", style=MUTED)
 
 
+def warning(message: str, con: Optional[Console] = None) -> None:
+    """Print a yellow ⚠ warning line (non-fatal; the command keeps running)."""
+    (con or _stdout).print(Text("⚠ ", style="yellow") + Text(message, style="yellow"))
+
+
 def hyperlink(text: str, url: Optional[str]) -> Text:
     """A terminal hyperlink (OSC 8): renders `text`, opens `url` on click; plain text if no url.
 

--- a/integrations/mason/tests/unit_tests/deploy_test.py
+++ b/integrations/mason/tests/unit_tests/deploy_test.py
@@ -107,19 +107,21 @@ class _FakeClient:
     host = "https://ws"
     current_user = "me@example.com"
 
+    def __init__(self):
+        # Seeded with one pre-existing store ("mem", whose id differs from its display name as the
+        # real API returns); created stores are appended so deploy's auto-create can then resolve them.
+        self._memory_stores = [{"name": "memory-stores/mem-id-123", "display_name": "mem"}]
+
     def get_memory_store(self, name):
         return {"name": f"memory-stores/{name}"}
 
     def list_memory_stores(self, page_size=None, page_token=None):
-        # One page; the store's resource name is an id distinct from its display name (as the real
-        # API returns), so resolution must match on display_name, not id.
-        return {
-            "managed_memory_stores": [{"name": "memory-stores/mem-id-123", "display_name": "mem"}],
-            "next_page_token": "",
-        }
+        return {"managed_memory_stores": list(self._memory_stores), "next_page_token": ""}
 
     def create_memory_store(self, display_name, *, retry_transient=False):
-        return {"name": "memory-stores/mem-id-123", "display_name": display_name}
+        store = {"name": f"memory-stores/{display_name}", "display_name": display_name}
+        self._memory_stores.append(store)
+        return store
 
     def get_session_store(self, name):
         return {"session_store_name": name}
@@ -452,7 +454,7 @@ def test_deploy_durability_binding_uses_dedicated_backend_with_session_store(
 
     result = CliRunner().invoke(
         deploy_mod.deploy,
-        ["myapp", "--source", str(src)],
+        ["myapp", "--source", str(src), "--no-create-stores"],
         obj=_FakeCtx(),
     )
 
@@ -508,7 +510,7 @@ def test_deploy_durability_binding_does_not_reuse_memory_store(
 
     result = CliRunner().invoke(
         deploy_mod.deploy,
-        ["myapp", "--source", str(src)],
+        ["myapp", "--source", str(src), "--no-create-stores"],
         obj=_FakeCtx(),
     )
 
@@ -1037,8 +1039,6 @@ def test_store_bindings_ignores_missing_manifest(tmp_path: pathlib.Path):
 
 
 def test_deploy_writes_deployment_name_to_toml(tmp_path: pathlib.Path, monkeypatch):
-    from databricks_mason.agent_project import AgentProject
-
     src = tmp_path / "app"
     src.mkdir()
     (src / "app.yaml").write_text(yaml.safe_dump({"command": ["x"]}))
@@ -1093,6 +1093,73 @@ def test_deploy_without_name_or_toml_errors(tmp_path: pathlib.Path, monkeypatch)
     assert result.exit_code != 0
     assert "No deployment name" in result.output
     assert called == []  # errored before shelling out to `databricks apps`
+
+
+def test_ensure_default_stores_creates_and_binds_unbound(tmp_path: pathlib.Path):
+    _agent_toml(tmp_path)  # a project with no stores bound
+    project = AgentProject.load(tmp_path)
+
+    deploy_mod._ensure_default_stores(project, "foo", _FakeClient())
+
+    assert project.memory_store == "foo-memory"
+    assert project.session_store == "foo-session"
+    reloaded = AgentProject.load(tmp_path)  # persisted for later deploys
+    assert reloaded.memory_store == "foo-memory"
+    assert reloaded.session_store == "foo-session"
+
+
+def test_ensure_default_stores_leaves_a_bound_store_alone(tmp_path: pathlib.Path):
+    _agent_toml(tmp_path, memory="existing-mem")  # memory bound, session unbound
+    project = AgentProject.load(tmp_path)
+
+    deploy_mod._ensure_default_stores(project, "foo", _FakeClient())
+
+    assert project.memory_store == "existing-mem"  # untouched
+    assert project.session_store == "foo-session"  # only the missing one filled in
+
+
+def test_deploy_auto_creates_default_stores(tmp_path: pathlib.Path, monkeypatch):
+    src = tmp_path / "app"
+    src.mkdir()
+    (src / "app.yaml").write_text(yaml.safe_dump({"command": ["x"]}))
+    _agent_toml(src)  # no stores bound
+
+    monkeypatch.setattr(deploy_mod, "_deployment_exists", lambda a, p: True)
+    monkeypatch.setattr(
+        deploy_mod,
+        "_databricks",
+        lambda args, profile, **kw: types.SimpleNamespace(returncode=0, stdout="", stderr=""),
+    )
+
+    result = CliRunner().invoke(deploy_mod.deploy, ["myapp", "--source", str(src)], obj=_FakeCtx())
+
+    assert result.exit_code == 0, result.output
+    project = AgentProject.load(src)
+    assert project.memory_store == "myapp-memory"
+    assert project.session_store == "myapp-session"
+
+
+def test_deploy_no_create_stores_leaves_stores_unbound(tmp_path: pathlib.Path, monkeypatch):
+    src = tmp_path / "app"
+    src.mkdir()
+    (src / "app.yaml").write_text(yaml.safe_dump({"command": ["x"]}))
+    _agent_toml(src)  # no stores bound
+
+    monkeypatch.setattr(deploy_mod, "_deployment_exists", lambda a, p: True)
+    monkeypatch.setattr(
+        deploy_mod,
+        "_databricks",
+        lambda args, profile, **kw: types.SimpleNamespace(returncode=0, stdout="", stderr=""),
+    )
+
+    result = CliRunner().invoke(
+        deploy_mod.deploy, ["myapp", "--source", str(src), "--no-create-stores"], obj=_FakeCtx()
+    )
+
+    assert result.exit_code == 0, result.output
+    project = AgentProject.load(src)
+    assert project.memory_store is None
+    assert project.session_store is None
 
 
 def test_deploy_grants_bound_store(tmp_path: pathlib.Path, monkeypatch):

--- a/integrations/mason/tests/unit_tests/dev_test.py
+++ b/integrations/mason/tests/unit_tests/dev_test.py
@@ -390,3 +390,29 @@ def test_dev_runs_from_project_containing_directly_edited_agent_manifest(
     assert result.exit_code == 0, result.output
     assert db.call_args.kwargs["cwd"] == str(tmp_path)
     assert manifest.read_text() == 'schema_version = 1\n\n[agent]\nframework = "langgraph"\n'
+
+
+def test_dev_warns_when_stores_unbound(tmp_path: pathlib.Path):
+    # `mason dev` never provisions stores (unlike deploy); it warns so the gap isn't silent.
+    (tmp_path / "app.yaml").write_text("command: []\n")  # no agent.toml -> both unbound
+    with mock.patch.object(dev_mod, "_databricks"):
+        result = CliRunner().invoke(dev_mod.dev, ["--source", str(tmp_path)], obj=_Ctx())
+    assert result.exit_code == 0, result.output
+    assert "No memory store bound" in result.output
+    assert "No session store bound" in result.output
+
+
+def test_dev_silent_when_stores_bound(tmp_path: pathlib.Path):
+    (tmp_path / "app.yaml").write_text("command: []\n")
+    (tmp_path / "agent.toml").write_text(
+        'schema_version = 1\n\n[agent]\nframework = "openai"\n'
+        '\n[memory_store]\nname = "mem"\n\n[session_store]\nname = "sess"\n'
+    )
+    with (
+        mock.patch.object(dev_mod, "_databricks"),
+        mock.patch.object(dev_mod, "validate_stores"),
+    ):
+        result = CliRunner().invoke(dev_mod.dev, ["--source", str(tmp_path)], obj=_Ctx())
+    assert result.exit_code == 0, result.output
+    assert "No memory store bound" not in result.output
+    assert "No session store bound" not in result.output

--- a/integrations/mason/tests/unit_tests/render_test.py
+++ b/integrations/mason/tests/unit_tests/render_test.py
@@ -47,6 +47,14 @@ def test_hyperlink_carries_url_and_plain_text():
     assert "link https://example.com/app" in str(link.style)
 
 
+def test_warning_prints_yellow_message():
+    con, buf = _console()
+    render.warning("careful now", con=con)
+    out = buf.getvalue()
+    assert "careful now" in out
+    assert "⚠" in out
+
+
 def test_hyperlink_without_url_is_plain():
     link = render.hyperlink("my-app", None)
     assert link.plain == "my-app"


### PR DESCRIPTION
## Summary

`mason deploy` now provisions the agent's managed stores by default, and `mason dev` warns when they're missing.

- **`mason deploy` creates + binds by default.** For any memory/session slot not already bound in `agent.toml`, deploy creates and binds a default store named `<name>-memory` / `<name>-session` (create-or-reuse, same code path as `mason memory/sessions bind`). A store already bound is left untouched — it only fills the gaps — and the new bindings are persisted so later deploys reuse them and the existing validate/grant/durability steps pick them up.
- **`--no-create-stores`** opts out (mirrors the flag on the `bind` commands): an unbound slot stays unbound.
- **`mason dev` never provisions — it warns.** After reading the bindings it prints a yellow `⚠` for each unbound store (`No memory store bound…` / `No session store bound…`), so the missing long-term memory / durable history isn't a silent surprise.

### Why provision by default rather than detect usage
There's no reliable way to tell from an agent's *code* whether it uses a store: the templates always call `memory_tools()` / `checkpointer()` and those no-op unless a store is configured — the SDK gates on the **binding**, not the code. So static analysis can't distinguish "uses memory" from "doesn't," which is why deploy provisions both by default (with an explicit opt-out) and dev warns rather than guessing.

## Changes
- `deploy.py`: `_ensure_default_stores()` + `--no-create-stores`, run before store validation.
- `dev.py`: per-unbound-store warning after reading bindings.
- `render.py`: `warning()` helper (yellow `⚠`).

## Test plan
- [x] `pytest tests/unit_tests/` — 421 passed. Added auto-create tests (both / one already bound / `--no-create-stores` skips), dev warning tests (warns per unbound / silent when bound), and a `render.warning` test. The durability/grant tests pass `--no-create-stores` to preserve their unbound-store scenarios; the test fake now reflects just-created memory stores.
- [x] `ruff check` / `ruff format --check` — clean

This pull request and its description were written by Isaac.