### PR TITLE
Use dedicated Lakebase for Mason durability

### DIFF
--- a/integrations/mason/src/databricks_mason/deploy.py
+++ b/integrations/mason/src/databricks_mason/deploy.py
@@ -2,9 +2,9 @@
 
 `mason deploy` is the integrated entry point: it provisions the memory/session stores
 bound in `agent.toml`, grants the app's service principal access to them, then rolls out
-the deployment. Durable agents reuse the Session Store database or provision a dedicated
-database when no Session Store is bound. The managed stores are read from `agent.toml` at runtime,
-so they are not written into `app.yaml`. `mason deployments` covers the lifecycle verbs
+the deployment. Durable agents use a dedicated, app-owned Lakebase project. The managed stores
+are read from `agent.toml` at runtime, so they are not written into `app.yaml`. `mason deployments`
+covers the lifecycle verbs
 (`list`/`get`/`logs`/`start`/`stop`/`delete`).
 
 Deployments run on the Databricks Apps runtime, which this module drives via the
@@ -16,7 +16,7 @@ from __future__ import annotations
 import json
 import pathlib
 import time
-from dataclasses import dataclass, replace
+from dataclasses import dataclass
 from typing import Any, Optional
 
 import click
@@ -510,16 +510,9 @@ def deploy(
     durability_enabled = bool(project and project.durability_enabled)
     if durability_enabled:
         durability_schema = lakebase_durability_store.get_lakebase_schema(name)
-        if session_store:
-            durability_backend = replace(
-                session_store_access.backend(session_store),
-                schema=durability_schema,
-                tables=(),
-            )
-        else:
-            durability_backend = lakebase_durability_store.get_or_create_backend(
-                name, obj.profile, create=True
-            )
+        durability_backend = lakebase_durability_store.get_or_create_backend(
+            name, obj.profile, create=True
+        )
         env_updates[_AGENT_DURABILITY_STORE_ENV] = durability_backend.endpoint_path
         env_updates[_AGENT_DURABILITY_SCHEMA_ENV] = durability_schema
         provisioned["Agent durability store"] = durability_backend.database_path

--- a/integrations/mason/src/databricks_mason/lakebase_durability_store.py
+++ b/integrations/mason/src/databricks_mason/lakebase_durability_store.py
@@ -13,7 +13,7 @@ from databricks_mason.store_access import LakebaseBackend, _databricks
 _BRANCH = "production"
 _ENDPOINT = "primary"
 _DATABASE = "databricks-postgres"
-_RESOURCE_NAME = "postgres"
+_RESOURCE_NAME = "postgres-durability"
 
 
 def backend(app: str) -> LakebaseBackend:

--- a/integrations/mason/tests/unit_tests/deploy_test.py
+++ b/integrations/mason/tests/unit_tests/deploy_test.py
@@ -323,20 +323,29 @@ def test_deploy_non_durable_template_does_not_enable_runtime_store(
     assert "DATABRICKS_MASON_RUNTIME_ENDPOINT" not in env
 
 
-def test_deploy_durability_binding_reuses_session_store_before_startup(
+def test_deploy_durability_binding_uses_dedicated_backend_with_session_store(
     tmp_path: pathlib.Path, monkeypatch
 ) -> None:
     src = tmp_path / "app"
     src.mkdir()
     (src / "app.yaml").write_text(yaml.safe_dump({"command": ["x"]}))
     _write_agent_manifest(src, durability=True, session="sessions")
+    selected = deploy_mod.lakebase_durability_store.backend("mason-myapp")
+    session_backend = deploy_mod.session_store_access.backend("sessions")
     events = []
 
     monkeypatch.setattr(deploy_mod, "_deployment_exists", lambda a, p: True)
     monkeypatch.setattr(
         deploy_mod.lakebase_durability_store,
         "get_or_create_backend",
-        lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError("must reuse session")),
+        lambda app, profile, create: selected,
+    )
+    monkeypatch.setattr(
+        deploy_mod.session_store_access,
+        "backend",
+        lambda *args, **kwargs: (_ for _ in ()).throw(
+            AssertionError("must not use session store for durability")
+        ),
     )
     monkeypatch.setattr(
         deploy_mod,
@@ -362,7 +371,9 @@ def test_deploy_durability_binding_reuses_session_store_before_startup(
     assert result.exit_code == 0, result.output
     assert [event[0] for event in events] == ["attach", "deploy"]
     backend = events[0][1][0]
-    assert backend.database == "sessions"
+    assert backend == selected
+    assert backend.database != "sessions"
+    assert backend.resource_name != session_backend.resource_name
     assert backend.schema == deploy_mod.lakebase_durability_store.get_lakebase_schema("mason-myapp")
     assert backend.tables == ()
     env = {

--- a/integrations/mason/tests/unit_tests/lakebase_durability_store_test.py
+++ b/integrations/mason/tests/unit_tests/lakebase_durability_store_test.py
@@ -16,7 +16,7 @@ def test_backend_uses_one_deterministic_autoscaling_project() -> None:
     assert backend.branch == "production"
     assert backend.endpoint_id == "primary"
     assert backend.database == "databricks-postgres"
-    assert backend.resource_name == "postgres"
+    assert backend.resource_name == "postgres-durability"
     assert backend.schema == durability.get_lakebase_schema("mason-My_App")
     assert backend.schema.startswith("databricks_mason_runtime_")
     assert backend.schema != durability.get_lakebase_schema("mason-other-app")

--- a/integrations/mason/tests/unit_tests/store_access_test.py
+++ b/integrations/mason/tests/unit_tests/store_access_test.py
@@ -7,7 +7,7 @@ import types
 
 import psycopg
 
-from databricks_mason import memory_store_access, session_store_access
+from databricks_mason import lakebase_durability_store, memory_store_access, session_store_access
 from databricks_mason import store_access as sa
 
 
@@ -46,6 +46,31 @@ def test_apply_postgres_resources_sends_all_backends_in_one_update(monkeypatch):
     payload = json.loads(captured["args"][captured["args"].index("--json") + 1])
     names = {r["name"] for r in payload["resources"]}
     assert names == {"postgres", "postgres-memory"}  # one update carries both
+
+
+def test_session_store_update_preserves_dedicated_durability_resource(monkeypatch):
+    resources = []
+
+    def fake_db(args, profile, **kw):
+        if args[:2] == ["apps", "get"]:
+            return types.SimpleNamespace(
+                returncode=0, stdout=json.dumps({"resources": resources}), stderr=""
+            )
+        payload = json.loads(args[args.index("--json") + 1])
+        resources[:] = payload["resources"]
+        return types.SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(sa, "_databricks", fake_db)
+    durability = lakebase_durability_store.backend("mason-app")
+    session = session_store_access.backend("sessions")
+
+    assert sa.apply_postgres_resources("app", [durability], "prof") is None
+    assert sa.apply_postgres_resources("app", [session], "prof") is None
+
+    assert {resource["name"] for resource in resources} == {
+        "postgres-durability",
+        "postgres",
+    }
 
 
 class _FakeConn:


### PR DESCRIPTION
## Summary

- always provision or reuse a dedicated app-owned Lakebase project for the durable runtime
- use a distinct `postgres-durability` app resource so Session and Memory Store resources remain unchanged
- add regression coverage for durability alongside a bound Session Store

This fixes deploy failures for non-admin users who can create a managed Session Store but cannot grant the app service principal permissions on the store service's underlying Lakebase project.

## Validation

- `uv run pytest tests/unit_tests -q` — 433 passed
- `uv run ruff format --check --diff` — passed
- `uv run ruff check` — passed
- `uv run ty check` (after `uv sync --all-extras`) — passed

### Live deployment (`e2-dogfood`)

Deployed a durable LangGraph agent with managed Session Store `pr568-qinxin-session` bound. Deployment succeeded and the app reached `RUNNING` with one active instance. Final Apps resources retained both databases:

- `postgres-durability` → `projects/mason-pr568-fixed-app-durability/branches/production/databases/databricks-postgres` (`CAN_CONNECT_AND_CREATE`)
- `postgres` → `projects/databricks-internal-agent-session-store/branches/production/databases/pr568-qinxin-session` (`CAN_CONNECT_AND_CREATE`)

This verifies the later Session Store grant no longer replaces the dedicated durability resource.