### PR TITLE
[mason] add a `claude` agent framework template on the Anthropic Tool Runner

### DIFF
--- a/integrations/mason/pyproject.toml
+++ b/integrations/mason/pyproject.toml
@@ -48,6 +48,17 @@ runtime-openai = [
     "databricks-agents>=1.9.3",
     "uvicorn>=0.20.0",
 ]
+# `runtime-claude` = the Anthropic SDK Tool Runner adapter (databricks_mason.claude). Same shared
+# framework-neutral stack; the framework SDK is `anthropic` (no OpenAI/LangGraph deps).
+runtime-claude = [
+    "databricks-ai-bridge[memory]>=0.21.0",
+    "anthropic>=0.69.0",
+    "fastapi>=0.129.0",
+    "mlflow>=3.10.1",
+    "opentelemetry-exporter-otlp-proto-grpc>=1.25.0",
+    "databricks-agents>=1.9.3",
+    "uvicorn>=0.20.0",
+]
 
 [project.scripts]
 mason = "databricks_mason.cli:main"

--- a/integrations/mason/src/databricks_mason/agent_project.py
+++ b/integrations/mason/src/databricks_mason/agent_project.py
@@ -23,7 +23,7 @@ TRACING_TABLE = "tracing"
 
 _SCHEMA_VERSION = 1
 _DURABILITY_TABLE = "durability"
-_SUPPORTED_FRAMEWORKS = {"langgraph", "openai"}
+_SUPPORTED_FRAMEWORKS = {"langgraph", "openai", "claude"}
 _SUPPORTED_SCOPE_KINDS = {"table", "volume", "workspace"}
 _SUPPORTED_PERMISSIONS = {"read_only", "read_write"}
 _TOOL_ID = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.-]*$")

--- a/integrations/mason/src/databricks_mason/claude/__init__.py
+++ b/integrations/mason/src/databricks_mason/claude/__init__.py
@@ -1,0 +1,85 @@
+"""Anthropic SDK Tool Runner adapter for running an agent on Databricks (installed via ``databricks-mason[runtime-claude]``).
+
+Composable pieces you drop into an agent built on the Anthropic Python SDK's Tool Runner
+(``client.beta.messages.tool_runner`` / ``@beta_tool``) — a conversation-history helper, MCP servers
+declared in ``agent.toml``, long-term memory tools, MLflow tracing, and an ``anthropic`` client that
+picks up ``ANTHROPIC_API_KEY`` (or Bedrock)::
+
+    from databricks_mason.claude import (
+        client,
+        configure_tracing,
+        mcp_servers,
+        memory_tools,
+        session_history,
+    )
+
+    configure_tracing()
+    history = session_history(session_id, actor)
+    runner = client().beta.messages.tool_runner(
+        model="claude-opus-5",
+        max_tokens=16000,
+        tools=[*your_tools, *memory_tools(actor)],
+        messages=[*history.load(), *new_messages],
+    )
+
+These need the agent stack (anthropic, mlflow), so they sit behind the ``[runtime-claude]`` extra to
+keep a plain ``databricks-mason`` CLI install light. ``__all__`` is the curated surface.
+"""
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from databricks_mason.claude.client import client
+    from databricks_mason.claude.mcp import mcp_servers
+    from databricks_mason.claude.memory import memory_tools
+    from databricks_mason.claude.sessions import session_history
+    from databricks_mason.runtime import tag_session, workspace_client, workspace_headers
+
+
+def configure_tracing() -> None:
+    """Enable MLflow tracing with Anthropic autologging. Call once at startup.
+
+    Safe to call unconditionally — tracing turns on only when the MLflow destination and experiment
+    are configured in the environment (see :func:`databricks_mason.runtime.configure_tracing`).
+    """
+    import mlflow
+
+    from databricks_mason.runtime import configure_tracing as _configure_tracing
+
+    _configure_tracing(autolog=mlflow.anthropic.autolog)
+
+
+__all__ = [
+    # An `anthropic` client (Anthropic, or AnthropicBedrock when CLAUDE_CODE_USE_BEDROCK is set).
+    "client",
+    # MCP servers from agent.toml (plus any you pass) — hand to the runner as `mcp_servers=`.
+    "mcp_servers",
+    # Long-term memory tools (opt-in via AGENT_MEMORY_STORE) — add to your tool list.
+    "memory_tools",
+    # Conversation history — the Tool Runner is stateless, so load()/append() the transcript.
+    "session_history",
+    # MLflow tracing (Anthropic autolog bound in) — call configure_tracing() once at startup.
+    "configure_tracing",
+    "tag_session",
+    "workspace_client",
+    "workspace_headers",
+]
+
+_MODULE_BY_NAME = {
+    "client": "databricks_mason.claude.client",
+    "mcp_servers": "databricks_mason.claude.mcp",
+    "memory_tools": "databricks_mason.claude.memory",
+    "session_history": "databricks_mason.claude.sessions",
+    "tag_session": "databricks_mason.runtime",
+    "workspace_client": "databricks_mason.runtime",
+    "workspace_headers": "databricks_mason.runtime",
+}
+
+
+def __getattr__(name: str) -> object:
+    module = _MODULE_BY_NAME.get(name)
+    if module is None:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+    import importlib
+
+    return getattr(importlib.import_module(module), name)

