### PR TITLE
Fix Mason UI runtime capability reporting

### DIFF
--- a/integrations/mason/src/databricks_mason/runtime/durability/app.py
+++ b/integrations/mason/src/databricks_mason/runtime/durability/app.py
@@ -67,6 +67,10 @@ class AgentApp(FastAPI):
         store = durability_store
         if store is None:
             store = default_durability_store() if durable_runtime else InMemoryDurabilityStore()
+        # Report the effective backend, which may differ from ``durable_runtime`` locally:
+        # ``mason dev`` deliberately uses process-local storage even when deployed durability is
+        # enabled in agent.toml.
+        self.run_store_durable = not isinstance(store, InMemoryDurabilityStore)
         self._runtime = DurableRuntime(
             self._execute,
             durability_store=store,

--- a/integrations/mason/templates/ui/agent-langgraph/CHAT_APP.md
+++ b/integrations/mason/templates/ui/agent-langgraph/CHAT_APP.md
@@ -18,7 +18,7 @@ Session reflects checkpoint history; Memory requires `AGENT_MEMORY_STORE`. The t
 the only manual capability choice.
 
 The chat header's model picker lists the workspace's ready chat serving endpoints
-(`GET /api/demo/config` → `models`, discovered from `serving_endpoints.list()` and filtered to the
+(`GET /api/ui/config` → `models`, discovered from `serving_endpoints.list()` and filtered to the
 `llm/v1/chat` task), with `agent.agent.MODEL` pinned as the default. Each request sends the selected
 endpoint as `model` in the invocation body; the agent is rebuilt per turn, so the picker changes the
 model for the next turn without a restart. Discovery is best-effort: if listing is unavailable (e.g.

--- a/integrations/mason/templates/ui/agent-langgraph/runtime/ui.py
+++ b/integrations/mason/templates/ui/agent-langgraph/runtime/ui.py
@@ -10,11 +10,12 @@ from functools import lru_cache
 from pathlib import Path
 from typing import Any
 
-from databricks_mason import workspace_client
 from fastapi import FastAPI, HTTPException, Query, Request
 from fastapi.responses import FileResponse, JSONResponse
 from fastapi.staticfiles import StaticFiles
 from pydantic import BaseModel, Field
+
+from databricks_mason import workspace_client
 
 _UI_ROOT = Path(__file__).resolve().parent.parent / "ui"
 _INSTANCE_ID = uuid.uuid4().hex[:12]  # identifies this process in the UI
@@ -306,6 +307,7 @@ def _require_session() -> None:
 
 async def _checkpoint_history(session_id: str, actor: str) -> dict[str, Any]:
     from agent.agent import create_agent_graph
+
     from databricks_mason.langgraph.session_store import thread_config
 
     graph = await create_agent_graph(actor)
@@ -356,27 +358,45 @@ def _chat_session_items(result: dict[str, Any]) -> dict[str, Any]:
 
 
 def install_ui(app: FastAPI) -> None:
-    """Mount the Mason demo UI and its runtime control endpoints."""
+    """Mount the Mason UI and its runtime control endpoints."""
     app.mount("/ui-assets", StaticFiles(directory=_UI_ROOT), name="mason-demo-ui-assets")
+
+    @app.middleware("http")
+    async def disable_ui_caching(request: Request, call_next):
+        response = await call_next(request)
+        if request.url.path == "/" or request.url.path.startswith("/ui-assets/"):
+            response.headers["Cache-Control"] = "no-store"
+        return response
 
     @app.get("/", include_in_schema=False)
     async def index() -> FileResponse:
         return FileResponse(_UI_ROOT / "index.html")
 
-    @app.get("/api/demo/config", include_in_schema=False)
-    async def demo_config(request: Request) -> dict:
+    @app.get("/api/ui/config", include_in_schema=False)
+    async def ui_config(request: Request) -> dict:
         actor = _request_actor(request)
         memory_store = _memory_store()
         session_store = _session_store()
         default_model = _default_model()
+        run_store_durable = bool(getattr(app, "run_store_durable", False))
+        run_store_mode = "Durable run store" if run_store_durable else "In-process run store"
         return {
             "session_id": _request_session_id(request),
             "instance_id": _INSTANCE_ID,
             "viewer": actor if actor != "agent" else "Local developer",
             "deployed": _is_deployed(),
             "models": {"default": default_model, "available": [default_model]},
-            "streaming": {"enabled": True, "transport": "Server-sent events"},
-            "background": {"enabled": True, "durable": True},
+            "streaming": {
+                "enabled": True,
+                "transport": "Server-sent events",
+                "durable": run_store_durable,
+                "mode": run_store_mode,
+            },
+            "background": {
+                "enabled": True,
+                "durable": run_store_durable,
+                "mode": run_store_mode,
+            },
             "session": {
                 "durable": bool(session_store),
                 "managed": bool(session_store),

--- a/integrations/mason/templates/ui/agent-langgraph/tests/test_demo_ui.py
+++ b/integrations/mason/templates/ui/agent-langgraph/tests/test_demo_ui.py
@@ -1,8 +1,9 @@
 import pytest
-from databricks_mason import AgentApp
-from databricks_mason.runtime.durability.store import InMemoryDurabilityStore
 from fastapi.testclient import TestClient
 from runtime import ui
+
+from databricks_mason import AgentApp
+from databricks_mason.runtime.durability.store import InMemoryDurabilityStore
 
 
 class _FakeStateClient:
@@ -119,14 +120,17 @@ def test_demo_ui_routes(monkeypatch):
 
     index = client.get("/")
     assert index.status_code == 200
+    assert index.headers["cache-control"] == "no-store"
     assert 'id="new-session"' in index.text
     assert 'id="session-list"' in index.text
     assert 'id="model-select"' in index.text
     app_script = client.get("/ui-assets/app.js")
     assert app_script.status_code == 200
+    assert app_script.headers["cache-control"] == "no-store"
     assert "mason memory bind <store-name>" in app_script.text
     assert "refreshSessionView({ hydrateChat: true })" in app_script.text
     assert "function renderModels(" in app_script.text
+    assert 'demoUrl("/api/ui/config")' in app_script.text
     assert 'demoUrl("/api/demo/models")' in app_script.text
     assert 'fetch("/api/session/new"' not in app_script.text
     assert "/api/demo/sessions/${encodeURIComponent(sessionId)}/open" in app_script.text
@@ -136,7 +140,7 @@ def test_demo_ui_routes(monkeypatch):
     assert "@media (min-width: 1181px)" in styles
     assert "scrollbar-gutter: stable" in styles
 
-    config = client.get("/api/demo/config").json()
+    config = client.get("/api/ui/config").json()
     assert config["session_id"] == "routing-session"
     assert config["deployed"] is False
     assert config["models"] == {
@@ -145,12 +149,21 @@ def test_demo_ui_routes(monkeypatch):
     }
     assert config["streaming"]["enabled"] is True
     assert config["background"]["enabled"] is True
-    assert config["background"]["durable"] is True
+    assert config["streaming"]["durable"] is False
+    assert config["streaming"]["mode"] == "In-process run store"
+    assert config["background"]["durable"] is False
+    assert config["background"]["mode"] == "In-process run store"
     assert config["memory"]["enabled"] is False
     assert config["session"]["managed"] is False
     assert config["session"]["history"] is True
     assert "durability" not in config
     assert "recovery" not in config
+    assert client.get("/api/demo/config").status_code == 404
+
+    client.app.run_store_durable = True
+    durable_config = client.get("/api/ui/config").json()
+    assert durable_config["streaming"]["mode"] == "Durable run store"
+    assert durable_config["background"]["mode"] == "Durable run store"
 
     assert client.get("/api/demo/models").json() == {
         "default": "databricks-gpt-5-2",
@@ -177,10 +190,10 @@ def test_demo_ui_routes(monkeypatch):
 def test_demo_config_distinguishes_run_local_from_a_deployed_app(monkeypatch):
     monkeypatch.setenv("DATABRICKS_APP_NAME", "app")
     monkeypatch.setenv("DATABRICKS_APP_URL", "http://127.0.0.1:8000")
-    assert _client(monkeypatch).get("/api/demo/config").json()["deployed"] is False
+    assert _client(monkeypatch).get("/api/ui/config").json()["deployed"] is False
 
     monkeypatch.setenv("DATABRICKS_APP_URL", "https://agent.example.databricksapps.com")
-    assert _client(monkeypatch).get("/api/demo/config").json()["deployed"] is True
+    assert _client(monkeypatch).get("/api/ui/config").json()["deployed"] is True
 
 
 def test_demo_config_does_not_wait_for_model_discovery(monkeypatch):
@@ -192,7 +205,7 @@ def test_demo_config_does_not_wait_for_model_discovery(monkeypatch):
         lambda: calls.append(True) or ["databricks-gpt-5-2", "databricks-gpt-5-5"],
     )
 
-    assert client.get("/api/demo/config").status_code == 200
+    assert client.get("/api/ui/config").status_code == 200
     assert calls == []
     assert client.get("/api/demo/models").json()["available"] == [
         "databricks-gpt-5-2",
@@ -204,7 +217,7 @@ def test_demo_config_does_not_wait_for_model_discovery(monkeypatch):
 def test_unmanaged_checkpoint_history_route(monkeypatch):
     client = _client(monkeypatch, history=True, session_id="local-session")
 
-    config = client.get("/api/demo/config").json()
+    config = client.get("/api/ui/config").json()
     assert config["session"]["managed"] is False
     assert config["session"]["history"] is True
 
@@ -391,7 +404,7 @@ async def test_checkpoint_history_reads_messages_and_interrupts(monkeypatch):
 def test_managed_memory_and_session_routes(monkeypatch):
     client = _client(monkeypatch, configured=True, session_id="s1")
 
-    config = client.get("/api/demo/config").json()
+    config = client.get("/api/ui/config").json()
     assert config["memory"] == {
         "enabled": True,
         "store": "memory-stores/store",
@@ -440,14 +453,11 @@ def test_managed_memory_and_session_routes(monkeypatch):
         "previous_session_id": "s1",
         "managed": True,
     }
+    assert client.get("/api/ui/config", params={"session_id": "s2"}).json()["session_id"] == "s2"
     assert (
-        client.get("/api/demo/config", params={"session_id": "s2"}).json()["session_id"]
-        == "s2"
-    )
-    assert (
-        client.get("/api/demo/session/items", params={"session_id": "s2"}).json()[
-            "session_items"
-        ][0]["data"]["content"]
+        client.get("/api/demo/session/items", params={"session_id": "s2"}).json()["session_items"][
+            0
+        ]["data"]["content"]
         == "s2"
     )
 

--- a/integrations/mason/templates/ui/agent-langgraph/ui/app.js
+++ b/integrations/mason/templates/ui/agent-langgraph/ui/app.js
@@ -799,7 +799,7 @@ async function loadModels() {
 
 async function loadConfig() {
   try {
-    const response = await fetch(demoUrl("/api/demo/config"), { cache: "no-store" });
+    const response = await fetch(demoUrl("/api/ui/config"), { cache: "no-store" });
     const config = await jsonResponse(response);
     state.config = config;
     state.instanceId = config.instance_id;
@@ -807,15 +807,15 @@ async function loadConfig() {
     renderModels(config.models);
     void loadModels().catch((error) => addEvent("models.error", { message: String(error) }));
     elements.viewerValue.textContent = config.viewer;
-    elements.streamingMode.textContent = config.streaming.transport;
-    elements.backgroundMode.textContent = config.background.durable ? "Durable run store" : "In-process run store";
+    elements.streamingMode.textContent = config.streaming.mode;
+    elements.backgroundMode.textContent = config.background.mode;
     elements.sessionMode.textContent = config.session.mode;
     elements.memoryMode.textContent = config.memory.enabled ? `Managed · actor ${config.memory.actor}` : "Not connected";
     setCapability(
       elements.streamingStatus,
       config.streaming.enabled,
       config.streaming.enabled
-        ? `Streaming responses over ${config.streaming.transport}.`
+        ? `Streaming responses over ${config.streaming.transport} use the ${config.streaming.durable ? "durable" : "in-process"} run store.`
         : "Streaming is disabled for this deployment.",
     );
     setCapability(
@@ -931,5 +931,9 @@ elements.refreshMemory.addEventListener("click", listMemoryEntries);
 
 loadConfig().catch((error) => {
   appendError(error);
+  elements.streamingMode.textContent = "Unavailable";
+  elements.backgroundMode.textContent = "Unavailable";
+  elements.sessionMode.textContent = "Unavailable";
+  elements.memoryMode.textContent = "Unavailable";
   elements.memoryHelp.textContent = "Runtime configuration is unavailable.";
 });

--- a/integrations/mason/templates/ui/agent-openai/CHAT_APP.md
+++ b/integrations/mason/templates/ui/agent-openai/CHAT_APP.md
@@ -18,7 +18,7 @@ Session reflects transcript history; Memory requires `AGENT_MEMORY_STORE`. The t
 the only manual capability choice.
 
 The chat header's model picker lists the workspace's ready chat serving endpoints
-(`GET /api/demo/config` → `models`, discovered from `serving_endpoints.list()` and filtered to the
+(`GET /api/ui/config` → `models`, discovered from `serving_endpoints.list()` and filtered to the
 `llm/v1/chat` task), with `agent.agent.MODEL` pinned as the default. Each request sends the selected
 endpoint as `model` in the invocation body; the agent is rebuilt per turn, so the picker changes the
 model for the next turn without a restart. Discovery is best-effort: if listing is unavailable (e.g.

--- a/integrations/mason/templates/ui/agent-openai/runtime/ui.py
+++ b/integrations/mason/templates/ui/agent-openai/runtime/ui.py
@@ -10,11 +10,12 @@ from functools import lru_cache
 from pathlib import Path
 from typing import Any
 
-from databricks_mason import workspace_client
 from fastapi import FastAPI, HTTPException, Query, Request
 from fastapi.responses import FileResponse, JSONResponse
 from fastapi.staticfiles import StaticFiles
 from pydantic import BaseModel, Field
+
+from databricks_mason import workspace_client
 
 _UI_ROOT = Path(__file__).resolve().parent.parent / "ui"
 _INSTANCE_ID = uuid.uuid4().hex[:12]  # identifies this process in the UI
@@ -350,27 +351,45 @@ def _chat_session_items(result: dict[str, Any]) -> dict[str, Any]:
 
 
 def install_ui(app: FastAPI) -> None:
-    """Mount the Mason demo UI and its runtime control endpoints."""
+    """Mount the Mason UI and its runtime control endpoints."""
     app.mount("/ui-assets", StaticFiles(directory=_UI_ROOT), name="mason-demo-ui-assets")
+
+    @app.middleware("http")
+    async def disable_ui_caching(request: Request, call_next):
+        response = await call_next(request)
+        if request.url.path == "/" or request.url.path.startswith("/ui-assets/"):
+            response.headers["Cache-Control"] = "no-store"
+        return response
 
     @app.get("/", include_in_schema=False)
     async def index() -> FileResponse:
         return FileResponse(_UI_ROOT / "index.html")
 
-    @app.get("/api/demo/config", include_in_schema=False)
-    async def demo_config(request: Request) -> dict:
+    @app.get("/api/ui/config", include_in_schema=False)
+    async def ui_config(request: Request) -> dict:
         actor = _request_actor(request)
         memory_store = _memory_store()
         session_store = _session_store()
         default_model = _default_model()
+        run_store_durable = bool(getattr(app, "run_store_durable", False))
+        run_store_mode = "Durable run store" if run_store_durable else "In-process run store"
         return {
             "session_id": _request_session_id(request),
             "instance_id": _INSTANCE_ID,
             "viewer": actor if actor != "agent" else "Local developer",
             "deployed": _is_deployed(),
             "models": {"default": default_model, "available": [default_model]},
-            "streaming": {"enabled": True, "transport": "Server-sent events"},
-            "background": {"enabled": True, "durable": True},
+            "streaming": {
+                "enabled": True,
+                "transport": "Server-sent events",
+                "durable": run_store_durable,
+                "mode": run_store_mode,
+            },
+            "background": {
+                "enabled": True,
+                "durable": run_store_durable,
+                "mode": run_store_mode,
+            },
             "session": {
                 "durable": bool(session_store),
                 "managed": bool(session_store),

--- a/integrations/mason/templates/ui/agent-openai/tests/test_demo_ui.py
+++ b/integrations/mason/templates/ui/agent-openai/tests/test_demo_ui.py
@@ -1,8 +1,9 @@
 import pytest
-from databricks_mason import AgentApp
-from databricks_mason.runtime.durability.store import InMemoryDurabilityStore
 from fastapi.testclient import TestClient
 from runtime import ui
+
+from databricks_mason import AgentApp
+from databricks_mason.runtime.durability.store import InMemoryDurabilityStore
 
 
 class _FakeStateClient:
@@ -113,14 +114,17 @@ def test_demo_ui_routes(monkeypatch):
 
     index = client.get("/")
     assert index.status_code == 200
+    assert index.headers["cache-control"] == "no-store"
     assert 'id="new-session"' in index.text
     assert 'id="session-list"' in index.text
     assert 'id="model-select"' in index.text
     app_script = client.get("/ui-assets/app.js")
     assert app_script.status_code == 200
+    assert app_script.headers["cache-control"] == "no-store"
     assert "mason memory bind <store-name>" in app_script.text
     assert "refreshSessionView({ hydrateChat: true })" in app_script.text
     assert "function renderModels(" in app_script.text
+    assert 'demoUrl("/api/ui/config")' in app_script.text
     assert 'demoUrl("/api/demo/models")' in app_script.text
     assert 'fetch("/api/session/new"' not in app_script.text
     assert "/api/demo/sessions/${encodeURIComponent(sessionId)}/open" in app_script.text
@@ -130,7 +134,7 @@ def test_demo_ui_routes(monkeypatch):
     assert "@media (min-width: 1181px)" in styles
     assert "scrollbar-gutter: stable" in styles
 
-    config = client.get("/api/demo/config").json()
+    config = client.get("/api/ui/config").json()
     assert config["session_id"] == "routing-session"
     assert config["deployed"] is False
     assert config["models"] == {
@@ -139,13 +143,22 @@ def test_demo_ui_routes(monkeypatch):
     }
     assert config["streaming"]["enabled"] is True
     assert config["background"]["enabled"] is True
-    assert config["background"]["durable"] is True
+    assert config["streaming"]["durable"] is False
+    assert config["streaming"]["mode"] == "In-process run store"
+    assert config["background"]["durable"] is False
+    assert config["background"]["mode"] == "In-process run store"
     assert config["memory"]["enabled"] is False
     assert config["session"]["managed"] is False
     assert config["session"]["history"] is True
     assert config["session"]["mode"] == "In-process session"
     assert "durability" not in config
     assert "recovery" not in config
+    assert client.get("/api/demo/config").status_code == 404
+
+    client.app.run_store_durable = True
+    durable_config = client.get("/api/ui/config").json()
+    assert durable_config["streaming"]["mode"] == "Durable run store"
+    assert durable_config["background"]["mode"] == "Durable run store"
 
     assert client.get("/api/demo/models").json() == {
         "default": "databricks-gpt-5-2",
@@ -172,10 +185,10 @@ def test_demo_ui_routes(monkeypatch):
 def test_demo_config_distinguishes_run_local_from_a_deployed_app(monkeypatch):
     monkeypatch.setenv("DATABRICKS_APP_NAME", "app")
     monkeypatch.setenv("DATABRICKS_APP_URL", "http://127.0.0.1:8000")
-    assert _client(monkeypatch).get("/api/demo/config").json()["deployed"] is False
+    assert _client(monkeypatch).get("/api/ui/config").json()["deployed"] is False
 
     monkeypatch.setenv("DATABRICKS_APP_URL", "https://agent.example.databricksapps.com")
-    assert _client(monkeypatch).get("/api/demo/config").json()["deployed"] is True
+    assert _client(monkeypatch).get("/api/ui/config").json()["deployed"] is True
 
 
 def test_demo_config_does_not_wait_for_model_discovery(monkeypatch):
@@ -187,7 +200,7 @@ def test_demo_config_does_not_wait_for_model_discovery(monkeypatch):
         lambda: calls.append(True) or ["databricks-gpt-5-2", "databricks-gpt-5-5"],
     )
 
-    assert client.get("/api/demo/config").status_code == 200
+    assert client.get("/api/ui/config").status_code == 200
     assert calls == []
     assert client.get("/api/demo/models").json()["available"] == [
         "databricks-gpt-5-2",
@@ -199,7 +212,7 @@ def test_demo_config_does_not_wait_for_model_discovery(monkeypatch):
 def test_unmanaged_local_history_route(monkeypatch):
     client = _client(monkeypatch, history=True, session_id="local-session")
 
-    config = client.get("/api/demo/config").json()
+    config = client.get("/api/ui/config").json()
     assert config["session"]["managed"] is False
     assert config["session"]["history"] is True
 
@@ -361,7 +374,7 @@ async def test_local_history_reads_messages_from_in_process_session(monkeypatch)
 def test_managed_memory_and_session_routes(monkeypatch):
     client = _client(monkeypatch, configured=True, session_id="s1")
 
-    config = client.get("/api/demo/config").json()
+    config = client.get("/api/ui/config").json()
     assert config["memory"] == {
         "enabled": True,
         "store": "memory-stores/store",
@@ -410,14 +423,11 @@ def test_managed_memory_and_session_routes(monkeypatch):
         "previous_session_id": "s1",
         "managed": True,
     }
+    assert client.get("/api/ui/config", params={"session_id": "s2"}).json()["session_id"] == "s2"
     assert (
-        client.get("/api/demo/config", params={"session_id": "s2"}).json()["session_id"]
-        == "s2"
-    )
-    assert (
-        client.get("/api/demo/session/items", params={"session_id": "s2"}).json()[
-            "session_items"
-        ][0]["data"]["content"]
+        client.get("/api/demo/session/items", params={"session_id": "s2"}).json()["session_items"][
+            0
+        ]["data"]["content"]
         == "s2"
     )
 

--- a/integrations/mason/templates/ui/agent-openai/ui/app.js
+++ b/integrations/mason/templates/ui/agent-openai/ui/app.js
@@ -763,7 +763,7 @@ async function loadModels() {
 
 async function loadConfig() {
   try {
-    const response = await fetch(demoUrl("/api/demo/config"), { cache: "no-store" });
+    const response = await fetch(demoUrl("/api/ui/config"), { cache: "no-store" });
     const config = await jsonResponse(response);
     state.config = config;
     state.instanceId = config.instance_id;
@@ -771,15 +771,15 @@ async function loadConfig() {
     renderModels(config.models);
     void loadModels().catch((error) => addEvent("models.error", { message: String(error) }));
     elements.viewerValue.textContent = config.viewer;
-    elements.streamingMode.textContent = config.streaming.transport;
-    elements.backgroundMode.textContent = config.background.durable ? "Durable run store" : "In-process run store";
+    elements.streamingMode.textContent = config.streaming.mode;
+    elements.backgroundMode.textContent = config.background.mode;
     elements.sessionMode.textContent = config.session.mode;
     elements.memoryMode.textContent = config.memory.enabled ? `Managed · actor ${config.memory.actor}` : "Not connected";
     setCapability(
       elements.streamingStatus,
       config.streaming.enabled,
       config.streaming.enabled
-        ? `Streaming responses over ${config.streaming.transport}.`
+        ? `Streaming responses over ${config.streaming.transport} use the ${config.streaming.durable ? "durable" : "in-process"} run store.`
         : "Streaming is disabled for this deployment.",
     );
     setCapability(
@@ -895,5 +895,9 @@ elements.refreshMemory.addEventListener("click", listMemoryEntries);
 
 loadConfig().catch((error) => {
   appendError(error);
+  elements.streamingMode.textContent = "Unavailable";
+  elements.backgroundMode.textContent = "Unavailable";
+  elements.sessionMode.textContent = "Unavailable";
+  elements.memoryMode.textContent = "Unavailable";
   elements.memoryHelp.textContent = "Runtime configuration is unavailable.";
 });

--- a/integrations/mason/tests/unit_tests/runtime_app_test.py
+++ b/integrations/mason/tests/unit_tests/runtime_app_test.py
@@ -376,6 +376,7 @@ def test_agent_app_defaults_to_process_local_state_even_inside_apps(monkeypatch)
     app = AgentApp()
 
     assert app.durable_runtime is False
+    assert app.run_store_durable is False
     assert isinstance(app._runtime.durability_store, InMemoryDurabilityStore)
 
 


### PR DESCRIPTION
## Summary

- rename the UI configuration endpoint from `/api/demo/config` to `/api/ui/config`
- report the effective run store for both streaming and background execution
- show `In-process run store` for local/in-memory execution and `Durable run store` for Lakebase
- prevent stale UI assets after redeploy and replace indefinite `Checking…` states with `Unavailable` on configuration errors

## Validation

- `ruff check` and formatting passed
- Mason unit and functional suite: `462 passed`
- verified custom-server templates do not include the Mason chat UI or capability endpoint