### PR TITLE
[mason] init: pin template to matching release tag when it exists

### DIFF
--- a/integrations/mason/src/databricks_mason/init.py
+++ b/integrations/mason/src/databricks_mason/init.py
@@ -93,15 +93,22 @@ def _template_ref(framework: str) -> str:
     except PackageNotFoundError:
         return default_ref
     tag = f"{_RELEASE_TAG_PREFIX}{installed}"
-    return tag if _remote_ref_exists(_TEMPLATES[framework]["repo"], tag) else default_ref
+    if _remote_ref_exists(_TEMPLATES[framework]["repo"], tag):
+        return tag
+    render.warning(
+        f"No release tag '{tag}' for installed databricks-mason {installed}; scaffolding from "
+        f"'{default_ref}', which may be ahead of your installed package."
+    )
+    return default_ref
 
 
 def _remote_ref_exists(repo: str, tag: str) -> bool:
     """Whether `tag` exists in `repo`, via a lightweight `git ls-remote` (no clone).
 
-    A missing tag exits non-zero (2), which is an expected answer here rather than an error, so
-    this checks the return code directly instead of going through `_git`. Any failure to confirm
-    the tag (missing, or an unreachable remote) returns False, falling back to the default ref.
+    `git ls-remote --exit-code` exits 0 when the tag is found and 2 when it is genuinely absent (an
+    untagged local build — a legitimate `main` fallback). Any other exit is a real failure (an
+    unreachable remote, auth) that we surface rather than silently treating as "absent" and fetching
+    a possibly-drifted `main`.
     """
     result = subprocess.run(
         ["git", "ls-remote", "--exit-code", "--tags", repo, f"refs/tags/{tag}"],
@@ -109,7 +116,14 @@ def _remote_ref_exists(repo: str, tag: str) -> bool:
         capture_output=True,
         check=False,
     )
-    return result.returncode == 0
+    if result.returncode == 0:
+        return True
+    if result.returncode == 2:
+        return False
+    raise AgentCliError(
+        f"Could not check for release tag '{tag}'.",
+        hint=(result.stderr or result.stdout or "").strip(),
+    )
 
 
 def _git(args: list[str], *, cwd: Optional[pathlib.Path] = None) -> subprocess.CompletedProcess:
@@ -404,6 +418,7 @@ def init(
             {
                 "framework": selected_framework,
                 "template": template_name,
+                "template_ref": resolved_ref or selected_ref,
                 "directory": str(dest),
                 "server": server,
                 "chat_app_enabled": chat_app_enabled,
@@ -413,9 +428,11 @@ def init(
         )
         return
 
+    template_ref = f"{selected_ref} ({resolved_ref[:12]})" if resolved_ref else selected_ref
     fields = {
         "Framework": selected_framework,
         "Server": "Mason AgentApp" if mason_server else "Custom FastAPI",
+        "Template ref": template_ref,
         "Durable runtime": "enabled" if durable_runtime else "disabled",
         "Directory": str(dest),
     }

--- a/integrations/mason/src/databricks_mason/init.py
+++ b/integrations/mason/src/databricks_mason/init.py
@@ -77,10 +77,13 @@ _CHAT_APP_TEMPLATES = {
 def _template_ref(framework: str) -> str:
     """The git ref to fetch a framework's template from, absent a `--ref` override.
 
-    For a versioned framework, fetch the tag matching the installed CLI so the scaffold's pinned
-    `databricks-mason` matches what the user has. Fall back to the default ref when the version
-    isn't a published release — an editable/dev build (e.g. `0.1.0.dev0`, or a local `+`
-    local-version install) has no corresponding tag, so those keep fetching `main`.
+    A registry install pins the scaffold's `databricks-mason` at its own version, so fetch the
+    template from the matching `databricks-mason-v<version>` release tag — the template as it
+    shipped with that release — rather than `main`, which may have drifted ahead. Pre-release
+    versions (`0.1.4.dev0`) are tagged like any other release, so they pin too. Fall back to `main`
+    only when no matching tag exists, e.g. a version built and installed locally that was never
+    tagged. Editable and Git installs never reach here — `init` resolves those to their exact
+    source checkout before consulting this.
     """
     default_ref = _TEMPLATES[framework]["ref"]
     if framework not in _VERSIONED_TEMPLATES:
@@ -89,9 +92,24 @@ def _template_ref(framework: str) -> str:
         installed = _installed_version("databricks-mason")
     except PackageNotFoundError:
         return default_ref
-    if "dev" in installed or "+" in installed:
-        return default_ref
-    return f"{_RELEASE_TAG_PREFIX}{installed}"
+    tag = f"{_RELEASE_TAG_PREFIX}{installed}"
+    return tag if _remote_ref_exists(_TEMPLATES[framework]["repo"], tag) else default_ref
+
+
+def _remote_ref_exists(repo: str, tag: str) -> bool:
+    """Whether `tag` exists in `repo`, via a lightweight `git ls-remote` (no clone).
+
+    A missing tag exits non-zero (2), which is an expected answer here rather than an error, so
+    this checks the return code directly instead of going through `_git`. Any failure to confirm
+    the tag (missing, or an unreachable remote) returns False, falling back to the default ref.
+    """
+    result = subprocess.run(
+        ["git", "ls-remote", "--exit-code", "--tags", repo, f"refs/tags/{tag}"],
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    return result.returncode == 0
 
 
 def _git(args: list[str], *, cwd: Optional[pathlib.Path] = None) -> subprocess.CompletedProcess:

--- a/integrations/mason/tests/unit_tests/init_test.py
+++ b/integrations/mason/tests/unit_tests/init_test.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import json
 import pathlib
+import subprocess
 from unittest import mock
 
 import pytest
@@ -16,6 +17,10 @@ from click.testing import CliRunner
 
 from databricks_mason import init as init_mod
 from databricks_mason.errors import AgentCliError
+
+# The real implementation, captured before the autouse fixture stubs it out, so the tests that
+# exercise `_remote_ref_exists` itself run the actual function rather than the network stub.
+_real_remote_ref_exists = init_mod._remote_ref_exists
 
 
 class _Ctx:
@@ -29,6 +34,9 @@ class _Ctx:
 @pytest.fixture(autouse=True)
 def _skip_generated_runtime_rewrite(monkeypatch: pytest.MonkeyPatch):
     monkeypatch.setattr(init_mod, "_editable_template_source", lambda: None)
+    # Keep the release-tag lookup off the network in unit tests; the _template_ref tests below
+    # override this explicitly.
+    monkeypatch.setattr(init_mod, "_remote_ref_exists", lambda *_: False)
 
 
 def test_framework_specs_have_repo_ref_path():
@@ -48,19 +56,22 @@ def test_framework_specs_have_repo_ref_path():
     assert init_mod._CHAT_APP_TEMPLATES["openai"] == "integrations/mason/templates/ui/agent-openai"
 
 
-def test_template_ref_pins_versioned_template_to_release_tag(monkeypatch: pytest.MonkeyPatch):
-    monkeypatch.setattr(init_mod, "_installed_version", lambda _: "0.3.0")
-    # A released CLI fetches each versioned template tagged for its own version.
-    assert init_mod._template_ref("langgraph") == "databricks-mason-v0.3.0"
-    assert init_mod._template_ref("openai") == "databricks-mason-v0.3.0"
-
-
-@pytest.mark.parametrize("installed", ["0.1.0.dev0", "0.2.0+local"])
-def test_template_ref_falls_back_to_main_for_unreleased_builds(
+@pytest.mark.parametrize("installed", ["0.3.0", "0.1.4.dev0"])
+def test_template_ref_pins_versioned_template_to_release_tag(
     installed: str, monkeypatch: pytest.MonkeyPatch
 ):
-    # Dev/editable/local-version builds have no matching release tag, so fetch `main`.
+    # Whenever a matching release tag exists, fetch the template from it — a `.dev0` pre-release is
+    # tagged like any other release, so it pins to its own tag rather than drifting to `main`.
     monkeypatch.setattr(init_mod, "_installed_version", lambda _: installed)
+    monkeypatch.setattr(init_mod, "_remote_ref_exists", lambda *_: True)
+    assert init_mod._template_ref("langgraph") == f"databricks-mason-v{installed}"
+    assert init_mod._template_ref("openai") == f"databricks-mason-v{installed}"
+
+
+def test_template_ref_falls_back_to_main_when_no_matching_tag(monkeypatch: pytest.MonkeyPatch):
+    # A locally built, never-tagged version has no matching release tag, so fetch `main`.
+    monkeypatch.setattr(init_mod, "_installed_version", lambda _: "0.9.9.dev0+g1234abc")
+    monkeypatch.setattr(init_mod, "_remote_ref_exists", lambda *_: False)
     assert init_mod._template_ref("langgraph") == "main"
 
 
@@ -70,6 +81,32 @@ def test_template_ref_falls_back_when_package_not_installed(monkeypatch: pytest.
 
     monkeypatch.setattr(init_mod, "_installed_version", _raise)
     assert init_mod._template_ref("langgraph") == "main"
+
+
+def test_remote_ref_exists_queries_the_tag_and_reads_exit_code(monkeypatch: pytest.MonkeyPatch):
+    seen = {}
+
+    def fake_run(cmd, **_):
+        seen["cmd"] = cmd
+        return subprocess.CompletedProcess(cmd, 0)
+
+    monkeypatch.setattr(init_mod.subprocess, "run", fake_run)
+    assert _real_remote_ref_exists("https://repo.git", "databricks-mason-v0.3.0") is True
+    assert seen["cmd"] == [
+        "git",
+        "ls-remote",
+        "--exit-code",
+        "--tags",
+        "https://repo.git",
+        "refs/tags/databricks-mason-v0.3.0",
+    ]
+
+
+def test_remote_ref_exists_false_when_tag_absent(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr(
+        init_mod.subprocess, "run", lambda cmd, **_: subprocess.CompletedProcess(cmd, 2)
+    )
+    assert _real_remote_ref_exists("https://repo.git", "databricks-mason-v9.9.9") is False
 
 
 def test_installed_git_template_source_uses_recorded_commit(monkeypatch: pytest.MonkeyPatch):

--- a/integrations/mason/tests/unit_tests/init_test.py
+++ b/integrations/mason/tests/unit_tests/init_test.py
@@ -35,8 +35,10 @@ class _Ctx:
 def _skip_generated_runtime_rewrite(monkeypatch: pytest.MonkeyPatch):
     monkeypatch.setattr(init_mod, "_editable_template_source", lambda: None)
     # Keep the release-tag lookup off the network in unit tests; the _template_ref tests below
-    # override this explicitly.
+    # override this explicitly. The False path warns, so silence that here (a dedicated test
+    # re-patches render.warning to assert it) to keep it out of scaffold tests' captured output.
     monkeypatch.setattr(init_mod, "_remote_ref_exists", lambda *_: False)
+    monkeypatch.setattr(init_mod.render, "warning", lambda *_a, **_k: None)
 
 
 def test_framework_specs_have_repo_ref_path():
@@ -69,10 +71,14 @@ def test_template_ref_pins_versioned_template_to_release_tag(
 
 
 def test_template_ref_falls_back_to_main_when_no_matching_tag(monkeypatch: pytest.MonkeyPatch):
-    # A locally built, never-tagged version has no matching release tag, so fetch `main`.
+    # A locally built, never-tagged version has no matching release tag, so fetch `main` — and warn,
+    # since that template may be ahead of the installed package.
     monkeypatch.setattr(init_mod, "_installed_version", lambda _: "0.9.9.dev0+g1234abc")
     monkeypatch.setattr(init_mod, "_remote_ref_exists", lambda *_: False)
+    warnings: list[str] = []
+    monkeypatch.setattr(init_mod.render, "warning", lambda message, **_: warnings.append(message))
     assert init_mod._template_ref("langgraph") == "main"
+    assert warnings and "0.9.9.dev0+g1234abc" in warnings[0]
 
 
 def test_template_ref_falls_back_when_package_not_installed(monkeypatch: pytest.MonkeyPatch):
@@ -107,6 +113,18 @@ def test_remote_ref_exists_false_when_tag_absent(monkeypatch: pytest.MonkeyPatch
         init_mod.subprocess, "run", lambda cmd, **_: subprocess.CompletedProcess(cmd, 2)
     )
     assert _real_remote_ref_exists("https://repo.git", "databricks-mason-v9.9.9") is False
+
+
+def test_remote_ref_exists_raises_on_unexpected_exit(monkeypatch: pytest.MonkeyPatch):
+    # A non-0/2 exit (e.g. 128 for an unreachable remote) is a real failure, not "tag absent" — so
+    # surface it rather than silently falling back to a possibly-drifted `main`.
+    monkeypatch.setattr(
+        init_mod.subprocess,
+        "run",
+        lambda cmd, **_: subprocess.CompletedProcess(cmd, 128, stderr="fatal: could not read"),
+    )
+    with pytest.raises(AgentCliError, match="Could not check for release tag"):
+        _real_remote_ref_exists("https://repo.git", "databricks-mason-v0.3.0")
 
 
 def test_installed_git_template_source_uses_recorded_commit(monkeypatch: pytest.MonkeyPatch):


### PR DESCRIPTION
Every published databricks-mason version is a .dev0 pre-release, so the "dev in version -> fetch main" heuristic fired for every real install, defeating the release-tag pin and letting mason init scaffold a template ahead of the installed
package. Replace it with a git ls-remote check: fetch databricks-mason-v<version>
when that tag exists, else fall back to main (locally built, never-tagged builds).

tested e2e