### PR TITLE
Add Genie visualization downloads

### DIFF
--- a/integrations/langchain/src/databricks_langchain/genie.py
+++ b/integrations/langchain/src/databricks_langchain/genie.py
@@ -65,6 +65,7 @@ def _query_genie_as_agent(
     query_sql = genie_response.query or ""
     query_result = genie_response.result if genie_response.result is not None else ""
     query_conversation_id = genie_response.conversation_id or ""
+    visualizations = genie_response.visualizations
 
     # Create a list of AIMessage to return
     messages = []
@@ -80,17 +81,23 @@ def _query_genie_as_agent(
         messages.append(AIMessage(content=query_result_content, name="query_result"))
 
         # Return with DataFrame included
-        return {
+        response = {
             "messages": messages,
             "conversation_id": query_conversation_id,
             "dataframe": query_result,  # Include raw DataFrame if Genie returned dataframe
         }
+        if visualizations:
+            response["visualizations"] = visualizations
+        return response
     else:
         # String result - just add to messages
         messages.append(AIMessage(content=query_result, name="query_result"))
 
         # Return without DataFrame field
-        return {"messages": messages, "conversation_id": query_conversation_id}
+        response = {"messages": messages, "conversation_id": query_conversation_id}
+        if visualizations:
+            response["visualizations"] = visualizations
+        return response
 
 
 def GenieAgent(
@@ -101,6 +108,7 @@ def GenieAgent(
     message_processor: Optional[Callable] = None,
     client: Optional["WorkspaceClient"] = None,
     return_pandas: bool = False,
+    enable_visualization: bool = False,
 ):
     """Create a genie agent that can be used to query the API. If a description is not provided, the description of the genie space will be used.
 
@@ -114,6 +122,7 @@ def GenieAgent(
                             use the chat history to form the query.
         client: Optional WorkspaceClient instance
         return_pandas: Whether to return results as pandas DataFrames (if False, returns markdown strings)
+        enable_visualization: Whether to ask Genie to generate and download visualization PNGs
 
 
     Examples:
@@ -159,6 +168,7 @@ def GenieAgent(
             genie_space_id,
             client=client,
             return_pandas=return_pandas,
+            enable_visualization=enable_visualization,
         )
 
         # Create a partial function with the genie_space_id pre-filled

--- a/integrations/langchain/tests/unit_tests/test_genie.py
+++ b/integrations/langchain/tests/unit_tests/test_genie.py
@@ -2,7 +2,7 @@ from unittest.mock import patch
 
 import pytest
 from databricks.sdk.service.dashboards import GenieSpace
-from databricks_ai_bridge.genie import Genie, GenieResponse
+from databricks_ai_bridge.genie import Genie, GenieResponse, GenieVizAttachment
 from langchain_core.messages import AIMessage
 
 from databricks_langchain.genie import (
@@ -413,3 +413,27 @@ def test_string_return_no_dataframe_field(MockWorkspaceClient):
         # Message content should be the string
         assert result["messages"][0].content == "String result"
         assert result["conversation_id"] == "conv-str-123"
+
+
+@patch("databricks.sdk.WorkspaceClient")
+def test_visualizations_are_returned(MockWorkspaceClient):
+    MockWorkspaceClient.genie.get_space.return_value = GenieSpace(
+        space_id="space-id",
+        title="Sales Space",
+        description="description",
+    )
+    visualization = GenieVizAttachment(
+        attachment_id="viz-1",
+        query_attachment_id="query-1",
+        title="Sales",
+        content=b"png",
+    )
+    genie_response = GenieResponse(result="Sales results", visualizations=[visualization])
+    genie = Genie("space-id", MockWorkspaceClient)
+
+    with patch.object(genie, "ask_question", return_value=genie_response):
+        result = _query_genie_as_agent(
+            {"messages": [{"role": "user", "content": "Show sales"}]}, genie, "Genie"
+        )
+
+    assert result["visualizations"] == [visualization]

--- a/src/databricks_ai_bridge/genie.py
+++ b/src/databricks_ai_bridge/genie.py
@@ -38,6 +38,17 @@ class GenieResponse:
     conversation_id: Optional[str] = None
     suggested_questions: Optional[List[str]] = None
     text_attachment_content: Optional[str] = ""
+    visualizations: Optional[List["GenieVizAttachment"]] = None
+
+
+@dataclass
+class GenieVizAttachment:
+    """A Genie visualization attachment with its rendered PNG content."""
+
+    attachment_id: str
+    query_attachment_id: Optional[str] = None
+    title: Optional[str] = None
+    content: bytes = b""
 
 
 @mlflow_trace(span_type="PARSER")
@@ -196,6 +207,7 @@ def _parse_attachments(resp: Dict[str, Any]) -> Dict[str, Any]:
         "query_attachment": None,
         "text_attachments": [],
         "suggested_questions_attachment": None,
+        "visualization_attachments": [],
     }
 
     attachments = resp.get("attachments") or []
@@ -217,6 +229,8 @@ def _parse_attachments(resp: Dict[str, Any]) -> Dict[str, Any]:
             result["text_attachments"].append(a)
         elif "suggested_questions" in a:
             result["suggested_questions_attachment"] = a
+        elif "viz" in a:
+            result["visualization_attachments"].append(a)
 
     return result
 
@@ -263,6 +277,7 @@ class Genie:
         client: Optional["WorkspaceClient"] = None,
         truncate_results=False,
         return_pandas: bool = False,
+        enable_visualization: bool = False,
     ):
         self.space_id = space_id
         workspace_client = client or WorkspaceClient()
@@ -274,26 +289,64 @@ class Genie:
         }
         self.truncate_results = truncate_results
         self.return_pandas = return_pandas
+        self.enable_visualization = enable_visualization
 
     @mlflow_trace
     def start_conversation(self, content):
+        body = {"content": content}
+        if self.enable_visualization:
+            body["enable_visualization"] = True
         resp = self.genie._api.do(
             "POST",
             f"/api/2.0/genie/spaces/{self.space_id}/start-conversation",
-            body={"content": content},
+            body=body,
             headers=self.headers,
         )
         return resp
 
     @mlflow_trace
     def create_message(self, conversation_id, content):
+        body = {"content": content}
+        if self.enable_visualization:
+            body["enable_visualization"] = True
         resp = self.genie._api.do(
             "POST",
             f"/api/2.0/genie/spaces/{self.space_id}/conversations/{conversation_id}/messages",
-            body={"content": content},
+            body=body,
             headers=self.headers,
         )
         return resp
+
+    @mlflow_trace
+    def download_visualization(
+        self,
+        conversation_id: str,
+        message_id: str,
+        attachment: Dict[str, Any],
+    ) -> GenieVizAttachment:
+        """Download a visualization attachment and materialize its PNG bytes."""
+        attachment_id = attachment.get("attachment_id")
+        if not attachment_id:
+            raise ValueError("Visualization attachment is missing attachment_id")
+
+        resp = self.genie._api.do(
+            "GET",
+            f"/api/2.0/genie/spaces/{self.space_id}/conversations/{conversation_id}/messages/{message_id}/attachments/{attachment_id}/download-visualization",
+            headers={"Accept": "application/octet-stream"},
+            raw=True,
+        )
+        contents = resp.get("contents") if isinstance(resp, dict) else resp
+        content = contents.read() if hasattr(contents, "read") else contents
+        if not isinstance(content, bytes):
+            raise TypeError("Visualization download did not return PNG bytes")
+
+        viz = attachment.get("viz") or {}
+        return GenieVizAttachment(
+            attachment_id=attachment_id,
+            query_attachment_id=viz.get("query_attachment_id"),
+            title=viz.get("title"),
+            content=content,
+        )
 
     @mlflow_trace
     def poll_for_result(self, conversation_id, message_id):
@@ -305,6 +358,7 @@ class Genie:
             conversation_id=conversation_id,
             suggested_questions=None,
             text_attachment_content=None,
+            visualizations=None,
         ):
             iteration_count = 0
             while iteration_count < MAX_ITERATIONS:
@@ -325,6 +379,7 @@ class Genie:
                         returned_conversation_id,
                         suggested_questions,
                         text_attachment_content,
+                        visualizations,
                     )
                 elif state in ["RUNNING", "PENDING"]:
                     logging.debug("Waiting for query result...")
@@ -337,6 +392,7 @@ class Genie:
                         returned_conversation_id,
                         suggested_questions,
                         text_attachment_content,
+                        visualizations,
                     )
             return GenieResponse(
                 f"Genie query for result timed out after {MAX_ITERATIONS} iterations of 5 seconds",
@@ -345,6 +401,7 @@ class Genie:
                 conversation_id,
                 suggested_questions,
                 text_attachment_content,
+                visualizations,
             )
 
         @mlflow_trace
@@ -413,6 +470,14 @@ class Genie:
                         text_attachment_content = _extract_text_attachment_content_from_attachments(
                             parsed["text_attachments"]
                         )
+                        visualizations = [
+                            self.download_visualization(
+                                returned_conversation_id or conversation_id,
+                                message_id,
+                                attachment,
+                            )
+                            for attachment in parsed["visualization_attachments"]
+                        ] or None
 
                         if parsed["query_attachment"]:
                             query_obj = parsed["query_attachment"].get("query") or {}
@@ -426,6 +491,7 @@ class Genie:
                                     suggested_questions=suggested_questions,
                                     conversation_id=returned_conversation_id,
                                     text_attachment_content=text_attachment_content,
+                                    visualizations=visualizations,
                                 )
 
                         # if there is no query attachment, use text attachment as result
@@ -434,6 +500,7 @@ class Genie:
                             suggested_questions=suggested_questions,
                             conversation_id=returned_conversation_id,
                             text_attachment_content=text_attachment_content,
+                            visualizations=visualizations,
                         )
 
                     elif current_status in {"CANCELLED", "QUERY_RESULT_EXPIRED"}:

--- a/tests/databricks_ai_bridge/test_genie.py
+++ b/tests/databricks_ai_bridge/test_genie.py
@@ -1,7 +1,7 @@
 import random
 from datetime import datetime, timedelta
-from io import StringIO
-from unittest.mock import MagicMock, patch
+from io import BytesIO, StringIO
+from unittest.mock import MagicMock, call, patch
 
 import mlflow
 import pandas as pd
@@ -9,6 +9,7 @@ import pytest
 
 from databricks_ai_bridge.genie import (
     Genie,
+    GenieVizAttachment,
     _count_tokens,
     _extract_suggested_questions_from_attachment,
     _extract_text_attachment_content_from_attachments,
@@ -51,6 +52,32 @@ def test_create_message(genie, mock_workspace_client):
         body={"content": "Hello again"},
         headers=genie.headers,
     )
+
+
+def test_visualizations_are_enabled_on_new_and_follow_up_messages(mock_workspace_client):
+    genie = Genie(space_id="test_space_id", enable_visualization=True)
+    mock_workspace_client.genie._api.do.side_effect = [
+        {"conversation_id": "123", "message_id": "456"},
+        {"conversation_id": "123", "message_id": "789"},
+    ]
+
+    genie.start_conversation("Show sales")
+    genie.create_message("123", "Break it down")
+
+    assert mock_workspace_client.genie._api.do.call_args_list == [
+        call(
+            "POST",
+            "/api/2.0/genie/spaces/test_space_id/start-conversation",
+            body={"content": "Show sales", "enable_visualization": True},
+            headers=genie.headers,
+        ),
+        call(
+            "POST",
+            "/api/2.0/genie/spaces/test_space_id/conversations/123/messages",
+            body={"content": "Break it down", "enable_visualization": True},
+            headers=genie.headers,
+        ),
+    ]
 
 
 def test_poll_for_result_completed_with_text(genie, mock_workspace_client):
@@ -831,9 +858,9 @@ def test_poll_for_result_continues_on_mlflow_tracing_exceptions(genie, mock_work
 
 # Parametrized tests for _parse_attachments
 @pytest.mark.parametrize(
-    "resp,exp_query,exp_texts,exp_questions",
+    "resp,exp_query,exp_texts,exp_questions,exp_visualizations",
     [
-        # All three attachment types
+        # Query, text, and suggested-question attachment types
         (
             {
                 "attachments": [
@@ -848,6 +875,7 @@ def test_poll_for_result_continues_on_mlflow_tracing_exceptions(genie, mock_work
             {"attachment_id": "1", "query": {"query": "SELECT *", "description": "Test"}},
             [{"attachment_id": "2", "text": {"content": "Summary text"}}],
             {"attachment_id": "3", "suggested_questions": {"questions": ["Q1?", "Q2?", "Q3?"]}},
+            [],
         ),
         # Only query
         (
@@ -859,6 +887,7 @@ def test_poll_for_result_continues_on_mlflow_tracing_exceptions(genie, mock_work
             {"attachment_id": "1", "query": {"query": "SELECT 1", "description": "Desc"}},
             [],
             None,
+            [],
         ),
         # Only text
         (
@@ -866,6 +895,7 @@ def test_poll_for_result_continues_on_mlflow_tracing_exceptions(genie, mock_work
             None,
             [{"attachment_id": "2", "text": {"content": "Text only"}}],
             None,
+            [],
         ),
         # Only suggested questions
         (
@@ -877,18 +907,20 @@ def test_poll_for_result_continues_on_mlflow_tracing_exceptions(genie, mock_work
             None,
             [],
             {"attachment_id": "3", "suggested_questions": {"questions": ["Question?"]}},
+            [],
         ),
         # Edge cases - empty text list and None for the single-valued fields
-        ({"attachments": []}, None, [], None),
-        ({}, None, [], None),
-        ({"attachments": None}, None, [], None),
-        ({"attachments": "not a list"}, None, [], None),
+        ({"attachments": []}, None, [], None, []),
+        ({}, None, [], None, []),
+        ({"attachments": None}, None, [], None, []),
+        ({"attachments": "not a list"}, None, [], None, []),
         # Invalid items - only valid dict is parsed
         (
             {"attachments": ["string", 123, None, {"query": {"query": "SELECT 1"}}]},
             {"query": {"query": "SELECT 1"}},
             [],
             None,
+            [],
         ),
         # Multiple query attachments (self-correction) - should return the LAST one
         (
@@ -910,6 +942,7 @@ def test_poll_for_result_continues_on_mlflow_tracing_exceptions(genie, mock_work
             },
             [],
             None,
+            [],
         ),
         # Self-correction: text between the first and last query is superseded and
         # dropped; text after the final query is kept in order.
@@ -937,6 +970,7 @@ def test_poll_for_result_continues_on_mlflow_tracing_exceptions(genie, mock_work
                 {"attachment_id": "6", "text": {"content": "follow-up prompt"}},
             ],
             {"attachment_id": "7", "suggested_questions": {"questions": ["Q2?"]}},
+            [],
         ),
         # A summary text before the query and a trailing text after it must both be
         # kept (the leading summary was previously overwritten).
@@ -954,15 +988,43 @@ def test_poll_for_result_continues_on_mlflow_tracing_exceptions(genie, mock_work
                 {"attachment_id": "3", "text": {"content": "Anything else?"}},
             ],
             None,
+            [],
+        ),
+        # Visualization attachments are identified by the API's viz field.
+        (
+            {
+                "attachments": [
+                    {
+                        "attachment_id": "4",
+                        "viz": {
+                            "title": "Sales by region",
+                            "query_attachment_id": "query_1",
+                        },
+                    }
+                ]
+            },
+            None,
+            [],
+            None,
+            [
+                {
+                    "attachment_id": "4",
+                    "viz": {
+                        "title": "Sales by region",
+                        "query_attachment_id": "query_1",
+                    },
+                }
+            ],
         ),
     ],
 )
-def test_parse_attachments(resp, exp_query, exp_texts, exp_questions):
+def test_parse_attachments(resp, exp_query, exp_texts, exp_questions, exp_visualizations):
     """Test parsing attachments with various input scenarios."""
     result = _parse_attachments(resp)
     assert result["query_attachment"] == exp_query
     assert result["text_attachments"] == exp_texts
     assert result["suggested_questions_attachment"] == exp_questions
+    assert result["visualization_attachments"] == exp_visualizations
 
 
 # Parametrized tests for _extract_suggested_questions_from_attachment
@@ -1049,6 +1111,52 @@ def test_poll_with_all_attachments(genie, mock_workspace_client):
     assert result.text_attachment_content == "Summary"
     assert result.conversation_id == "conv_123"
     assert isinstance(result.result, str)
+
+
+def test_poll_returns_visualizations_with_query_result(genie, mock_workspace_client):
+    visualization = {
+        "attachment_id": "viz_1",
+        "viz": {
+            "title": "Sales by region",
+            "query_attachment_id": "query_1",
+        },
+    }
+    mock_workspace_client.genie._api.do.side_effect = [
+        {
+            "status": "COMPLETED",
+            "conversation_id": "conv_123",
+            "attachments": [
+                {"attachment_id": "query_1", "query": {"query": "SELECT *"}},
+                visualization,
+            ],
+        },
+        {"contents": BytesIO(b"\x89PNG\r\n")},
+        {
+            "statement_response": {
+                "status": {"state": "SUCCEEDED"},
+                "conversation_id": "conv_123",
+                "manifest": {"schema": {"columns": []}},
+                "result": {"data_array": []},
+            }
+        },
+    ]
+
+    result = genie.poll_for_result("conv_123", "msg_456")
+
+    assert result.visualizations == [
+        GenieVizAttachment(
+            attachment_id="viz_1",
+            query_attachment_id="query_1",
+            title="Sales by region",
+            content=b"\x89PNG\r\n",
+        )
+    ]
+    mock_workspace_client.genie._api.do.assert_any_call(
+        "GET",
+        "/api/2.0/genie/spaces/test_space_id/conversations/conv_123/messages/msg_456/attachments/viz_1/download-visualization",
+        headers={"Accept": "application/octet-stream"},
+        raw=True,
+    )
 
 
 def test_poll_text_only_no_query(genie, mock_workspace_client):


### PR DESCRIPTION
## Summary

- add an opt-in `enable_visualization` flag to the core `Genie` client and LangChain `GenieAgent`
- request Genie-generated visualizations for new and continued conversations
- download visualization attachments as typed `GenieVizAttachment` objects containing PNG bytes and attachment metadata
- expose downloaded visualizations in `GenieResponse` and LangChain agent responses without changing behavior when visualization generation is disabled

## Validation

- `uv run --group tests pytest tests/databricks_ai_bridge/test_genie.py -q` — 81 passed
- `uv run ruff check` on changed core and LangChain files — passed
- `uv run ruff format --check` on changed core and LangChain files — passed
- root and LangChain `uv run ty check` — completed successfully
- `uv run --group tests pytest tests/unit_tests/test_genie.py -q` in `integrations/langchain` — 12 passed