--- a/integrations/mason/src/databricks_mason/claude/client.py
+++ b/integrations/mason/src/databricks_mason/claude/client.py
@@ -1,0 +1,24 @@
+"""Construct the Anthropic client the agent calls Claude through.
+
+Defaults to ``anthropic.Anthropic()`` (reads ``ANTHROPIC_API_KEY``). Set ``CLAUDE_CODE_USE_BEDROCK``
+to route through Amazon Bedrock using the app's AWS credentials instead — no Anthropic key needed.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+
+
+def use_bedrock() -> bool:
+    """Whether to route through Bedrock (``CLAUDE_CODE_USE_BEDROCK`` set to a truthy value)."""
+    return os.getenv("CLAUDE_CODE_USE_BEDROCK", "").strip().lower() in {"1", "true", "yes"}
+
+
+def client() -> Any:
+    """An ``anthropic`` client: ``AnthropicBedrock`` when ``CLAUDE_CODE_USE_BEDROCK`` is set, else ``Anthropic``."""
+    import anthropic
+
+    if use_bedrock():
+        return anthropic.AnthropicBedrock()
+    return anthropic.Anthropic()

--- a/integrations/mason/src/databricks_mason/claude/mcp.py
+++ b/integrations/mason/src/databricks_mason/claude/mcp.py
@@ -1,0 +1,83 @@
+"""MCP servers for the agent, from the ones declared in ``agent.toml`` (plus any the agent adds).
+
+``mcp_servers()`` reads the MCP servers declared in ``agent.toml`` (sandbox/mcp + uc_function) and
+returns Anthropic MCP-connector server dicts (``{"type": "url", "name", "url", "authorization_token"}``)
+to hand the Tool Runner as ``mcp_servers=`` (with beta ``mcp-client-2025-11-20`` and an ``mcp_toolset``
+tool). Fail-open to ``[]`` — an empty ``agent.toml`` yields no servers, and any build error is logged
+and skipped so it never fails the request.
+
+First cut: the Databricks-hosted MCP services are wired best-effort with the caller's bearer token;
+sandbox downscoping is not applied through the connector yet.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from databricks_mason.runtime.tool_manifest import (
+    ToolManifestError,
+    ToolRecord,
+    load_tools,
+)
+from databricks_mason.runtime.workspace import workspace_client
+
+logger = logging.getLogger(__name__)
+
+_FRAMEWORK = "claude"
+
+# The beta header the Anthropic MCP connector requires; pass it to the runner alongside mcp_servers.
+MCP_CONNECTOR_BETA = "mcp-client-2025-11-20"
+
+
+def _bearer_token(client: Any) -> str | None:
+    try:
+        auth = client.config.authenticate() or {}
+    except Exception:
+        return None
+    return (auth.get("Authorization") or "").removeprefix("Bearer ").strip() or None
+
+
+def _server_from_tool(tool: ToolRecord, client: Any, host: str, token: str | None) -> dict | None:
+    if tool.kind in {"sandbox", "mcp"}:
+        server = {
+            "type": "url",
+            "name": tool.id,
+            "url": f"{host}/ai-gateway/mcp-services/{tool.service}",
+        }
+    elif tool.kind == "uc_function":
+        server = {
+            "type": "url",
+            "name": tool.id,
+            "url": f"{host}/api/2.0/mcp/functions/{tool.function}",
+        }
+    else:
+        return None
+    if token:
+        server["authorization_token"] = token
+    return server
+
+
+def _declared_servers() -> list[dict]:
+    tools = load_tools(expected_framework=_FRAMEWORK)
+    if not tools:
+        return []
+    client = workspace_client()
+    host = client.config.host.rstrip("/")
+    token = _bearer_token(client)
+    return [s for tool in tools if (s := _server_from_tool(tool, client, host, token)) is not None]
+
+
+def mcp_servers(extra_servers: list[dict] | None = None) -> list[dict]:
+    """Build the agent's MCP-connector server dicts. Fail-open to ``[]``.
+
+    Includes the servers declared in ``agent.toml``; pass ``extra_servers`` to add your own. Returns
+    an empty list when there are none or construction fails, so it is safe to spread into the runner.
+    """
+    try:
+        return [*_declared_servers(), *(extra_servers or [])]
+    except ToolManifestError:
+        raise
+    except Exception:
+        logger.warning("Failed to build MCP servers; continuing without them.", exc_info=True)
+        return []

--- a/integrations/mason/src/databricks_mason/claude/memory.py
+++ b/integrations/mason/src/databricks_mason/claude/memory.py
@@ -1,0 +1,71 @@
+"""Long-term memory tools — opt-in, gated on ``AGENT_MEMORY_STORE``.
+
+Exposes two Tool Runner tools — ``remember`` and ``recall`` — over the Databricks managed memory
+store's ``agents/v1`` entries API, so facts persist across conversations. ``memory_tools(actor)``
+returns the tools when a memory store is configured, else an empty list.
+
+``actor`` is the identity whose memory these tools read and write; it is **closed over**, not a tool
+argument, so the model can't set or spoof it. Pass a fixed value for one shared memory.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from anthropic import beta_tool
+
+from databricks_mason.runtime.workspace import workspace_client
+
+_AGENTS_V1 = "/api/agents/v1"
+
+
+def _api():
+    # Build the client lazily (needs workspace auth) so importing this module stays cheap.
+    return workspace_client().api_client
+
+
+def memory_tools(actor: str, store: str | None = None) -> list[Any]:
+    """The long-term-memory tools for ``actor`` when a memory store is configured, else none.
+
+    The store resolves ``store`` arg → ``AGENT_MEMORY_STORE`` env → the ``[memory_store]`` binding in
+    agent.toml (`mason memory bind`) → none (no tools). ``actor`` partitions the store; it is captured
+    in the tools' closures (not exposed to the model).
+    """
+    from databricks_mason.runtime.tool_manifest import resolve_memory_store
+
+    store = resolve_memory_store(store)
+    if not store:
+        return []
+    store_path = f"{_AGENTS_V1}/memory-stores/{store}"
+
+    @beta_tool
+    def remember(fact: str, topic: str) -> str:
+        """Persist a durable fact about the user in long-term memory.
+
+        Args:
+            fact: The fact to remember.
+            topic: A short topic to file the fact under.
+        """
+        _api().do(
+            "POST",
+            f"{store_path}/entries",
+            body={"actor_id": actor, "path": f"/{topic}/{fact[:8]}.md", "content": fact},
+        )
+        return "stored"
+
+    @beta_tool
+    def recall(query: str) -> str:
+        """Search the user's long-term memory for facts relevant to the query.
+
+        Args:
+            query: What to search the user's long-term memory for.
+        """
+        data = _api().do(
+            "POST",
+            f"{store_path}/entries:search",
+            body={"actor_id": actor, "query": query, "limit": 5},
+        )
+        entries = data.get("managed_memory_entries") or []
+        return "\n".join(f"- {e.get('content')}" for e in entries) or "No relevant memories."
+
+    return [remember, recall]

--- a/integrations/mason/src/databricks_mason/claude/sessions.py
+++ b/integrations/mason/src/databricks_mason/claude/sessions.py
@@ -1,0 +1,110 @@
+"""Conversation history for the agent.
+
+The Anthropic Tool Runner is stateless: each turn you pass the full ``messages`` list and read back
+the new ones. ``session_history(session_id, actor)`` returns a small store you ``load()`` prior
+messages from and ``append()`` new ones to.
+
+Default (no config): an in-process dict keyed by session id — multi-turn works within one process,
+not across restarts/replicas. Durable (``AGENT_SESSION_STORE`` set): each message is stored as one
+item through the managed Session Store REST API (no Lakebase/Postgres connection), durable across
+restarts and replicas. Setting the env var is the only change; the agent code is identical.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Optional
+
+from databricks_mason.runtime.session_store_client import Session as _StoreSession
+from databricks_mason.runtime.session_store_client import SessionStoreClient
+
+_ORDER_BY = "create_time asc"
+
+# One in-process transcript per session id (the durable store needs no cache).
+_local_history: dict[str, list[dict[str, Any]]] = {}
+
+
+class _History:
+    """Load/append a conversation transcript as a list of Anthropic message dicts."""
+
+    def load(self) -> list[dict[str, Any]]:  # pragma: no cover - overridden
+        raise NotImplementedError
+
+    def append(self, messages: list[dict[str, Any]]) -> None:  # pragma: no cover - overridden
+        raise NotImplementedError
+
+
+def session_history(
+    session_id: str, actor: str | None = None, store: str | None = None
+) -> _History:
+    """The transcript store for ``session_id``: in-process by default, durable when a store is set.
+
+    The store name resolves ``store`` arg → ``AGENT_SESSION_STORE`` env → the ``[session_store]``
+    binding in agent.toml (`mason sessions bind`) → none. ``actor`` partitions the durable store.
+    """
+    from databricks_mason.runtime.tool_manifest import resolve_session_store
+
+    store = resolve_session_store(store)
+    if store:
+        return _DurableHistory(session_id, store, actor or session_id)
+    return _LocalHistory(session_id)
+
+
+class _LocalHistory(_History):
+    def __init__(self, session_id: str) -> None:
+        self._session_id = session_id
+
+    def load(self) -> list[dict[str, Any]]:
+        return list(_local_history.get(self._session_id, []))
+
+    def append(self, messages: list[dict[str, Any]]) -> None:
+        if messages:
+            _local_history.setdefault(self._session_id, []).extend(messages)
+
+
+class _DurableHistory(_History):
+    """Transcript backed by the Databricks Session Store REST API (one item per message)."""
+
+    def __init__(
+        self,
+        session_id: str,
+        session_store_name: str,
+        actor_id: str,
+        client: Optional[SessionStoreClient] = None,
+    ) -> None:
+        self._session_id = session_id
+        self._actor_id = actor_id
+        self._client = (client or SessionStoreClient()).set_session_store(session_store_name)
+        self._session: _StoreSession | None = None
+
+    def load(self) -> list[dict[str, Any]]:
+        return [item.data for item in self._client.list_items(self._resolve(), order_by=_ORDER_BY)]
+
+    def append(self, messages: list[dict[str, Any]]) -> None:
+        if messages:
+            self._client.append_items(self._resolve(), items=list(messages))
+
+    def _resolve(self) -> _StoreSession:
+        if self._session is not None:
+            return self._session
+        try:
+            self._session = self._client.get_session(session_id=self._session_id)
+        except tuple(_not_found_errors()):
+            self._session = self._client.create_session(
+                actor_id=self._actor_id,
+                session_id=self._session_id,
+                metadata={"client": "mason-claude-agent"},
+            )
+        return self._session
+
+
+def _not_found_errors() -> tuple[type, ...]:
+    try:
+        from databricks.sdk.errors import NotFound
+
+        return (NotFound,)
+    except ImportError:  # pragma: no cover - SDK always present in practice
+        return (_SessionNotFound,)
+
+
+class _SessionNotFound(Exception):
+    """Fallback 'not found' used only when databricks.sdk is unavailable."""

