### PR TITLE
[mason] init: scaffold commented memory/session store examples in agent.toml

### DIFF
--- a/integrations/mason/src/databricks_mason/agent_project.py
+++ b/integrations/mason/src/databricks_mason/agent_project.py
@@ -27,6 +27,19 @@ TRACING_TABLE = "tracing"
 
 _SCHEMA_VERSION = 1
 _DURABILITY_TABLE = "durability"
+# Commented-out store bindings written into a freshly scaffolded agent.toml (None = blank line).
+_STORE_EXAMPLE_LINES = (
+    None,
+    "Managed long-term memory (optional): `mason deploy` creates + binds one by default;",
+    "run `mason memory bind <name>`, or uncomment and set a store name here:",
+    "[memory_store]",
+    'name = "my-memory-store"',
+    None,
+    "Durable conversation history (optional): `mason deploy` creates + binds one by default;",
+    "run `mason sessions bind <name>`, or uncomment and set a store name here:",
+    "[session_store]",
+    'name = "my-session-store"',
+)
 _SUPPORTED_FRAMEWORKS = {"langgraph", "openai"}
 _SUPPORTED_SCOPE_KINDS = {"table", "volume", "workspace"}
 _SUPPORTED_PERMISSIONS = {"read_only", "read_write"}
@@ -418,6 +431,11 @@ class AgentProject:
         durability = tomlkit.table()
         durability.add("enabled", durability_enabled)
         document.add(_DURABILITY_TABLE, durability)
+        # Commented examples so a fresh project shows how managed stores are bound. `mason deploy`
+        # creates + binds these by default; uncomment (or run `mason memory/sessions bind`) to pin
+        # specific store names. They're comments, so `load` treats the project as unbound until then.
+        for line in _STORE_EXAMPLE_LINES:
+            document.add(tomlkit.nl() if line is None else tomlkit.comment(line))
         return cls(
             project_root,
             document,

--- a/integrations/mason/tests/unit_tests/agent_project_test.py
+++ b/integrations/mason/tests/unit_tests/agent_project_test.py
@@ -152,6 +152,18 @@ def test_bind_and_unbind_stores_round_trip(tmp_path: pathlib.Path):
     assert final.memory_store == "mem"
 
 
+def test_create_scaffolds_commented_store_examples(tmp_path: pathlib.Path):
+    AgentProject.create(tmp_path, framework="openai").write()
+    text = (tmp_path / "agent.toml").read_text(encoding="utf-8")
+    # Commented example bindings show the shape without activating a store.
+    assert "# [memory_store]" in text
+    assert "# [session_store]" in text
+    assert "mason memory bind" in text and "mason sessions bind" in text
+    reloaded = AgentProject.load(tmp_path)
+    assert reloaded.memory_store is None
+    assert reloaded.session_store is None
+
+
 def test_deployment_name_round_trips(tmp_path: pathlib.Path):
     _write_manifest(tmp_path)
     project = AgentProject.load(tmp_path)


### PR DESCRIPTION
## Summary

`mason init` now scaffolds an `agent.toml` that shows how managed stores are bound. `AgentProject.create` appends commented-out `[memory_store]` / `[session_store]` sections:

```toml
schema_version = 1

[agent]
framework = "openai"

# Managed long-term memory (optional): `mason deploy` creates + binds one by default;
# run `mason memory bind <name>`, or uncomment and set a store name here:
# [memory_store]
# name = "my-memory-store"

# Durable conversation history (optional): `mason deploy` creates + binds one by default;
# run `mason sessions bind <name>`, or uncomment and set a store name here:
# [session_store]
# name = "my-session-store"
```

They're comments, so nothing changes behaviorally — `AgentProject.load` still treats the project as unbound until the user uncomments (or runs `mason memory/sessions bind`, or lets `mason deploy` auto-create them). Stores can't be created at `init` time (offline, no workspace), so example scaffolding is the right shape rather than a live binding.

## Test plan
- [x] `pytest tests/unit_tests/` — 455 passed. Added a test asserting the created manifest carries the commented `[memory_store]`/`[session_store]` examples and still loads as unbound.
- [x] `ruff check` / `ruff format --check` — clean

This pull request and its description were written by Isaac.