### PR TITLE
Expose Genie follow-up clarification questions

### DIFF
--- a/src/databricks_ai_bridge/genie.py
+++ b/src/databricks_ai_bridge/genie.py
@@ -38,6 +38,7 @@ class GenieResponse:
     conversation_id: Optional[str] = None
     suggested_questions: Optional[List[str]] = None
     text_attachment_content: Optional[str] = ""
+    follow_up_question: Optional[str] = None
 
 
 @mlflow_trace(span_type="PARSER")
@@ -238,7 +239,7 @@ def _extract_suggested_questions_from_attachment(attachment) -> Optional[List[st
 
 
 def _extract_text_attachment_content_from_attachments(attachments) -> Optional[str]:
-    """Join the text summaries from a list of Genie API response text attachments."""
+    """Join answer text while excluding blocking follow-up questions."""
     if not isinstance(attachments, list):
         return ""
 
@@ -249,11 +250,31 @@ def _extract_text_attachment_content_from_attachments(attachments) -> Optional[s
         text_obj = attachment.get("text")
         if not isinstance(text_obj, dict):
             continue
+        if text_obj.get("purpose") == "FOLLOW_UP_QUESTION":
+            continue
         content = text_obj.get("content", "")
         if content:
             contents.append(content)
 
     return "\n\n".join(contents)
+
+
+def _extract_follow_up_question_from_attachments(attachments) -> Optional[str]:
+    """Return Genie's blocking clarification, distinct from suggested questions."""
+    if not isinstance(attachments, list):
+        return None
+    for attachment in attachments:
+        if not isinstance(attachment, dict):
+            continue
+        text_obj = attachment.get("text")
+        if not isinstance(text_obj, dict):
+            continue
+        if text_obj.get("purpose") != "FOLLOW_UP_QUESTION":
+            continue
+        content = text_obj.get("content")
+        if isinstance(content, str) and content.strip():
+            return content.strip()
+    return None
 
 
 class Genie:
@@ -305,6 +326,7 @@ class Genie:
             conversation_id=conversation_id,
             suggested_questions=None,
             text_attachment_content=None,
+            follow_up_question=None,
         ):
             iteration_count = 0
             while iteration_count < MAX_ITERATIONS:
@@ -325,6 +347,7 @@ class Genie:
                         returned_conversation_id,
                         suggested_questions,
                         text_attachment_content,
+                        follow_up_question,
                     )
                 elif state in ["RUNNING", "PENDING"]:
                     logging.debug("Waiting for query result...")
@@ -337,6 +360,7 @@ class Genie:
                         returned_conversation_id,
                         suggested_questions,
                         text_attachment_content,
+                        follow_up_question,
                     )
             return GenieResponse(
                 f"Genie query for result timed out after {MAX_ITERATIONS} iterations of 5 seconds",
@@ -345,6 +369,7 @@ class Genie:
                 conversation_id,
                 suggested_questions,
                 text_attachment_content,
+                follow_up_question,
             )
 
         @mlflow_trace
@@ -413,6 +438,9 @@ class Genie:
                         text_attachment_content = _extract_text_attachment_content_from_attachments(
                             parsed["text_attachments"]
                         )
+                        follow_up_question = _extract_follow_up_question_from_attachments(
+                            parsed["text_attachments"]
+                        )
 
                         if parsed["query_attachment"]:
                             query_obj = parsed["query_attachment"].get("query") or {}
@@ -426,6 +454,7 @@ class Genie:
                                     suggested_questions=suggested_questions,
                                     conversation_id=returned_conversation_id,
                                     text_attachment_content=text_attachment_content,
+                                    follow_up_question=follow_up_question,
                                 )
 
                         # if there is no query attachment, use text attachment as result
@@ -434,6 +463,7 @@ class Genie:
                             suggested_questions=suggested_questions,
                             conversation_id=returned_conversation_id,
                             text_attachment_content=text_attachment_content,