--- a/integrations/mason/src/databricks_mason/init.py
+++ b/integrations/mason/src/databricks_mason/init.py
@@ -44,6 +44,11 @@ _TEMPLATES: dict[str, dict[str, str]] = {
         "ref": "main",
         "path": "integrations/mason/templates/agent-langgraph",
     },
+    "claude": {
+        "repo": _MASON_REPO,
+        "ref": "main",
+        "path": "integrations/mason/templates/agent-claude",
+    },
 }
 
 _CUSTOM_SERVER_TEMPLATES: dict[str, dict[str, str]] = {

--- a/integrations/mason/src/databricks_mason/project_config.py
+++ b/integrations/mason/src/databricks_mason/project_config.py
@@ -14,7 +14,7 @@ from databricks_mason.errors import AgentCliError
 
 _CONFIG_PATH = pathlib.Path(".mason/project.toml")
 _SCHEMA_VERSION = 1
-_SUPPORTED_FRAMEWORKS = {"langgraph", "openai"}
+_SUPPORTED_FRAMEWORKS = {"langgraph", "openai", "claude"}
 _CUSTOM_SERVER_TEMPLATES = frozenset({"custom-agent-langgraph", "custom-agent-openai"})
 
 
@@ -108,6 +108,7 @@ def _infer_legacy_framework(project: pathlib.Path) -> ProjectMetadata:
         for package, framework in (
             ("databricks-openai", "openai"),
             ("databricks-langchain", "langgraph"),
+            ("anthropic", "claude"),
         )
         if package in packages
     }

--- a/integrations/mason/templates/agent-claude/.env.example
+++ b/integrations/mason/templates/agent-claude/.env.example
@@ -1,0 +1,29 @@
+# Copy to .env for local development:  cp .env.example .env
+#
+# This agent calls Claude through the Anthropic API, so a credential is REQUIRED for local dev.
+# Everything else — MLflow tracing, long-term memory, durable state — is optional and off by default.
+
+# --- Required: Anthropic model access ---
+# An Anthropic API key (https://console.anthropic.com/). Or set CLAUDE_CODE_USE_BEDROCK=1 below to
+# route through Amazon Bedrock with your AWS credentials instead of a key.
+ANTHROPIC_API_KEY=
+# CLAUDE_CODE_USE_BEDROCK=1
+
+# Model (optional; defaults to claude-opus-5). A request may also override it via input.model.
+# AGENT_CLAUDE_MODEL=claude-opus-5
+
+# --- Optional: MLflow tracing ---
+# Leave UNSET to skip tracing. To enable, set a destination AND an experiment.
+# MLFLOW_TRACKING_URI="databricks"
+# MLFLOW_EXPERIMENT_ID=
+# MLFLOW_EXPERIMENT_NAME=
+
+# --- Optional: long-term memory tools ---
+# Set to a managed memory store ID to register the remember/recall tools; see
+# databricks_mason/claude/memory.py.
+# AGENT_MEMORY_STORE=<memory-store-id>
+
+# --- Optional: durable conversation history (managed Session Store) ---
+# Leave UNSET to keep the in-process transcript (multi-turn within one process, not across
+# restarts/replicas). Set to a managed Session Store name to persist history over its REST API.
+# AGENT_SESSION_STORE=my-agent-sessions

--- a/integrations/mason/templates/agent-claude/.gitignore
+++ b/integrations/mason/templates/agent-claude/.gitignore
@@ -1,0 +1,5 @@
+.venv/
+__pycache__/
+*.pyc
+.env
+uv.lock

