### PR TITLE
[mason] Bump to 0.1.6.dev0

### DIFF
--- a/integrations/mason/pyproject.toml
+++ b/integrations/mason/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "databricks-mason"
-version = "0.1.5.dev0"
+version = "0.1.6.dev0"
 description = "Databricks integration for Mason"
 authors = [
     { name="Databricks", email="agent-feedback@databricks.com" },

--- a/integrations/mason/templates/agent-langgraph/pyproject.toml
+++ b/integrations/mason/templates/agent-langgraph/pyproject.toml
@@ -11,7 +11,7 @@ dependencies = [
     # The agent-side runtime helpers (databricks_mason.runtime) plus the agent stack they need
     # (langgraph, langchain, fastapi, mlflow, …) come from this extra — see the package's
     # [project.optional-dependencies] runtime.
-    "databricks-mason[runtime]>=0.1.5.dev0",
+    "databricks-mason[runtime]>=0.1.6.dev0",
     "uvicorn>=0.41.0",
     "python-dotenv>=1.2.1",
     "databricks-sdk>=0.79.0",

--- a/integrations/mason/templates/agent-openai/pyproject.toml
+++ b/integrations/mason/templates/agent-openai/pyproject.toml
@@ -11,7 +11,7 @@ dependencies = [
     # The agent-side runtime helpers (databricks_mason.runtime) plus the agent stack they need
     # (openai-agents, databricks-openai, fastapi, mlflow, …) come from this extra — see the package's
     # [project.optional-dependencies] runtime-openai.
-    "databricks-mason[runtime-openai]>=0.1.5.dev0",
+    "databricks-mason[runtime-openai]>=0.1.6.dev0",
     "uvicorn>=0.41.0",
     "python-dotenv>=1.2.1",
     "databricks-sdk>=0.79.0",

--- a/integrations/mason/templates/custom-agent-langgraph/pyproject.toml
+++ b/integrations/mason/templates/custom-agent-langgraph/pyproject.toml
@@ -5,7 +5,7 @@ description = "LangGraph agent with a custom FastAPI server"
 readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [
-    "databricks-mason>=0.1.5.dev0",
+    "databricks-mason>=0.1.6.dev0",
     "databricks-langchain>=0.17.0",
     "databricks-sdk>=0.79.0",
     "fastapi>=0.129.0",

--- a/integrations/mason/templates/custom-agent-openai/pyproject.toml
+++ b/integrations/mason/templates/custom-agent-openai/pyproject.toml
@@ -5,7 +5,7 @@ description = "OpenAI Agents SDK agent with a custom FastAPI server"
 readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [
-    "databricks-mason>=0.1.5.dev0",
+    "databricks-mason>=0.1.6.dev0",
     "databricks-openai>=0.13.0",
     "databricks-sdk>=0.79.0",
     "fastapi>=0.129.0",


### PR DESCRIPTION
Publishes the recent Mason merges, including the generic `mason endpoint invoke` command from #562 and the runtime/server/template updates from #592, and raises all current template runtime requirements to match.

## Changes

- bump `databricks-mason` to `0.1.6.dev0`
- update all four packaged template minimum requirements to `0.1.6.dev0`
- preserve the current `langgraph` / `openai` framework extras and packaged template paths while resolving conflicts with main

The release diff against main is exactly five version-line changes. This prevents newly generated apps from satisfying their dependency with the older `0.1.5.dev0` package, which does not provide the new framework extras.

## Validation

Validated at `50a01e4bac90ce4e2d4fca926059686e8970be68`:

- `env -u NO_COLOR TERM=xterm-256color .venv/bin/python -m pytest tests/unit_tests/ -q` — 551 passed
- `.venv/bin/ruff check` — passed
- `.venv/bin/ruff format --check` — passed
- `.venv/bin/ty check` — passed
- built and installed the `0.1.6.dev0` wheel; verified both framework extras and all packaged template bounds
- scaffolded all six framework/server/UI variants from the installed wheel; unmodified generated dependency declarations resolved the release wheel using `--find-links`, without local/Git source overrides
- 112 generated-project tests passed with network connections blocked; four live-model tests explicitly deselected
- verified LangGraph/OpenAI imports in fresh generated environments, covering the missing-extra deployment failure

The color-sensitive unit test requires `NO_COLOR` unset and a color-capable `TERM`; no product code or assertions were changed for testing. The wheel checks are hermetic validation, not new live workspace deployments.

## Release

After merge, tag the verified bump commit as `databricks-mason-v0.1.6.dev0`, then run the secure Mason release workflow with that tag, destination `pypi`, and dry-run disabled. Publishing is a separate step from this PR.

---
<!-- GITHUB_MCP_FOOTER: This attribution is automatically appended by GitHub MCP. -->
_This PR was created with [GitHub MCP](http://go/mcps)._