+                            follow_up_question=follow_up_question,
                         )
 
                     elif current_status in {"CANCELLED", "QUERY_RESULT_EXPIRED"}:

--- a/tests/databricks_ai_bridge/test_genie.py
+++ b/tests/databricks_ai_bridge/test_genie.py
@@ -10,6 +10,7 @@ import pytest
 from databricks_ai_bridge.genie import (
     Genie,
     _count_tokens,
+    _extract_follow_up_question_from_attachments,
     _extract_suggested_questions_from_attachment,
     _extract_text_attachment_content_from_attachments,
     _parse_attachments,
@@ -1022,6 +1023,35 @@ def test_extract_text_content(attachments, expected):
     assert _extract_text_attachment_content_from_attachments(attachments) == expected
 
 
+def test_text_attachment_purposes_keep_answers_and_clarifications_separate():
+    attachments = [
+        {
+            "text": {
+                "content": "The current answer is 42.",
+                "purpose": "TEXT_ATTACHMENT_PURPOSE_ANSWER",
+            }
+        },
+        {
+            "text": {
+                "content": "Which region should I use?",
+                "purpose": "FOLLOW_UP_QUESTION",
+            }
+        },
+    ]
+
+    assert _extract_text_attachment_content_from_attachments(attachments) == (
+        "The current answer is 42."
+    )
+    assert _extract_follow_up_question_from_attachments(attachments) == (
+        "Which region should I use?"
+    )
+
+
+@pytest.mark.parametrize("attachments", [None, [], "invalid", [{"text": {}}]])
+def test_missing_follow_up_question_returns_none(attachments):
+    assert _extract_follow_up_question_from_attachments(attachments) is None
+
+
 def test_poll_with_all_attachments(genie, mock_workspace_client):
     """Test with suggested questions, text, and query."""
     mock_workspace_client.genie._api.do.side_effect = [
@@ -1058,8 +1088,21 @@ def test_poll_text_only_no_query(genie, mock_workspace_client):
             "status": "COMPLETED",
             "conversation_id": "conv_456",
             "attachments": [
-                {"attachment_id": "1", "text": {"content": "Just text"}},
-                {"attachment_id": "2", "suggested_questions": {"questions": ["Follow-up?"]}},
+                {
+                    "attachment_id": "1",
+                    "text": {
+                        "content": "Just text",
+                        "purpose": "TEXT_ATTACHMENT_PURPOSE_ANSWER",
+                    },
+                },
+                {
+                    "attachment_id": "2",
+                    "text": {
+                        "content": "Which region?",
+                        "purpose": "FOLLOW_UP_QUESTION",
+                    },
+                },
+                {"attachment_id": "3", "suggested_questions": {"questions": ["Follow-up?"]}},
             ],
         }
     ]
@@ -1068,6 +1111,7 @@ def test_poll_text_only_no_query(genie, mock_workspace_client):
     assert result.result == "Just text"
     assert result.text_attachment_content == "Just text"
     assert result.suggested_questions == ["Follow-up?"]
+    assert result.follow_up_question == "Which region?"
 
 
 def test_poll_query_only(genie, mock_workspace_client):


### PR DESCRIPTION
## Summary

- add a typed `follow_up_question` field to `GenieResponse`
- recognize text attachments whose purpose is `FOLLOW_UP_QUESTION` as blocking clarification requests
- keep clarification prompts separate from ordinary answer text and from non-blocking `suggested_questions`
- propagate the clarification through both text-only and query-result response paths

## Validation

- `uv run --group tests pytest tests/databricks_ai_bridge/test_genie.py -q` — 83 passed
- `uv run ruff check src/databricks_ai_bridge/genie.py tests/databricks_ai_bridge/test_genie.py` — passed
- `uv run ruff format --check src/databricks_ai_bridge/genie.py tests/databricks_ai_bridge/test_genie.py` — passed
- `uv run ty check` — completed successfully

The tests cover separation of answer and clarification attachments, missing or malformed clarification payloads, and propagation through `GenieResponse`.