--- a/integrations/mason/templates/agent-claude/AGENTS.md
+++ b/integrations/mason/templates/agent-claude/AGENTS.md
@@ -1,0 +1,62 @@
+# Agent Development Guide
+
+This project is an Anthropic Tool Runner workload hosted by `databricks_mason.AgentApp`.
+
+## Commands
+
+```bash
+mason dev
+uv run pytest
+mason --profile <profile> deploy <name> --source .
+```
+
+## Request contract
+
+Use only `/api/invocations`. The transport body is:
+
+```json
+{
+  "id": "<uuid>",
+  "input": {
+    "session_id": "<stable-application-session>",
+    "messages": [{"role": "user", "content": "hello"}],
+    "resume": null,
+    "model": "optional-claude-model"
+  },
+  "background": false,
+  "stream": false
+}
+```
+
+`id` is the invocation identifier and idempotency key. Everything framework-specific belongs in
+`input`. The Apps router cookie is only for sticky routing, not application session state.
+
+## Model access
+
+Claude is reached through the Anthropic API — set `ANTHROPIC_API_KEY`, or `CLAUDE_CODE_USE_BEDROCK=1`
+for Bedrock. Default model `claude-opus-5` (`AGENT_CLAUDE_MODEL` / `input.model` override).
+
+## Code map
+
+| Change | File |
+| --- | --- |
+| Model, tools, HITL, event mapping | `agent/agent.py` |
+| Local tools (`@beta_tool`) | `agent/tools/` |
+| MCP servers | `agent/mcps.py` |
+| Mason server and durable-runtime option | `runtime/main.py` |
+
+`runtime/main.py` must stay a thin layer: construct `AgentApp`, register `invoke`, and register
+`on_recovery` when `DURABLE_RUNTIME` is enabled.
+
+## State and recovery
+
+- Invocation state/events: in-memory in `mason dev`; Lakebase after deploy (durable runtime on).
+- Conversation history: in-process by default; managed Session Store when bound (`databricks_mason.claude.session_history`).
+- Long-term memory: managed Memory Store when bound (`memory_tools`).
+- Human approval: gated tools in `REQUIRE_APPROVAL` surface an `interrupt`; pauses are in-process.
+- Recovery: the Tool Runner owns its loop, so recovery replays input against the persisted transcript.
+
+## Tools
+
+`agent/tools/all_tools()` auto-imports tool modules. Add a `@beta_tool`-decorated function in a new
+file rather than editing a registry. Gate an action tool by adding its name to `REQUIRE_APPROVAL`.

--- a/integrations/mason/templates/agent-claude/CLAUDE.md
+++ b/integrations/mason/templates/agent-claude/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/integrations/mason/templates/agent-claude/README.md
+++ b/integrations/mason/templates/agent-claude/README.md
@@ -1,0 +1,58 @@
+# Mason Claude Agent
+
+An agent built on the **Anthropic Python SDK Tool Runner** (`client.beta.messages.tool_runner` /
+`@beta_tool`), served by `databricks_mason.AgentApp` on Mason's durable runtime. It calls Claude
+through the Anthropic API.
+
+## Model access (required)
+
+Unlike the other Mason templates, this one calls the Anthropic API rather than Databricks Model
+Serving, so it needs an Anthropic credential:
+
+- set **`ANTHROPIC_API_KEY`** (from the Anthropic Console), or
+- set **`CLAUDE_CODE_USE_BEDROCK=1`** to route through Amazon Bedrock using the app's AWS identity.
+
+Default model is `claude-opus-5`; override with `AGENT_CLAUDE_MODEL` or per request via `input.model`.
+
+## Run locally
+
+```bash
+cp .env.example .env   # set ANTHROPIC_API_KEY
+mason dev
+```
+
+The API is at `http://localhost:8000/api/invocations`. Every request supplies a UUID `id`
+(idempotency key); agent-specific values live in `input`:
+
+```bash
+SESSION_ID=$(uuidgen); INVOCATION_ID=$(uuidgen)
+curl -sS http://localhost:8000/api/invocations \
+  -H 'Content-Type: application/json' \
+  -d "{\"id\":\"$INVOCATION_ID\",\"input\":{\"session_id\":\"$SESSION_ID\",\"messages\":[{\"role\":\"user\",\"content\":\"What time is it? Use your tool.\"}]}}"
+```
+
+Reuse `SESSION_ID` for multi-turn history; generate a new `INVOCATION_ID` per turn.
+
+## Human approval
+
+`send_message` is gated (listed in `REQUIRE_APPROVAL` in `agent/agent.py`). When the model calls it
+the agent stops before running it and returns an `interrupt`; resume with the same session id:
+
+```json
+{"id": "<new-uuid>", "input": {"session_id": "<same-session-id>", "resume": {"decisions": [{"type": "approve"}]}}}
+```
+
+Approval pauses are in-process (not durable), matching the other Mason templates.
+
+## Configure and deploy
+
+- Change the model/system prompt and tool assembly in `agent/agent.py`.
+- Add local tools under `agent/tools/` (`@beta_tool`); modules are auto-discovered.
+- Add MCP servers in `agent/mcps.py` or with `mason tools add mcp`.
+- Bind long-term memory with `mason memory bind <store>`; durable history with `mason sessions bind <store>`.
+
+```bash
+mason --profile <profile> deploy agent-claude --source .
+```
+
+Set `ANTHROPIC_API_KEY` (or `CLAUDE_CODE_USE_BEDROCK`) in `app.yaml`'s `env` before deploying.

