### PR TITLE
[mason] unify memory & session store presentation (list + get)

### DIFF
--- a/integrations/mason/src/databricks_mason/memory.py
+++ b/integrations/mason/src/databricks_mason/memory.py
@@ -198,10 +198,10 @@ def _render_store_detail(obj, store: dict) -> None:
         _BREADCRUMB,
         field(store, "display_name") or _store_id(store),
         {
-            "Name": field(store, "name"),
-            "Store ID": _store_id(store),
+            "Name": field(store, "display_name"),
+            "Resource name": field(store, "name"),
             "Workspace": field(store, "workspace_id"),
-            "Owner": field(store, "owner_user_id"),
+            "Creator": field(store, "owner_user_id"),
             "Storage": render.field(field(store, "storage_backend") or {}, "backend_id"),
             "Description": field(store, "description"),
             "Created": timefmt.absolute(_store_created(store)),

--- a/integrations/mason/src/databricks_mason/memory.py
+++ b/integrations/mason/src/databricks_mason/memory.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import pathlib
+import sys
 from typing import Any
 
 import click
@@ -247,38 +248,50 @@ def stores_create(obj, display_name, description) -> None:
 
 
 @stores.command("list")
-@click.option("--page-size", type=int, default=None)
+@click.option("--page-size", type=int, default=25, show_default=True)
 @click.option("--page-token", default=None)
 @click.pass_obj
 def stores_list(obj, page_size, page_token) -> None:
-    """List memory stores in the workspace."""
-    data = obj.client().list_memory_stores(page_size, page_token)
+    """List memory stores in the workspace (25 per page; paginates interactively on a terminal)."""
+    client = obj.client()
     if obj.output == "json":
-        render.emit_json(data)
+        render.emit_json(client.list_memory_stores(page_size, page_token))
         return
-    items = field(data, "managed_memory_stores") or []
-    rows = [
-        [
-            field(s, "display_name"),
-            _store_id(s),
-            timefmt.relative(_store_created(s)),
-            timefmt.relative(_store_updated(s)),
-            _truncate(field(s, "description"), 40),
+    # On a terminal, offer to fetch the next page instead of only printing the --page-token hint.
+    interactive = sys.stdin.isatty() and sys.stdout.isatty()
+    while True:
+        data = client.list_memory_stores(page_size, page_token)
+        items = field(data, "managed_memory_stores") or []
+        rows = [
+            [
+                field(s, "display_name"),
+                _store_id(s),
+                timefmt.relative(_store_created(s)),
+                timefmt.relative(_store_updated(s)),
+                _truncate(field(s, "description"), 40),
+            ]
+            for s in items
         ]
-        for s in items
-    ]
-    render.resource_table(
-        "Managed Memory Stores",
-        [
-            ("Name", "left"),
-            ("Store ID", "left"),
-            ("Created", "left"),
-            ("Updated", "left"),
-            ("Description", "left"),
-        ],
-        rows,
-        subtitle=_page_note(data),
-    )
+        token = field(data, "next_page_token")
+        render.resource_table(
+            "Managed Memory Stores",
+            [
+                ("Name", "left"),
+                ("Resource name", "left"),
+                ("Created", "left"),
+                ("Updated", "left"),
+                ("Description", "left"),
+            ],
+            rows,
+            # In an interactive session the prompt below replaces the token hint.
+            subtitle=None if (interactive and token) else _page_note(data),
+            no_wrap=[1],  # keep the resource name full-width; other columns narrow to fit
+        )
+        if not token or not interactive:
+            break
+        if not click.confirm("Show next page?", default=False):
+            break
+        page_token = token
 
 
 @stores.command("get")

--- a/integrations/mason/src/databricks_mason/render.py
+++ b/integrations/mason/src/databricks_mason/render.py
@@ -137,13 +137,16 @@ def resource_table(
     *,
     subtitle: Optional[str] = None,
     con: Optional[Console] = None,
+    no_wrap: Optional[Sequence[int]] = None,
 ) -> None:
     """Render a titled list table.
 
     `columns` is a sequence of (header, justify) where justify is left/right/center.
+    `no_wrap` column indexes are kept full-width; the rest narrow to fit the terminal.
     """
     con = con or _stdout
     rows = list(rows)
+    no_wrap = set(no_wrap or ())
 
     con.print()
     con.print(Text(title, style=f"bold {ACCENT}"))
@@ -151,13 +154,31 @@ def resource_table(
         con.print(Text(subtitle, style=MUTED))
 
     table = Table(box=box.SIMPLE_HEAD, expand=False, pad_edge=False, show_edge=False)
-    for header, justify in columns:
-        table.add_column(header.upper(), justify=justify, header_style=f"bold {MUTED}")
+    for i, (header, justify) in enumerate(columns):
+        # Reserve a no_wrap column's full content width so Rich narrows the others instead.
+        min_width = (
+            max([len(header)] + [_cell_len(row[i]) for row in rows], default=0)
+            if i in no_wrap
+            else None
+        )
+        table.add_column(
+            header.upper(),
+            justify=justify,
+            header_style=f"bold {MUTED}",
+            no_wrap=i in no_wrap,
+            min_width=min_width,
+        )
     for row in rows:
         table.add_row(*[_cell(v) for v in row])
     con.print(table)
 
     con.print(Text(f"{len(rows)} item{'s' if len(rows) != 1 else ''}", style=MUTED))
+
+
+def _cell_len(value: Any) -> int:
+    if value is None:
+        return 1  # em-dash placeholder
+    return len(value.plain if isinstance(value, Text) else str(value))
 
 
 def _cell(value: Any) -> Any:

--- a/integrations/mason/src/databricks_mason/render.py
+++ b/integrations/mason/src/databricks_mason/render.py
@@ -146,7 +146,7 @@ def resource_table(
     """
     con = con or _stdout
     rows = list(rows)
-    no_wrap = set(no_wrap or ())
+    no_wrap_cols = set(no_wrap or ())
 
     con.print()
     con.print(Text(title, style=f"bold {ACCENT}"))
@@ -158,14 +158,14 @@ def resource_table(
         # Reserve a no_wrap column's full content width so Rich narrows the others instead.
         min_width = (
             max([len(header)] + [_cell_len(row[i]) for row in rows], default=0)
-            if i in no_wrap
+            if i in no_wrap_cols
             else None
         )
         table.add_column(
             header.upper(),
             justify=justify,
             header_style=f"bold {MUTED}",
-            no_wrap=i in no_wrap,
+            no_wrap=i in no_wrap_cols,
             min_width=min_width,
         )
     for row in rows:

--- a/integrations/mason/src/databricks_mason/sessions.py
+++ b/integrations/mason/src/databricks_mason/sessions.py
@@ -132,13 +132,16 @@ def sessions_unbind(obj, source: pathlib.Path) -> None:
 
 
 def _render_store_detail(store: dict) -> None:
+    name = field(store, "session_store_name")
     render.detail(
         f"{_BREADCRUMB} Store",
-        field(store, "session_store_name") or "—",
+        name or "—",
         {
-            "Name": field(store, "session_store_name"),
+            "Name": name,
+            "Resource name": f"session-stores/{name}" if name else None,
             "Store ID": field(store, "session_store_id"),
             "Creator": field(store, "creator_user_id"),
+            "Storage": render.field(field(store, "storage_backend") or {}, "backend_id"),
             "Description": field(store, "description"),
             "Created": timefmt.absolute(field(store, "create_time")),
             "Updated": timefmt.absolute(field(store, "update_time")),

--- a/integrations/mason/src/databricks_mason/sessions.py
+++ b/integrations/mason/src/databricks_mason/sessions.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import pathlib
+import sys
 from typing import Any, Optional
 
 import click
@@ -182,38 +183,49 @@ def stores_create(obj, name, description, metadata) -> None:
 
 
 @stores.command("list")
-@click.option("--page-size", type=int, default=None)
+@click.option("--page-size", type=int, default=25, show_default=True)
 @click.option("--page-token", default=None)
 @click.pass_obj
 def stores_list(obj, page_size, page_token) -> None:
-    """List session stores in the workspace."""
-    data = obj.client().list_session_stores(page_size, page_token)
+    """List session stores in the workspace (25 per page; paginates interactively on a terminal)."""
+    client = obj.client()
     if obj.output == "json":
-        render.emit_json(data)
+        render.emit_json(client.list_session_stores(page_size, page_token))
         return
-    items_ = field(data, "session_stores") or []
-    rows = [
-        [
-            field(s, "session_store_name"),
-            field(s, "creator_user_id"),
-            timefmt.relative(field(s, "create_time")),
-            timefmt.relative(field(s, "update_time")),
-            _truncate(field(s, "description"), 40),
+    # On a terminal, offer to fetch the next page instead of only printing the --page-token hint.
+    interactive = sys.stdin.isatty() and sys.stdout.isatty()
+    while True:
+        data = client.list_session_stores(page_size, page_token)
+        items_ = field(data, "session_stores") or []
+        rows = [
+            [
+                field(s, "session_store_name"),
+                timefmt.relative(field(s, "create_time")),
+                timefmt.relative(field(s, "update_time")),
+                _truncate(field(s, "description"), 40),
+            ]
+            for s in items_
         ]
-        for s in items_
-    ]
-    render.resource_table(
-        "Session Stores",
-        [
-            ("Name", "left"),
-            ("Creator", "left"),
-            ("Created", "left"),
-            ("Updated", "left"),
-            ("Description", "left"),
-        ],
-        rows,
-        subtitle=_page_note(data),
-    )
+        token = field(data, "next_page_token")
+        render.resource_table(
+            "Session Stores",
+            [
+                # A session store's resource name is its workspace-unique, human-readable name.
+                ("Resource name", "left"),
+                ("Created", "left"),
+                ("Updated", "left"),
+                ("Description", "left"),
+            ],
+            rows,
+            # In an interactive session the prompt below replaces the token hint.
+            subtitle=None if (interactive and token) else _page_note(data),
+            no_wrap=[0],  # keep the resource name full-width; other columns narrow to fit
+        )
+        if not token or not interactive:
+            break
+        if not click.confirm("Show next page?", default=False):
+            break
+        page_token = token
 
 
 @stores.command("get")

--- a/integrations/mason/tests/unit_tests/memory_test.py
+++ b/integrations/mason/tests/unit_tests/memory_test.py
@@ -64,6 +64,24 @@ def test_store_get_renders_timestamps_from_create_time():
     assert "2026" in result.output
 
 
+def test_store_get_unifies_name_resource_name_and_creator():
+    store = {
+        "name": "memory-stores/abc123",
+        "display_name": "demo",
+        "owner_user_id": "owner-1",
+        "storage_backend": {"backend_id": "projects/.../databases/abc123"},
+        "create_time": "2026-08-15T01:29:00Z",
+        "update_time": "2026-08-16T01:29:00Z",
+    }
+    result = CliRunner().invoke(stores, ["get", "abc123"], obj=_Ctx(_Client(store=store)))
+    assert result.exit_code == 0, result.output
+    assert "Name" in result.output and "demo" in result.output  # human-readable name
+    assert "Resource name" in result.output and "memory-stores/abc123" in result.output
+    assert "Creator" in result.output and "owner-1" in result.output  # was "Owner"
+    assert "Owner" not in result.output
+    assert "Store ID" not in result.output  # memory has no separate id row
+
+
 def test_store_create_suggests_binding_the_store():
     store = {"name": "memory-stores/abc123", "display_name": "demo"}
     result = CliRunner().invoke(

--- a/integrations/mason/tests/unit_tests/memory_test.py
+++ b/integrations/mason/tests/unit_tests/memory_test.py
@@ -90,6 +90,39 @@ def test_store_list_renders_timestamps_from_create_time():
     assert "ago" in result.output or "just now" in result.output
 
 
+def test_store_list_shows_bare_resource_name_without_prefix():
+    page = {"managed_memory_stores": [{"name": "memory-stores/abc123", "display_name": "demo"}]}
+    result = CliRunner().invoke(stores, ["list"], obj=_Ctx(_Client(page=page)))
+    assert result.exit_code == 0, result.output
+    assert "abc123" in result.output  # resource name shown without the memory-stores/ prefix
+    assert "memory-stores/abc123" not in result.output
+    assert "STORE ID" not in result.output.upper()  # column renamed to "Resource name"
+
+
+def test_store_list_defaults_page_size_to_25():
+    calls = []
+
+    class _RecClient(_Client):
+        def list_memory_stores(self, page_size=None, page_token=None):
+            calls.append((page_size, page_token))
+            return {"managed_memory_stores": []}
+
+    result = CliRunner().invoke(stores, ["list"], obj=_Ctx(_RecClient()))
+    assert result.exit_code == 0, result.output
+    assert calls == [(25, None)]  # defaults to a 25-result page
+
+
+def test_store_list_hints_next_page_when_not_interactive():
+    page = {
+        "managed_memory_stores": [{"name": "memory-stores/a", "display_name": "d"}],
+        "next_page_token": "tok-2",
+    }
+    # CliRunner has no TTY, so it prints the --page-token hint rather than prompting.
+    result = CliRunner().invoke(stores, ["list"], obj=_Ctx(_Client(page=page)))
+    assert result.exit_code == 0, result.output
+    assert "--page-token tok-2" in result.output
+
+
 def _bind_ctx(tmp_path):
     """A CLI context whose client records memory-store creation, over a scaffolded agent.toml."""
     (tmp_path / "agent.toml").write_text(

--- a/integrations/mason/tests/unit_tests/render_test.py
+++ b/integrations/mason/tests/unit_tests/render_test.py
@@ -81,6 +81,22 @@ def test_resource_table_renders_title_and_count():
     assert "1 item" in out
 
 
+def test_resource_table_keeps_no_wrap_column_full_width_when_narrow():
+    buf = io.StringIO()
+    con = Console(file=buf, width=60, no_color=True)
+    long_name = "memory-store-with-a-long-id"
+    render.resource_table(
+        "Stores",
+        [("Name", "left"), ("Resource name", "left"), ("Description", "left")],
+        [["demo", long_name, "some long description text here"]],
+        con=con,
+        no_wrap=[1],
+    )
+    out = buf.getvalue()
+    assert long_name in out  # resource name reserved full-width, never truncated
+    assert "DESCRIPTION" in out.upper()  # no column is dropped; it just narrows/wraps
+
+
 def test_success_next_steps_render_command_and_description():
     con, buf = _console()
     render.success(

--- a/integrations/mason/tests/unit_tests/sessions_test.py
+++ b/integrations/mason/tests/unit_tests/sessions_test.py
@@ -79,3 +79,31 @@ def test_store_list_defaults_page_size_to_25():
     result = CliRunner().invoke(stores, ["list"], obj=_Ctx(client))
     assert result.exit_code == 0, result.output
     assert client.calls == [(25, None)]
+
+
+class _StoreGetClient:
+    def __init__(self, store):
+        self._store = store
+
+    def get_session_store(self, name):
+        return self._store
+
+
+def test_store_get_unifies_name_resource_name_store_id_and_storage():
+    store = {
+        "session_store_name": "ann-session-store",
+        "session_store_id": "847efa51-dc53-4cf7",
+        "creator_user_id": "299811638972008",
+        "storage_backend": {"backend_id": "projects/.../databases/ann"},
+        "create_time": "2026-09-03T21:47:00Z",
+        "update_time": "2026-09-03T21:47:00Z",
+    }
+    result = CliRunner().invoke(
+        stores, ["get", "ann-session-store"], obj=_Ctx(_StoreGetClient(store))
+    )
+    assert result.exit_code == 0, result.output
+    assert "ann-session-store" in result.output  # human-readable name
+    # Resource name is the session-stores/<name> path.
+    assert "session-stores/ann-session-store" in result.output
+    assert "Store ID" in result.output and "847efa51-dc53-4cf7" in result.output
+    assert "Storage" in result.output  # storage now shown for session stores

--- a/integrations/mason/tests/unit_tests/sessions_test.py
+++ b/integrations/mason/tests/unit_tests/sessions_test.py
@@ -1,10 +1,10 @@
-"""Unit tests for `mason sessions items pop` rendering."""
+"""Unit tests for `mason sessions items pop` and `sessions stores list` rendering."""
 
 from __future__ import annotations
 
 from click.testing import CliRunner
 
-from databricks_mason.sessions import items
+from databricks_mason.sessions import items, stores
 
 
 class _Client:
@@ -42,3 +42,40 @@ def test_pop_empty_session_reports_empty():
     )
     assert result.exit_code == 0, result.output
     assert "already empty" in result.output
+
+
+class _StoreListClient:
+    def __init__(self, page):
+        self._page = page
+        self.calls = []
+
+    def list_session_stores(self, page_size=None, page_token=None):
+        self.calls.append((page_size, page_token))
+        return self._page
+
+
+def test_store_list_shows_resource_name_and_drops_creator():
+    page = {
+        "session_stores": [
+            {
+                "session_store_name": "my-sessions",
+                "session_store_id": "sess-abc123",
+                "creator_user_id": "user-99",
+            }
+        ]
+    }
+    result = CliRunner().invoke(stores, ["list"], obj=_Ctx(_StoreListClient(page)))
+    assert result.exit_code == 0, result.output
+    assert "my-sessions" in result.output  # resource name is the human-readable store name
+    assert "RESOURCE NAME" in result.output.upper()
+    assert "sess-abc123" not in result.output  # the opaque id is not shown
+    assert result.output.upper().count("NAME") == 1  # single "Resource name" column, no duplicate
+    assert "CREATOR" not in result.output.upper()  # creator column removed
+    assert "user-99" not in result.output
+
+
+def test_store_list_defaults_page_size_to_25():
+    client = _StoreListClient({"session_stores": []})
+    result = CliRunner().invoke(stores, ["list"], obj=_Ctx(client))
+    assert result.exit_code == 0, result.output
+    assert client.calls == [(25, None)]


### PR DESCRIPTION
## Summary

Unifies how `mason memory stores` and `mason sessions stores` present stores, in both `list` and `get`.

### `stores list`
- **memory:** `Store ID` column → `Resource name` (bare store id, no `memory-stores/` prefix); the human-readable `Name` column stays.
- **sessions:** single `Resource name` column = the human-readable `session_store_name` (the id in the `session-stores/<id>` path); redundant `Name` column dropped; `Creator` column removed.
- **both:** `Resource name` kept full-width (never truncated) — other columns (Created/Updated/Description) narrow/wrap when the terminal is tight, none dropped. `--page-size` defaults to 25 with interactive `Show next page?` paging; piped/`-o json` output keeps the `--page-token` hint.

### `stores get`
Aligned detail fields across both types:
- **`Name`** — human-readable, user-set name (memory `display_name`, session `session_store_name`).
- **`Resource name`** — resource path (`memory-stores/<id>` / `session-stores/<id>`).
- **`Store ID`** — session stores only (the `session_store_id` UUID); memory has no separate id row.
- Memory's `Owner` row renamed to **`Creator`** (matches session).
- **`Storage`** now shown for session stores too.

## Test plan
- [x] `pytest tests/unit_tests/` — 462 passed. Added list + get tests for both store types (resource-name field/labeling, creator, no-wrap full-width, default 25/page, next-page hint, unified get fields).
- [x] `ruff check` / `ruff format --check` — clean

This pull request and its description were written by Isaac.