### PR TITLE
[mason] drop the [tracing] extra and make MLflow a base dependency

### DIFF
--- a/integrations/mason/README.md
+++ b/integrations/mason/README.md
@@ -20,12 +20,6 @@ From source:
 pip install 'git+https://github.com/databricks/databricks-ai-bridge.git#subdirectory=integrations/mason'
 ```
 
-For tracing commands, install Mason with tracing extras:
-
-```sh
-pip install 'databricks-mason[tracing]'
-```
-
 For the SDK-hosted durable agent application, install the runtime extra:
 
 ```sh

--- a/integrations/mason/pyproject.toml
+++ b/integrations/mason/pyproject.toml
@@ -10,6 +10,12 @@ requires-python = ">=3.10"
 dependencies = [
     "click>=8.1",
     "databricks-sdk>=0.94.0",
+    # mlflow-skinny is the lightweight MLflow client (tracking + tracing REST APIs, incl. the
+    # Databricks tracking backend) with no server/UI/ML-flavor stack. `mason tracing` and the
+    # dev/deploy experiment provisioning only make thin client calls, and tracing is on by default,
+    # so this is a base dependency. Auth rides on databricks-sdk (above), so the heavier
+    # mlflow[databricks] extra (boto3/azure/gcs/databricks-agents, for artifact blob I/O) isn't needed.
+    "mlflow-skinny>=3.10.1",
     "psycopg[binary]>=3.1",
     "PyYAML>=6.0",
     "rich>=13.7",
@@ -18,9 +24,6 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-tracing = [
-    "mlflow[databricks]>=3.10.1",
-]
 # The agent-side runtime helpers a deployed agent imports. Kept as extras so a plain
 # `pip install databricks-mason` (the CLI) stays light; each template depends on the extra for its
 # framework. `runtime` = the LangGraph adapter (databricks_mason.langgraph); `runtime-openai` = the

--- a/integrations/mason/src/databricks_mason/tracing.py
+++ b/integrations/mason/src/databricks_mason/tracing.py
@@ -11,8 +11,9 @@ experiment app resource), reads traces, and builds the UI link.
 after
 a disable); ``mason tracing disable`` turns tracing off; ``list`` / ``get`` read traces back.
 
-MLflow is an optional dependency: ``configure``/``list``/``get`` and the dev/deploy experiment
-provisioning import it lazily and need ``mlflow[databricks]``; nothing else does.
+MLflow (``mlflow-skinny``) is a base dependency, but ``configure``/``list``/``get`` and the dev/deploy
+experiment provisioning still import it lazily — ``cli.py`` imports this module at startup, so a
+top-level import would pay mlflow's heavy import cost on every ``mason`` command.
 """
 
 from __future__ import annotations
@@ -34,10 +35,6 @@ _TRACES_DIR = "mason-traces"
 TRACES_TRACKING_URI_ENV = "MLFLOW_TRACKING_URI"
 TRACES_EXPERIMENT_ID_ENV = "MLFLOW_EXPERIMENT_ID"
 
-# Installing the `tracing` extra (rather than a bare mlflow) resolves both the missing- and
-# too-old-mlflow cases: the extra carries the version floor `mason tracing` needs.
-_INSTALL_HINT = "Install the tracing extra: pip install 'databricks-mason[tracing]'"
-
 
 def default_experiment_name(user: str, project: Optional[str]) -> str:
     """The per-project experiment path under the user's workspace home (shared by dev and deploy).
@@ -58,16 +55,14 @@ def experiment_url(host: Optional[str], experiment_id: str) -> Optional[str]:
 
 
 def _mlflow():
-    """Import mlflow lazily so the core CLI (and offline wheel) don't depend on it."""
-    try:
-        import mlflow  # noqa: PLC0415 - intentional lazy import
+    """Import mlflow lazily and return the module.
 
-        return mlflow
-    except ImportError as exc:
-        raise AgentCliError(
-            "MLflow is required for `mason tracing` configure/list/get.",
-            hint=_INSTALL_HINT,
-        ) from exc
+    mlflow-skinny is a base dependency, so this can't fail on a correct install; the lazy import
+    exists only to keep it off the CLI startup path (``cli.py`` imports this module eagerly).
+    """
+    import mlflow  # noqa: PLC0415 - intentional lazy import (startup cost, not optionality)
+
+    return mlflow
 
 
 def _set_tracking_uri(mlflow, profile: Optional[str]) -> None:

--- a/integrations/mason/tests/unit_tests/dev_test.py
+++ b/integrations/mason/tests/unit_tests/dev_test.py
@@ -192,8 +192,8 @@ def test_dev_runs_offline_when_client_unavailable(tmp_path: pathlib.Path):
 
 
 def test_dev_runs_without_traces_when_tracing_setup_fails(tmp_path: pathlib.Path, monkeypatch):
-    # Tracing is best-effort locally: if provisioning raises (e.g. no mlflow), dev still runs the
-    # agent, just without wiring any MLflow env.
+    # Tracing is best-effort locally: if provisioning raises (e.g. offline / no workspace access),
+    # dev still runs the agent, just without wiring any MLflow env.
     import yaml
 
     from databricks_mason.errors import AgentCliError
@@ -202,7 +202,7 @@ def test_dev_runs_without_traces_when_tracing_setup_fails(tmp_path: pathlib.Path
     (tmp_path / ".venv").mkdir()
 
     def _boom(*a, **k):
-        raise AgentCliError("MLflow is required")
+        raise AgentCliError("could not reach the workspace")
 
     monkeypatch.setattr(dev_mod, "resolve_trace_experiment_id", _boom)
     with mock.patch.object(dev_mod, "_databricks") as db:

--- a/integrations/mason/tests/unit_tests/tracing_test.py
+++ b/integrations/mason/tests/unit_tests/tracing_test.py
@@ -256,19 +256,6 @@ def test_get_reports_missing_trace(tmp_path: pathlib.Path):
     assert "No trace found" in result.output
 
 
-# --- mlflow guard -----------------------------------------------------------
-
-
-def test_list_surfaces_clean_error_when_mlflow_absent(tmp_path: pathlib.Path):
-    _project(tmp_path)
-    with mock.patch.object(tracing_mod, "_mlflow", side_effect=AgentCliError("MLflow is required")):
-        result = CliRunner().invoke(
-            tracing_mod.tracing_list, ["--experiment", "1", "--source", str(tmp_path)], obj=_Ctx()
-        )
-    assert result.exit_code != 0
-    assert "MLflow is required" in result.output
-
-
 def test_status_str_handles_enum_like_and_none():
     class _EnumLike:
         name = "OK"


### PR DESCRIPTION
## Summary

MLflow tracing used to be opt-in, so its MLflow dependency was isolated behind an optional `[tracing]` extra (`pip install 'databricks-mason[tracing]'`) to keep a plain CLI install light. Tracing is now **on by default** for `mason dev` / `mason deploy` (#554), so gating MLflow behind an extra no longer makes sense - a default-on feature that silently no-ops (or errors with an "install the extra" hint) until the user installs a separate package is a broken out-of-the-box experience.

This PR folds MLflow into the base dependencies so tracing works on a plain `pip install databricks-mason`.

## Why `mlflow-skinny` (not `mlflow[databricks]`)

To avoid re-introducing the very weight the extra was meant to avoid, the base dependency is **`mlflow-skinny`**, the lightweight MLflow client - not full `mlflow`, and not `mlflow[databricks]`.

The CLI is a thin client - `tracing.py` only calls `set_tracking_uri`, `get_experiment_by_name`, `create_experiment`, `get_experiment`, `search_traces`, `get_trace`. It logs no models, uses no flavors, serves nothing.

- `mlflow-skinny` ships every module the CLI uses, including the Databricks tracking backend (`mlflow/store/tracking/databricks_rest_store.py`) and the `mlflow/tracing/` APIs.
- `mlflow-skinny` requires `databricks-sdk` as a **core** dependency, and mason already declares `databricks-sdk>=0.94.0` - so Databricks auth is covered without the `[databricks]` extra.
- The `[databricks]` extra only adds artifact-store SDKs + agents (`boto3`, `botocore`, `azure-storage-file-datalake`, `google-cloud-storage`, `databricks-agents`) for blob artifact I/O the CLI never performs - so `mlflow[databricks]` is actually the *heaviest* option.
- Full `mlflow` additionally pulls the server/UI/ML stack (Flask, gunicorn, scikit-learn, scipy) - not needed.

The `runtime` / `runtime-openai` extras (the deployed agent) keep full `mlflow` unchanged - the agent needs framework autolog flavors (`mlflow.langchain.autolog`, `mlflow.openai.autolog`) that skinny lacks. Full `mlflow` depends on the matching `mlflow-skinny`, so base-skinny + runtime-full resolve cleanly.

## Changes

- **`pyproject.toml`**: add `mlflow-skinny>=3.10.1` to base `dependencies`; remove the `[tracing]` optional extra. `runtime` / `runtime-openai` extras untouched.
- **`src/databricks_mason/tracing.py`**: remove `_INSTALL_HINT` and the `ImportError -> "install the extra"` handling in `_mlflow()`. **Keep** the lazy import: `cli.py` imports `tracing.py` at startup, so a top-level `import mlflow` would pay mlflow's heavy import cost on every `mason` command (even `--help`). The lazy import now exists purely for startup performance, not optionality. Docstrings updated to match.
- **`README.md`**: remove the `pip install 'databricks-mason[tracing]'` install note.
- **Tests**: remove `test_list_surfaces_clean_error_when_mlflow_absent` (asserted the removed install-hint path); retarget `test_dev_runs_without_traces_when_tracing_setup_fails` from a now-impossible "no mlflow" cause to a still-real one (offline / no workspace access).

## Testing

### Unit tests, types, lint (from `integrations/mason`)

```
$ uv run python -m pytest tests/unit_tests/ -q
431 passed in 15.43s

$ uv run ty check
All checks passed!

$ uv run ruff check
All checks passed!

$ uv run ruff format --check
91 files already formatted
```

### Clean-venv install - proves `mlflow-skinny` resolves and the heavy deps stay out

Installed the CLI into a fresh venv with base deps only (no extras), then inspected what resolved:

```
$ uv venv /tmp/mason-skinny-check --python 3.11
$ uv pip install --python /tmp/mason-skinny-check .

$ /tmp/mason-skinny-check/bin/python -c "<list installed mlflow + heavy dists>"
mlflow dists present: ['mlflow-skinny']
heavy deps present (should be empty/none): []
```

`mlflow-skinny` is the only mlflow distribution present; no full `mlflow`, `boto3`, `botocore`, `databricks-agents`, `azure-storage-*`, `google-cloud-*`, `scikit-learn`, `scipy`, `flask`, or `gunicorn`.

### CLI smoke test + API surface + startup laziness (same skinny-only venv)

```
$ /tmp/mason-skinny-check/bin/mason --help            -> OK
$ /tmp/mason-skinny-check/bin/mason tracing --help    -> OK

# every mlflow API the CLI calls resolves under skinny-only:
  mlflow.set_tracking_uri: OK
  mlflow.get_experiment_by_name: OK
  mlflow.create_experiment: OK
  mlflow.get_experiment: OK
  mlflow.search_traces: OK
  mlflow.get_trace: OK
  databricks_rest_store import: OK

# loading the CLI does NOT import mlflow (lazy import keeps startup fast):
  mlflow imported at CLI load?: False
```

### Live end-to-end against a real workspace (e2-dogfood, skinny-only venv)

Created an experiment, read it back, ran the CLI's exact managed trace-read call (`search_traces(locations=..., return_type="list")`), then deleted the experiment - all using `mlflow-skinny` with no `[databricks]` extra and no full `mlflow` present:

```
$ MLFLOW_DISABLE_AGENT_HINT=1 /tmp/mason-skinny-check/bin/python <probe: set_tracking_uri("databricks")>
create_experiment OK -> 3523494796349526
get_experiment OK -> 3523494796349526 | name: /Users/james.wu@databricks.com/mason-traces/_skinny_probe_1789021848
search_traces OK -> returned 0 traces (expected 0)
cleanup: deleted probe experiment 3523494796349526
```

This confirms the Databricks tracking backend and managed trace read work end-to-end from `mlflow-skinny` alone (auth via the existing `databricks-sdk`), so no `[databricks]` extra is required.

This pull request and its description were written by Isaac.