--- a/integrations/mason/templates/agent-claude/agent/agent.py
+++ b/integrations/mason/templates/agent-claude/agent/agent.py
@@ -1,0 +1,232 @@
+import logging
+import os
+from collections.abc import AsyncGenerator
+from typing import Any
+
+from agent.mcps import build_mcp_servers
+
+# Importing the tools package auto-registers every tool module.
+from agent.tools import all_tools
+from databricks_mason import DurableAgentContext, tag_session
+from databricks_mason.claude import (
+    client as claude_client,
+    configure_tracing,
+    mcp_servers,
+    memory_tools,
+    session_history,
+)
+from databricks_mason.claude.mcp import MCP_CONNECTOR_BETA
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_MODEL = "claude-opus-5"
+MAX_TOKENS = 16000
+
+# Tools that require human approval before they run. When the model calls one, the agent stops before
+# executing it and emits an `interrupt`; the client resumes by sending `resume` with the same session
+# id. Empty it to disable approval gating.
+REQUIRE_APPROVAL = {"send_message"}
+
+
+def configure() -> None:
+    """Wire up global state; call once at server startup (not at import)."""
+    _check_anthropic_auth()
+    configure_tracing()
+
+
+def _check_anthropic_auth() -> None:
+    """Fail fast at startup with a clear message if no Anthropic credential is configured."""
+    from databricks_mason.claude.client import use_bedrock
+
+    if use_bedrock() or os.getenv("ANTHROPIC_API_KEY"):
+        return
+    raise RuntimeError(
+        "Anthropic auth is not configured — the agent can't call Claude.\n"
+        "Fix one of:\n"
+        "  • set ANTHROPIC_API_KEY (an Anthropic API key) in .env / the app env, or\n"
+        "  • set CLAUDE_CODE_USE_BEDROCK=1 to route through Amazon Bedrock with the app's AWS creds."
+    )
+
+
+def _model(payload: dict[str, Any]) -> str:
+    """The serving model for this run: request ``model`` → ``AGENT_CLAUDE_MODEL`` env → default."""
+    model = payload.get("model")
+    if isinstance(model, str) and model:
+        return model
+    return os.getenv("AGENT_CLAUDE_MODEL", DEFAULT_MODEL)
+
+
+def create_tools(actor: str) -> list[Any]:
+    """The agent's tools: local ``@beta_tool`` tools + long-term-memory tools for ``actor``."""
+    return [*all_tools(), *memory_tools(actor)]
+
+
+def _payload(value: Any) -> dict[str, Any]:
+    """Normalize the application payload carried inside the durable request's ``input`` field."""
+    if isinstance(value, list):
+        return {"messages": value}
+    if not isinstance(value, dict):
+        raise ValueError("input must be a message list or an object")
+    return value
+
+
+def _session_id(payload: dict[str, Any], context: DurableAgentContext) -> str:
+    value = payload.get("session_id") or context.session_id
+    if not isinstance(value, str) or not value:
+        raise ValueError("session_id must be a non-empty string")
+    return value
+
+
+def _actor(payload: dict[str, Any], session_id: str) -> str:
+    value = payload.get("actor") or session_id
+    if not isinstance(value, str) or not value:
+        raise ValueError("actor must be a non-empty string")
+    return value
+
+
+async def invoke(value: Any, context: DurableAgentContext) -> dict:
+    """Run the first attempt for one durable invocation."""
+    return await _run_agent(_payload(value), context)
+
+
+async def on_recovery(value: Any, context: DurableAgentContext) -> dict:
+    """Replay the persisted application input after the runtime replaces a stale worker.
+
+    The Tool Runner owns its loop, so a mid-run pause can't be restored; recovery replays the input
+    against the persisted transcript (same limitation as the other Mason templates' HITL).
+    """
+    return await _run_agent(_payload(value), context)
+
+
+async def _run_agent(payload: dict[str, Any], context: DurableAgentContext) -> dict:
+    session_id = _session_id(payload, context)
+    actor = _actor(payload, session_id)
+    tag_session(session_id)
+
+    outputs = [
+        event
+        async for event in _persisted_agent_events(payload, context, session_id, actor)
+        if event.get("type") in ("message", "interrupt")
+    ]
+    interrupted = bool(outputs and outputs[-1].get("type") == "interrupt")
+    return {
+        "output": [event["message"] if event["type"] == "message" else event for event in outputs],
+        "session_id": session_id,
+        "status": "interrupted" if interrupted else "completed",
+    }
+
+
+async def _persisted_agent_events(
+    payload: dict[str, Any],
+    context: DurableAgentContext,
+    session_id: str,
+    actor: str,
+) -> AsyncGenerator[dict, None]:
+    async for event in _agent_events(payload, session_id, actor):
+        await context.emit(event)
+        yield event
+
+
+async def _agent_events(
+    payload: dict[str, Any], session_id: str, actor: str
+) -> AsyncGenerator[dict, None]:
+    """Translate one Tool Runner run into persisted runtime events.
+
+    The runner is stateless, so prior turns come from the durable transcript and new turns are
+    appended after the run. History persists the user turn and the assistant's final text (not
+    intermediate tool calls), keeping the stored transcript a valid user/assistant alternation.
+    """
+    history = session_history(session_id, actor)
+    prior = history.load()
+
+    resume = payload.get("resume")
+    approve_all = False
+    new_messages: list[dict[str, Any]] = []
+    if resume is not None:
+        if not isinstance(resume, dict):
+            raise ValueError("resume must be an object")
+        approve_all, new_messages = _decisions(resume)
+    else:
+        messages = payload.get("messages") or []
+        if not isinstance(messages, list):
+            raise ValueError("messages must be a list")
+        new_messages = messages
+
+    tools = create_tools(actor)
+    kwargs: dict[str, Any] = {
+        "model": _model(payload),
+        "max_tokens": MAX_TOKENS,
+        "tools": tools,
+        "messages": [*prior, *new_messages],
+    }
+    servers = mcp_servers(build_mcp_servers())
+    if servers:
+        kwargs["mcp_servers"] = servers
+        kwargs["betas"] = [MCP_CONNECTOR_BETA]
+
+    interrupted = False
+    answer_parts: list[str] = []
+    # The runner is a sync iterator; each __next__ produces one assistant turn and, before the next,
+    # executes any (non-gated) tool calls. Breaking on a gated call stops before it runs.
+    for message in claude_client().beta.messages.tool_runner(**kwargs):
+        content = list(getattr(message, "content", []) or [])
+        text = "".join(b.text for b in content if getattr(b, "type", None) == "text")
+        if text:
+            answer_parts.append(text)
+            yield {"type": "delta", "content": text, "id": getattr(message, "id", None)}
+        yield {"type": "message", "message": _normalize(content)}
+
+        gated = [
+            block
+            for block in content
+            if getattr(block, "type", None) == "tool_use"
+            and block.name in REQUIRE_APPROVAL
+            and not approve_all
+        ]
+        if gated:
+            interrupted = True
+            for block in gated:
+                yield {
+                    "type": "interrupt",
+                    "id": block.id,
+                    "value": {"action_requests": [{"name": block.name, "args": block.input}]},
+                }
+            break
+
+    persisted = list(new_messages)
+    answer = "\n".join(answer_parts)
+    if answer and not interrupted:
+        persisted.append({"role": "assistant", "content": answer})
+    history.append(persisted)
+
+
+def _decisions(resume: dict) -> tuple[bool, list[dict[str, Any]]]:
+    """Read the approval contract ``{"decisions": [{"type": "approve"|"reject", "message"?}]}``.
+
+    First cut: any ``approve`` lets the gated tool(s) run on the re-run; each ``reject`` adds a user
+    note so the model backs off. Approval isn't mapped to a specific pending call id.
+    """
+    approve_all = False
+    rejections: list[dict[str, Any]] = []
+    for decision in resume.get("decisions") or []:
+        if decision.get("type") == "approve":
+            approve_all = True
+        else:
+            rejections.append(
+                {"role": "user", "content": decision.get("message") or "The user declined that action."}
+            )
+    return approve_all, rejections
+
+
+def _normalize(content: list) -> dict:
+    """Normalize one assistant turn's content blocks to the UI's ``{role, content, tool_calls?}`` shape."""
+    text = "".join(b.text for b in content if getattr(b, "type", None) == "text")
+    tool_calls = [
+        {"name": b.name, "args": b.input}
+        for b in content
+        if getattr(b, "type", None) == "tool_use"
+    ]
+    message: dict[str, Any] = {"role": "assistant", "content": text}
+    if tool_calls:
+        message["tool_calls"] = tool_calls
+    return message

