### PR TITLE
[mason] Fail fast on throttling and surface the original service error

### DIFF
--- a/integrations/mason/src/databricks_mason/_api_client.py
+++ b/integrations/mason/src/databricks_mason/_api_client.py
@@ -28,6 +28,11 @@ _MCP_SERVICES_PATH = "/api/2.1/unity-catalog/mcp-services"
 _MAX_ATTEMPTS = 2
 _RETRY_BASE_DELAY_S = 0.2
 
+# Bound the SDK's own retry budget (default 300s). The SDK retries every HTTP 429/503 as platform
+# throttling, so an interactive command otherwise hangs up to 5 minutes on a sustained 429 before
+# surfacing anything; cap it so throttling fails fast with a clear error.
+_CLI_RETRY_TIMEOUT_S = 60
+
 
 def _query(**kwargs: Any) -> dict[str, Any]:
     """Build a query dict, dropping None and empty values."""
@@ -92,8 +97,17 @@ def _profile_host(profile: str) -> Optional[str]:
     return parser.get(profile, "host", fallback=None)
 
 
+def _bound_retry_timeout(client: WorkspaceClient) -> WorkspaceClient:
+    # Shorten the SDK's default 300s retry budget so 429/503 throttling fails in ~1 min, not ~5.
+    try:
+        client.api_client._api_client._retry_timeout_seconds = _CLI_RETRY_TIMEOUT_S
+    except AttributeError:
+        pass
+    return client
+
+
 def _workspace_client(profile: Optional[str]) -> WorkspaceClient:
-    client = WorkspaceClient(profile=profile)
+    client = _bound_retry_timeout(WorkspaceClient(profile=profile))
     if not profile or not client.config.workspace_id:
         return client
 
@@ -103,10 +117,12 @@ def _workspace_client(profile: Optional[str]) -> WorkspaceClient:
         return client
 
     workspace_id = str(client.config.workspace_id)
-    return WorkspaceClient(
-        profile=profile,
-        host=configured_host,
-        custom_headers={"X-Databricks-Org-Id": workspace_id},
+    return _bound_retry_timeout(
+        WorkspaceClient(
+            profile=profile,
+            host=configured_host,
+            custom_headers={"X-Databricks-Org-Id": workspace_id},
+        )
     )
 
 

--- a/integrations/mason/src/databricks_mason/errors.py
+++ b/integrations/mason/src/databricks_mason/errors.py
@@ -78,6 +78,10 @@ def wrap_api_error(exc: Exception) -> AgentCliError:
     `error_code` attribute; we stay duck-typed so we don't couple to the SDK's error
     hierarchy or version.
     """
+    # When the SDK exhausts its retry budget it raises a TimeoutError chaining the last underlying
+    # error as __cause__; surface that original service error, not the generic retry wrapper.
+    if isinstance(exc, TimeoutError) and exc.__cause__ is not None:
+        exc = exc.__cause__
     error_code = getattr(exc, "error_code", None)
     # A message-less DatabricksError wraps `IOError(None)`, so `str(exc)` is the literal
     # "None". Treat that (and an empty string) as "no detail" so we surface the error code

--- a/integrations/mason/tests/unit_tests/client_test.py
+++ b/integrations/mason/tests/unit_tests/client_test.py
@@ -317,6 +317,8 @@ def test_profile_auth_is_forwarded_when_multiple_profiles_share_a_host(
         client = _workspace_client("selected")
 
     assert client.config.profile == "selected"
+    # The interactive client caps the SDK's retry budget so throttling fails fast, not after ~5 min.
+    assert client.api_client._api_client._retry_timeout_seconds == 60
 
 
 class _TransientError(RuntimeError):

--- a/integrations/mason/tests/unit_tests/errors_test.py
+++ b/integrations/mason/tests/unit_tests/errors_test.py
@@ -73,3 +73,24 @@ def test_non_transient_error_keeps_original_message():
     mapped = wrap_api_error(NotFoundError("store not found"))
     assert mapped.message == "store not found"
     assert mapped.hint is None
+
+
+def test_retry_timeout_surfaces_original_service_error():
+    # When the SDK exhausts its retry budget it raises TimeoutError chaining the last underlying
+    # error; the wrapped error must surface that original service error, not the retry wrapper.
+    class ResourceExhausted(RuntimeError):
+        error_code = "RESOURCE_EXHAUSTED"
+
+    original = ResourceExhausted("Workspace has reached the maximum of 50 managed memory stores")
+    timeout = TimeoutError("Timed out after 0:01:00")
+    timeout.__cause__ = original
+
+    mapped = wrap_api_error(timeout)
+    assert mapped.error_code == "RESOURCE_EXHAUSTED"
+    assert "maximum of 50" in mapped.message
+    assert "Timed out" not in mapped.message
+
+
+def test_retry_timeout_without_cause_falls_through():
+    mapped = wrap_api_error(TimeoutError("Timed out after 0:01:00"))
+    assert "Timed out" in mapped.message


### PR DESCRIPTION
## Summary

The Databricks SDK retries every HTTP 429/503 as platform throttling for up to `retry_timeout_seconds` (default **300s**). So a throttled or at-limit Mason call — e.g. creating a store when the workspace is at its per-project cap — hung the CLI/SDK for ~5 minutes and then raised a bare `TimeoutError`, hiding the real service error, even though the server rejected the very first request.

Two changes to the interactive client:

- **Fail fast:** cap the SDK retry budget to 60s (`_CLI_RETRY_TIMEOUT_S`) on the client `_workspace_client` builds, so sustained throttling surfaces in ~1 minute instead of ~5.
- **Surface the real error:** when the SDK does exhaust retries, unwrap the `TimeoutError`'s chained `__cause__` in `wrap_api_error`, so the original service error (its `error_code` and message) is shown instead of the generic retry timeout.

Context: the specific 429 that triggered this (the managed-store per-project cap returning `RESOURCE_EXHAUSTED`) is being fixed server-side separately to return a non-retryable `BAD_REQUEST` (400). This client change is defense-in-depth for any remaining genuine 429/503 throttling.

## Test plan

- [x] `pytest tests/unit_tests` — 476 passed, including new `errors_test` cases (a retry `TimeoutError` surfaces its chained service error; a cause-less timeout falls through cleanly) and a `client_test` assertion that the built client's retry budget is 60s.
- [x] `ruff check` / `ruff format` clean.

This pull request and its description were written by Isaac.