--- a/integrations/mason/templates/agent-claude/agent/mcps.py
+++ b/integrations/mason/templates/agent-claude/agent/mcps.py
@@ -1,0 +1,16 @@
+"""MCP servers to offer the agent — this is where you configure them.
+
+Empty by default: the agent runs with only the MCP servers declared in ``agent.toml``. Add
+MCP-connector server dicts here to offer more; ``agent.py`` joins them with the ``agent.toml``
+servers and passes them to the Tool Runner.
+"""
+
+
+def build_mcp_servers() -> list[dict]:
+    """Return extra Anthropic MCP-connector servers to offer the agent. Empty by default.
+
+    Example::
+
+        return [{"type": "url", "name": "docs", "url": "https://mcp.example.com/sse"}]
+    """
+    return []

--- a/integrations/mason/templates/agent-claude/agent/tools/__init__.py
+++ b/integrations/mason/templates/agent-claude/agent/tools/__init__.py
@@ -1,0 +1,23 @@
+"""Agent tools package.
+
+Every module here is auto-imported, and every Anthropic Tool Runner tool it defines (via the
+``@beta_tool`` decorator) is collected by ``all_tools()``. Drop a new ``*.py`` into this folder with a
+``@beta_tool``-decorated function and it's picked up automatically — no wiring to edit.
+"""
+
+import importlib
+import inspect
+import pkgutil
+
+from anthropic.lib.tools import BetaFunctionTool
+
+
+def all_tools() -> list[BetaFunctionTool]:
+    """Every Tool Runner tool defined across the modules in this package."""
+    tools: list[BetaFunctionTool] = []
+    for module in pkgutil.iter_modules(__path__):
+        mod = importlib.import_module(f"{__name__}.{module.name}")
+        for _, obj in inspect.getmembers(mod, lambda o: isinstance(o, BetaFunctionTool)):
+            if obj not in tools:  # a tool imported into several modules is collected once
+                tools.append(obj)
+    return tools

--- a/integrations/mason/templates/agent-claude/agent/tools/sample_tool.py
+++ b/integrations/mason/templates/agent-claude/agent/tools/sample_tool.py
@@ -1,0 +1,15 @@
+"""Sample tool. A working example — add your own tools as new files in this package.
+
+Decorate a function with ``@beta_tool`` (Anthropic Tool Runner) and it becomes an agent tool; the
+package auto-collects it via ``all_tools()``, which ``create_tools`` uses.
+"""
+
+from datetime import datetime
+
+from anthropic import beta_tool
+
+
+@beta_tool
+def get_current_time() -> str:
+    """Get the current date and time."""
+    return datetime.now().isoformat()

--- a/integrations/mason/templates/agent-claude/agent/tools/send_message.py
+++ b/integrations/mason/templates/agent-claude/agent/tools/send_message.py
@@ -1,0 +1,20 @@
+"""A side-effecting sample tool, gated by human approval.
+
+Unlike ``get_current_time`` (a harmless read), this stands in for an action with real consequences.
+Its name is listed in ``REQUIRE_APPROVAL`` in ``agent/agent.py``: when the model calls it the agent
+stops before running it and emits an ``interrupt``, resuming on an approve/reject decision. Swap the
+body for a real send; the approval gate is what the template is demonstrating.
+"""
+
+from anthropic import beta_tool
+
+
+@beta_tool
+def send_message(recipient: str, body: str) -> str:
+    """Send a message to a recipient. Use when the user asks to notify or message someone.
+
+    Args:
+        recipient: Who to send the message to.
+        body: The message body.
+    """
+    return f"Message sent to {recipient}: {body}"

--- a/integrations/mason/templates/agent-claude/app.yaml
+++ b/integrations/mason/templates/agent-claude/app.yaml
@@ -1,0 +1,17 @@
+command: ["uv", "run", "start-server"]
+# databricks apps listen by default on port 8000
+#
+# The agent calls Claude through the Anthropic API, so it needs a credential — set ANTHROPIC_API_KEY,
+# or CLAUDE_CODE_USE_BEDROCK=1 to use the app's AWS identity via Amazon Bedrock. Mason injects the
+# deployed Lakebase durability endpoint. To enable tracing, add the literal values below.
+#
+# env:
+#   - name: ANTHROPIC_API_KEY
+#     value: "<your-anthropic-api-key>"    # or set CLAUDE_CODE_USE_BEDROCK below instead
+#   # - name: CLAUDE_CODE_USE_BEDROCK
+#   #   value: "1"
+#   # Tracing (set a destination + an experiment).
+#   - name: MLFLOW_TRACKING_URI
+#     value: "databricks"
+#   - name: MLFLOW_EXPERIMENT_ID
+#     value: "<experiment-id>"

--- a/integrations/mason/templates/agent-claude/pyproject.toml
+++ b/integrations/mason/templates/agent-claude/pyproject.toml
@@ -1,0 +1,44 @@
+[project]
+name = "agent-claude"
+version = "0.1.0"
+description = "Anthropic Tool Runner agent on Mason's durable runtime for Databricks Apps"
+readme = "README.md"
+authors = [
+    { name = "Agent Developer", email = "developer@example.com" }
+]
+requires-python = ">=3.11"
+dependencies = [
+    # The agent-side runtime helpers (databricks_mason.runtime) plus the agent stack they need
+    # (anthropic, fastapi, mlflow, …) come from this extra — see the package's
+    # [project.optional-dependencies] runtime-claude.
+    "databricks-mason[runtime-claude]>=0.1.5.dev0",
+    "uvicorn>=0.41.0",
+    "python-dotenv>=1.2.1",
+    "databricks-sdk>=0.79.0",
+    "databricks-agents>=1.9.3",
+]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["agent", "runtime"]
+
+
+[dependency-groups]
+dev = [
+    "hatchling>=1.28.0",
+    "pytest>=9.0.2",
+    "pytest-asyncio>=1.3.0",
+]
+
+[tool.uv]
+default-groups = ["dev"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+asyncio_mode = "auto"
+
+[project.scripts]
+start-server = "runtime.main:main"

--- a/integrations/mason/templates/agent-claude/runtime/main.py
+++ b/integrations/mason/templates/agent-claude/runtime/main.py
@@ -1,0 +1,26 @@
+"""Run the Anthropic Tool Runner agent through Mason's durable application."""
+
+import os
+from pathlib import Path
+
+# Importing the agent is side-effect-free (no env is read until configure()), so it sits up top.
+import agent.agent
+import uvicorn
+from dotenv import load_dotenv
+
+from databricks_mason import AgentApp
+
+# override=False so injected env (from `mason dev -p` or the deploy platform) wins over a checked-in .env.
+load_dotenv(dotenv_path=Path(__file__).parent.parent / ".env", override=False)
+agent.agent.configure()
+
+DURABLE_RUNTIME = True
+
+app = AgentApp(durable_runtime=DURABLE_RUNTIME)
+app.invoke(agent.agent.invoke)
+if DURABLE_RUNTIME:
+    app.on_recovery(agent.agent.on_recovery)
+
+
+def main() -> None:
+    uvicorn.run("runtime.main:app", host="0.0.0.0", port=int(os.getenv("PORT", "8000")))

--- a/integrations/mason/templates/agent-claude/tests/test_agent.py
+++ b/integrations/mason/templates/agent-claude/tests/test_agent.py
@@ -1,0 +1,182 @@
+"""Smoke tests for the Claude agent.
+
+Hermetic tests import only leaf modules and mock the Anthropic client (no live API, no auth), so they
+run anywhere. The live test builds the full agent and calls Claude; it is skipped unless an Anthropic
+credential is configured.
+"""
+
+import os
+
+import pytest
+from anthropic.lib.tools import BetaFunctionTool
+
+from agent.agent import (
+    REQUIRE_APPROVAL,
+    _agent_events,
+    _normalize,
+    _run_agent,
+    invoke,
+    on_recovery,
+)
+from agent.tools import all_tools
+
+
+class _Block:
+    def __init__(self, type, *, text=None, name=None, input=None, id=None):
+        self.type, self.text, self.name, self.input, self.id = type, text, name, input, id
+
+
+class _Msg:
+    def __init__(self, content, *, id="m1", stop_reason="end_turn"):
+        self.content, self.id, self.stop_reason = content, id, stop_reason
+
+
+class _Ctx:
+    session_id = "sess"
+
+    async def emit(self, event):
+        return 0
+
+
+def _fake_client(messages):
+    """A stand-in anthropic client whose tool_runner yields ``messages``."""
+    from types import SimpleNamespace
+
+    def tool_runner(**_kwargs):
+        return iter(messages)
+
+    client = SimpleNamespace(beta=SimpleNamespace(messages=SimpleNamespace(tool_runner=tool_runner)))
+    return lambda: client
+
+
+def test_tools_autoregister():
+    tools = all_tools()
+    assert tools, "expected the sample tools to auto-register"
+    assert all(isinstance(t, BetaFunctionTool) for t in tools)
+    assert {"get_current_time", "send_message"} <= {t.name for t in tools}
+
+
+def test_gated_tool_is_listed_for_approval():
+    assert "send_message" in REQUIRE_APPROVAL
+    assert "send_message" in {t.name for t in all_tools()}
+
+
+def test_normalize_text_and_tool_calls():
+    content = [
+        _Block("text", text="hi"),
+        _Block("tool_use", name="send_message", input={"recipient": "x", "body": "y"}, id="c1"),
+    ]
+    assert _normalize(content) == {
+        "role": "assistant",
+        "content": "hi",
+        "tool_calls": [{"name": "send_message", "args": {"recipient": "x", "body": "y"}}],
+    }
+
+
+@pytest.mark.asyncio
+async def test_agent_events_emit_delta_and_message(monkeypatch):
+    import agent.agent as agent_module
+
+    monkeypatch.setattr(agent_module, "mcp_servers", lambda *_a: [])
+    monkeypatch.setattr(agent_module, "create_tools", lambda _actor: [])
+    monkeypatch.setattr(agent_module, "claude_client", _fake_client([_Msg([_Block("text", text="hello")])]))
+
+    events = [
+        e async for e in _agent_events({"messages": [{"role": "user", "content": "hi"}]}, "s1", "a")
+    ]
+    assert {"type": "delta", "content": "hello", "id": "m1"} in events
+    assert {"type": "message", "message": {"role": "assistant", "content": "hello"}} in events
+
+
+@pytest.mark.asyncio
+async def test_gated_tool_surfaces_interrupt(monkeypatch):
+    import agent.agent as agent_module
+
+    monkeypatch.setattr(agent_module, "mcp_servers", lambda *_a: [])
+    monkeypatch.setattr(agent_module, "create_tools", lambda _actor: [])
+    tool_use = _Block("tool_use", name="send_message", input={"recipient": "x", "body": "y"}, id="call-1")
+    monkeypatch.setattr(agent_module, "claude_client", _fake_client([_Msg([tool_use])]))
+
+    result = await _run_agent({"session_id": "s2", "messages": [{"role": "user", "content": "msg x"}]}, _Ctx())
+    assert result["status"] == "interrupted"
+    assert result["output"][-1] == {
+        "type": "interrupt",
+        "id": "call-1",
+        "value": {"action_requests": [{"name": "send_message", "args": {"recipient": "x", "body": "y"}}]},
+    }
+
+
+@pytest.mark.asyncio
+async def test_run_agent_completed_envelope(monkeypatch):
+    import agent.agent as agent_module
+
+    monkeypatch.setattr(agent_module, "mcp_servers", lambda *_a: [])
+    monkeypatch.setattr(agent_module, "create_tools", lambda _actor: [])
+    monkeypatch.setattr(agent_module, "claude_client", _fake_client([_Msg([_Block("text", text="done")])]))
+
+    result = await _run_agent({"session_id": "s3", "messages": [{"role": "user", "content": "hi"}]}, _Ctx())
+    assert result["session_id"] == "s3"
+    assert result["status"] == "completed"
+    assert result["output"] == [{"role": "assistant", "content": "done"}]
+
+
+def test_memory_tools_present_when_store_configured(monkeypatch):
+    monkeypatch.setenv("AGENT_MEMORY_STORE", "mem-store-1")
+    from databricks_mason.claude import memory_tools
+
+    tools = memory_tools("actor-1")
+    assert [t.name for t in tools] == ["remember", "recall"]
+    assert all(isinstance(t, BetaFunctionTool) for t in tools)
+
+
+def test_memory_tools_absent_without_store(monkeypatch):
+    monkeypatch.delenv("AGENT_MEMORY_STORE", raising=False)
+    from databricks_mason.claude import memory_tools
+
+    assert memory_tools("actor-1") == []
+
+
+def test_configure_raises_clear_error_without_credentials(monkeypatch):
+    from agent.agent import configure
+
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    monkeypatch.delenv("CLAUDE_CODE_USE_BEDROCK", raising=False)
+    with pytest.raises(RuntimeError, match="Anthropic auth is not configured"):
+        configure()
+
+
+@pytest.mark.asyncio
+async def test_invoke_and_recovery_use_same_application_payload(monkeypatch):
+    import agent.agent as agent_module
+
+    calls = []
+
+    async def fake_run_agent(payload, context):
+        calls.append((payload, context))
+        return {"output": []}
+
+    monkeypatch.setattr(agent_module, "_run_agent", fake_run_agent)
+    payload = {"session_id": "session-1", "messages": [{"role": "user", "content": "hi"}]}
+    context = object()
+
+    await invoke(payload, context)
+    await on_recovery(payload, context)
+    assert calls == [(payload, context), (payload, context)]
+
+
+def _has_anthropic_auth() -> bool:
+    return bool(os.getenv("ANTHROPIC_API_KEY") or os.getenv("CLAUDE_CODE_USE_BEDROCK"))
+
+
+@pytest.mark.skipif(not _has_anthropic_auth(), reason="no Anthropic credential; skipping live call")
+@pytest.mark.asyncio
+async def test_agent_responds_end_to_end():
+    from agent.agent import _run_agent, configure
+
+    configure()
+    result = await _run_agent(
+        {"session_id": "e2e", "messages": [{"role": "user", "content": "Reply with: pong"}]},
+        _Ctx(),
+    )
+    assert result["status"] == "completed"
+    assert result["output"]

--- a/integrations/mason/templates/agent-claude/tests/test_runtime.py
+++ b/integrations/mason/templates/agent-claude/tests/test_runtime.py
@@ -1,0 +1,19 @@
+from databricks_mason import AgentApp
+from databricks_mason.runtime.durability.store import InMemoryDurabilityStore
+
+
+async def _invoke(request, context):
+    return request
+
+
+def test_runtime_exposes_only_durable_invocation_routes() -> None:
+    app = AgentApp(durable_runtime=True, durability_store=InMemoryDurabilityStore())
+    app.invoke(_invoke)
+    app.on_recovery(_invoke)
+    paths = app.openapi()["paths"]
+
+    assert paths["/api/invocations"]["post"]
+    assert paths["/api/invocations/{invocation_id}"]["get"]
+    assert paths["/api/invocations/{invocation_id}/events"]["get"]
+    assert "/invocations" not in paths
+    assert "/api/health" not in paths


### PR DESCRIPTION
## Summary

Adds a third `mason` agent framework, **`claude`**, for `mason init --framework claude`. It's built on the pure-Python **Anthropic SDK Tool Runner** (`client.beta.messages.tool_runner` / `@beta_tool`) — deliberately *not* the Claude Agent SDK (which requires the Node `claude` CLI as a subprocess) and *not* the OpenAI stack. It mirrors the `agent-openai` template's layout and mason contracts.

### Why the Tool Runner (not the Claude Agent SDK)
The Claude Agent SDK is Claude Code packaged as a library and shells out to the Node `claude` binary — a poor fit for a pure-Python Databricks App. The Anthropic SDK's Tool Runner is the functional analog of the OpenAI Agents SDK (define tools, it runs the agentic loop) and fits mason's per-turn `invoke` contract cleanly with no extra runtime.

### What's included
- **`databricks_mason.claude`** runtime module (behind a new `[runtime-claude]` extra whose framework dep is `anthropic`): `configure_tracing()` (MLflow `anthropic` autolog), `memory_tools(actor)` (remember/recall as `@beta_tool`), `session_history()` (in-process or durable Session Store — the runner is stateless), `mcp_servers()` (agent.toml MCP-connector servers, fail-open), `client()` (Anthropic, or `AnthropicBedrock` via `CLAUDE_CODE_USE_BEDROCK`).
- **`templates/agent-claude/`**: `agent/`, `runtime/`, `tests/`, `app.yaml`, `.env.example`, docs — mirroring `agent-openai`. `agent.py` drives the Tool Runner and maps its stream to mason's `delta`/`message`/`interrupt` events; HITL gates tools listed in `REQUIRE_APPROVAL`. Default model `claude-opus-5` (`AGENT_CLAUDE_MODEL` / `input.model` override).
- **Auth**: `ANTHROPIC_API_KEY` by default, `CLAUDE_CODE_USE_BEDROCK=1` opt-in. Unlike the other templates, this one calls the Anthropic API (not Databricks serving), so it needs a credential — documented in the README/`app.yaml`, and `configure()` fails fast with a clear message if none is set.
- **Wiring**: `claude` added to `_SUPPORTED_FRAMEWORKS` (both `agent_project.py` and `project_config.py`), `_TEMPLATES` (so `--framework claude` works), and the legacy dependency-inference marker. Shipped **unversioned** (fetched from `main`), not in `_VERSIONED_TEMPLATES`.

### First-cut design notes / compromises
- **History**: the Tool Runner is stateless and doesn't expose its internal message list, so persisted history keeps the user turn + the assistant's final text (not intermediate tool_use/tool_result), which keeps the stored transcript a valid user/assistant alternation across turns.
- **HITL approval**: any `approve` decision allows the gated tool(s) to run on the re-run (not mapped to a specific pending call id); pauses are in-process (not durable), matching the other templates.
- **MCP**: agent.toml-declared servers are wired to the Anthropic MCP connector best-effort (fail-open) and sandbox downscoping is not yet applied through the connector. Default template declares no MCP servers, so this path is inert by default.
- **Streaming**: the sync Tool Runner yields whole assistant turns, so `delta` events carry each turn's text as one chunk rather than token-level deltas.

## Test plan
- [x] `pytest tests/unit_tests/` (mason) — 454 passed (adding `claude` to the framework sets broke nothing).
- [x] `PYTHONPATH=templates/agent-claude pytest templates/agent-claude/tests` — 11 passed, 1 skipped (live). Covers: tool auto-registration, `REQUIRE_APPROVAL`, event serialization (delta/message), gated-tool interrupt + envelope, memory tools present/absent by store config, and the no-credential error.
- [x] `import databricks_mason.claude` clean; `ruff check` / `ruff format --check` clean.

This pull request and its description were written by Isaac.